### PR TITLE
New traits version

### DIFF
--- a/block-cipher-trait/src/dev.rs
+++ b/block-cipher-trait/src/dev.rs
@@ -44,9 +44,14 @@ macro_rules! new_test {
                 let ciphertext = &ciphertexts[
                     (idx[2][0] as usize)..(idx[2][1] as usize)];
                 if !run_test(key, plaintext, ciphertext) {
-                    panic!("\nFailed at test number {}:\n\
-                        key: {:?}\nplaintext: {:?}\nciphertext: {:?}\n",
-                        i, key, plaintext, ciphertext
+                    panic!("\n\
+                        Failed at test number {}:\n\
+                        key: [{}..{}]{:?}\n\
+                        plaintext: {:?}\n\
+                        ciphertext: {:?}\n",
+                        i, idx[0][0], idx[0][1], key,
+                        idx[1][0], idx[1][1], plaintext,
+                        idx[2][0], idx[2][1], ciphertext,
                     );
                 }
 

--- a/block-cipher-trait/src/dev.rs
+++ b/block-cipher-trait/src/dev.rs
@@ -4,6 +4,9 @@ macro_rules! new_test {
     ($name:ident, $test_name:expr, $cipher:ty) => {
         #[test]
         fn $name() {
+            use des::BlockCipher;
+            use block_cipher_trait::generic_array::GenericArray;
+
             fn run_test(key: &[u8], pt: &[u8], ct: &[u8]) -> bool {
                 let state = <$cipher as BlockCipher>::new_varkey(key).unwrap();
 

--- a/block-cipher-trait/src/dev.rs
+++ b/block-cipher-trait/src/dev.rs
@@ -11,7 +11,7 @@ pub struct Test {
 
 #[macro_export]
 macro_rules! new_block_cipher_tests {
-    ( $( $name:expr ),*  ) => {
+    [ $( $name:expr ),*  ] => {
         [$(
             Test {
                 name: $name,
@@ -21,6 +21,7 @@ macro_rules! new_block_cipher_tests {
             },
         )*]
     };
+    [ $( $name:expr ),+, ] => (new_tests!($($name),+))
 }
 
 pub fn encrypt_decrypt<B: BlockCipher>(tests: &[Test]) {

--- a/block-cipher-trait/src/dev.rs
+++ b/block-cipher-trait/src/dev.rs
@@ -45,7 +45,7 @@ macro_rules! new_test {
                     (idx[2][0] as usize)..(idx[2][1] as usize)];
                 if !run_test(key, plaintext, ciphertext) {
                     panic!("\n\
-                        Failed at test number {}:\n\
+                        Failed test №{}\n\
                         key: [{}..{}]\t{:?}\n\
                         plaintext: [{}..{}]\t{:?}\n\
                         ciphertext: [{}..{}]\t{:?}\n",

--- a/block-cipher-trait/src/dev.rs
+++ b/block-cipher-trait/src/dev.rs
@@ -30,7 +30,7 @@ macro_rules! new_test {
                 concat!("data/", $test_name, ".index.bin"));
             // u32 (2 bytes); start + end (x2); key, plaintext, ciphertext (x3)
             assert_eq!(index.len() % (2*3*2), 0, "invlaid index length");
-            for i, chunk in index.chunks(2*3*2).enumerate() {
+            for (i, chunk) in index.chunks(2*3*2).enumerate() {
                 // proper aligment is assumed here
                 let idx = unsafe {
                     &*(chunk.as_ptr() as *const [[u16; 2]; 3])

--- a/block-cipher-trait/src/dev.rs
+++ b/block-cipher-trait/src/dev.rs
@@ -42,11 +42,12 @@ macro_rules! new_test {
                 let plaintext = &plaintexts[
                     (idx[1][0] as usize)..(idx[1][1] as usize)];
                 let ciphertext = &ciphertexts[
-                    (idx[2][0] as usize)..(idx[2][1] as usize)]
+                    (idx[2][0] as usize)..(idx[2][1] as usize)];
                 if !run_test(key, plaintext, ciphertext) {
                     panic!(
                         "Failed at test number {}:\nkey: {:?}\nplaintext: {:?}\n ciphertext: {:?}",
-                        i, key, plaintext, ciphertext);
+                        i, key, plaintext, ciphertext
+                    );
                 }
 
             }

--- a/block-cipher-trait/src/dev.rs
+++ b/block-cipher-trait/src/dev.rs
@@ -44,8 +44,8 @@ macro_rules! new_test {
                 let ciphertext = &ciphertexts[
                     (idx[2][0] as usize)..(idx[2][1] as usize)];
                 if !run_test(key, plaintext, ciphertext) {
-                    panic!(
-                        "Failed at test number {}:\nkey: {:?}\nplaintext: {:?}\n ciphertext: {:?}",
+                    panic!("\nFailed at test number {}:\n\
+                        key: {:?}\nplaintext: {:?}\nciphertext: {:?}\n",
                         i, key, plaintext, ciphertext
                     );
                 }

--- a/block-cipher-trait/src/dev.rs
+++ b/block-cipher-trait/src/dev.rs
@@ -4,7 +4,7 @@ macro_rules! new_test {
     ($name:ident, $test_name:expr, $cipher:ty) => {
         #[test]
         fn $name() {
-            use des::BlockCipher;
+            use block_cipher_trait::BlockCipher;
             use block_cipher_trait::generic_array::GenericArray;
 
             fn run_test(key: &[u8], pt: &[u8], ct: &[u8]) -> bool {

--- a/block-cipher-trait/src/dev.rs
+++ b/block-cipher-trait/src/dev.rs
@@ -46,9 +46,9 @@ macro_rules! new_test {
                 if !run_test(key, plaintext, ciphertext) {
                     panic!("\n\
                         Failed at test number {}:\n\
-                        key: [{}..{}]{:?}\n\
-                        plaintext: {:?}\n\
-                        ciphertext: {:?}\n",
+                        key: [{}..{}]\t{:?}\n\
+                        plaintext: [{}..{}]\t{:?}\n\
+                        ciphertext: [{}..{}]\t{:?}\n",
                         i, idx[0][0], idx[0][1], key,
                         idx[1][0], idx[1][1], plaintext,
                         idx[2][0], idx[2][1], ciphertext,

--- a/block-cipher-trait/src/dev.rs
+++ b/block-cipher-trait/src/dev.rs
@@ -38,6 +38,10 @@ macro_rules! new_test {
                 let idx = unsafe {
                     &*(chunk.as_ptr() as *const [[u16; 2]; 3])
                 };
+                // convert to LE for BE machine
+                for val in idx.iter_mut() {
+                    for i in in val.iter_mut() { *i = i.to_le(); }
+                }
                 let key = &keys[(idx[0][0] as usize)..(idx[0][1] as usize)];
                 let plaintext = &plaintexts[
                     (idx[1][0] as usize)..(idx[1][1] as usize)];

--- a/block-cipher-trait/src/dev.rs
+++ b/block-cipher-trait/src/dev.rs
@@ -1,6 +1,6 @@
 use generic_array::GenericArray;
 
-use super::{NewVarKey, BlockCipher};
+use super::BlockCipher;
 
 pub struct Test {
     pub name: &'static str,
@@ -23,10 +23,10 @@ macro_rules! new_block_cipher_tests {
     };
 }
 
-pub fn encrypt_decrypt<B: NewVarKey + BlockCipher>(tests: &[Test]) {
+pub fn encrypt_decrypt<B: BlockCipher>(tests: &[Test]) {
     // test encryption
     for test in tests {
-        let state = B::new(test.key).unwrap();
+        let state = B::new_varkey(test.key).unwrap();
         let mut block = GenericArray::clone_from_slice(test.input);
         state.encrypt_block(&mut block);
         assert_eq!(test.output, block.as_slice());
@@ -34,7 +34,7 @@ pub fn encrypt_decrypt<B: NewVarKey + BlockCipher>(tests: &[Test]) {
 
     // test decription
     for test in tests {
-        let state = B::new(test.key).unwrap();
+        let state = B::new_varkey(test.key).unwrap();
         let mut block = GenericArray::clone_from_slice(test.output);
         state.decrypt_block(&mut block);
         assert_eq!(test.input, block.as_slice());
@@ -42,16 +42,16 @@ pub fn encrypt_decrypt<B: NewVarKey + BlockCipher>(tests: &[Test]) {
 }
 
 #[macro_export]
-macro_rules! bench_block_cipher {
+macro_rules! bench {
     ($cipher:path, $key_len:expr) => {
         extern crate test;
 
         use test::Bencher;
-        use block_cipher_trait::{BlockCipher, NewVarKey};
+        use block_cipher_trait::BlockCipher;
 
         #[bench]
         pub fn encrypt(bh: &mut Bencher) {
-            let state = <$cipher>::new(&[1u8; $key_len]).unwrap();
+            let state = <$cipher>::new_varkey(&[1u8; $key_len]).unwrap();
             let mut block = Default::default();
 
             bh.iter(|| {
@@ -63,7 +63,7 @@ macro_rules! bench_block_cipher {
 
         #[bench]
         pub fn decrypt(bh: &mut Bencher) {
-            let state = <$cipher>::new(&[1u8; $key_len]).unwrap();
+            let state = <$cipher>::new_varkey(&[1u8; $key_len]).unwrap();
             let mut block = Default::default();
 
             bh.iter(|| {

--- a/block-cipher-trait/src/dev.rs
+++ b/block-cipher-trait/src/dev.rs
@@ -40,7 +40,7 @@ macro_rules! new_test {
                 };
                 // convert to LE for BE machine
                 for val in idx.iter_mut() {
-                    for i in in val.iter_mut() { *i = i.to_le(); }
+                    for i in val.iter_mut() { *i = i.to_le(); }
                 }
                 let key = &keys[(idx[0][0] as usize)..(idx[0][1] as usize)];
                 let plaintext = &plaintexts[

--- a/block-cipher-trait/src/dev.rs
+++ b/block-cipher-trait/src/dev.rs
@@ -35,8 +35,8 @@ macro_rules! new_test {
             assert_eq!(index.len() % (2*3*2), 0, "invlaid index length");
             for (i, chunk) in index.chunks(2*3*2).enumerate() {
                 // proper aligment is assumed here
-                let idx = unsafe {
-                    &*(chunk.as_ptr() as *const [[u16; 2]; 3])
+                let mut idx = unsafe {
+                    *(chunk.as_ptr() as *const [[u16; 2]; 3])
                 };
                 // convert to LE for BE machine
                 for val in idx.iter_mut() {

--- a/block-cipher-trait/src/dev.rs
+++ b/block-cipher-trait/src/dev.rs
@@ -38,12 +38,15 @@ macro_rules! new_test {
                 let idx = unsafe {
                     &*(chunk.as_ptr() as *const [[u16; 2]; 3])
                 };
-                if !run_test(
-                    &keys[(idx[0][0] as usize)..(idx[0][1] as usize)],
-                    &plaintexts[(idx[1][0] as usize)..(idx[1][1] as usize)],
-                    &ciphertexts[(idx[2][0] as usize)..(idx[2][1] as usize)],
-                ) {
-                    panic!("Failed at test number: {}", i);
+                let key = &keys[(idx[0][0] as usize)..(idx[0][1] as usize)];
+                let plaintext = &plaintexts[
+                    (idx[1][0] as usize)..(idx[1][1] as usize)];
+                let ciphertext = &ciphertexts[
+                    (idx[2][0] as usize)..(idx[2][1] as usize)]
+                if !run_test(key, plaintext, ciphertext) {
+                    panic!(
+                        "Failed at test number {}:\nkey: {:?}\nplaintext: {:?}\n ciphertext: {:?}",
+                        i, key, plaintext, ciphertext);
                 }
 
             }

--- a/block-cipher-trait/src/dev.rs
+++ b/block-cipher-trait/src/dev.rs
@@ -10,7 +10,7 @@ pub struct Test {
 }
 
 #[macro_export]
-macro_rules! new_block_cipher_tests {
+macro_rules! new_tests {
     [ $( $name:expr ),*  ] => {
         [$(
             Test {
@@ -21,10 +21,10 @@ macro_rules! new_block_cipher_tests {
             },
         )*]
     };
-    [ $( $name:expr ),+, ] => (new_tests!($($name),+))
+    [ $( $name:expr ),+, ] => (new_tests![$($name),+])
 }
 
-pub fn encrypt_decrypt<B: BlockCipher>(tests: &[Test]) {
+pub fn run_tests<B: BlockCipher>(tests: &[Test]) {
     // test encryption
     for test in tests {
         let state = B::new_varkey(test.key).unwrap();

--- a/block-cipher-trait/src/lib.rs
+++ b/block-cipher-trait/src/lib.rs
@@ -11,14 +11,35 @@ pub mod dev;
 
 type ParBlocks<B, P> = GenericArray<GenericArray<u8, B>, P>;
 
+/// Error struct which used with `NewVarKey`
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub struct InvalidKeyLength;
+
 /// The trait which defines in-place encryption and decryption
 /// over single block or several blocks in parallel.
 pub trait BlockCipher {
+    /// Key size in bytes with which cipher guaranteed to be initialized
+    type KeySize: ArrayLength<u8>;
     /// Size of the block in bytes
     type BlockSize: ArrayLength<u8>;
     /// Number of blocks which can be processed in parallel by
     /// cipher implementation
     type ParBlocks: ArrayLength<GenericArray<u8, Self::BlockSize>>;
+
+    /// Create new block cipher instance from key with fixed size.
+    fn new(key: &GenericArray<u8, Self::KeySize>) -> Self;
+
+    /// Create new block cipher instance from key with variable size.
+    ///
+    /// Default implementation will accept only keys with length equal to
+    /// `KeySize`, but some ciphers can accept range of key lengths.
+    fn new_varkey(key: &[u8]) -> Result<Self, InvalidKeyLength> {
+        if key.len() != Self::KeySize::to_usize() {
+            Err(InvalidKeyLength)
+        } else {
+            Ok(Self::new(GenericArray::from_slice(key)))
+        }
+    }
 
     /// Encrypt block in-place
     fn encrypt_block(&self, block: &mut GenericArray<u8, Self::BlockSize>);
@@ -46,36 +67,5 @@ pub trait BlockCipher {
         blocks: &mut ParBlocks<Self::BlockSize, Self::ParBlocks>)
     {
         for block in blocks.iter_mut() { self.decrypt_block(block); }
-    }
-}
-
-/// Trait for creation of block cipher with fixed size key
-pub trait NewFixKey {
-    type KeySize: ArrayLength<u8>;
-
-    /// Create new block cipher instance with given fixed size key
-    fn new(key: &GenericArray<u8, Self::KeySize>) -> Self;
-}
-
-/// Error struct which used with `NewVarKey`
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
-pub struct InvalidKeyLength;
-
-/// Trait for creation of block cipher with variable size keys.
-///
-/// This trait is auto implemented for `NewFixKey`.
-pub trait NewVarKey: Sized {
-    /// Create new block cipher instance with given key, if length of given
-    /// key is unsupported by implementation error will be returned.
-    fn new(key: &[u8]) -> Result<Self, InvalidKeyLength>;
-}
-
-impl<T: NewFixKey> NewVarKey for T {
-    fn new(key: &[u8]) -> Result<Self, InvalidKeyLength> {
-        if key.len() != T::KeySize::to_usize() {
-            Err(InvalidKeyLength)
-        } else {
-            Ok(T::new(GenericArray::from_slice(key)))
-        }
     }
 }

--- a/block-cipher-trait/src/lib.rs
+++ b/block-cipher-trait/src/lib.rs
@@ -17,7 +17,7 @@ pub struct InvalidKeyLength;
 
 /// The trait which defines in-place encryption and decryption
 /// over single block or several blocks in parallel.
-pub trait BlockCipher {
+pub trait BlockCipher: core::marker::Sized {
     /// Key size in bytes with which cipher guaranteed to be initialized
     type KeySize: ArrayLength<u8>;
     /// Size of the block in bytes

--- a/crypto-mac/Cargo.toml
+++ b/crypto-mac/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crypto-mac"
-version = "0.5.2"
+version = "0.6.0"
 authors = ["RustCrypto Developers"]
 license = "MIT/Apache-2.0"
 description = "Trait for Message Authentication Code (MAC) algorithms"

--- a/crypto-mac/src/dev.rs
+++ b/crypto-mac/src/dev.rs
@@ -74,6 +74,7 @@ macro_rules! bench {
     ($name:ident, $engine:path, $bs:expr) => {
         #[bench]
         fn $name(b: &mut Bencher) {
+            let key = Default::default();
             let mut m = <$engine>::new(&key);
             let data = [0; $bs];
 

--- a/crypto-mac/src/dev.rs
+++ b/crypto-mac/src/dev.rs
@@ -1,40 +1,73 @@
 use super::Mac;
 
-pub struct Test {
-    pub name: &'static str,
-    pub key: &'static [u8],
-    pub input: &'static [u8],
-    pub output: &'static [u8],
-}
-
 #[macro_export]
-macro_rules! new_tests {
-    ( $( $name:expr ),*  ) => {
-        [$(
-            Test {
-                name: $name,
-                key: include_bytes!(concat!("data/", $name, ".key.bin")),
-                input: include_bytes!(concat!("data/", $name, ".input.bin")),
-                output: include_bytes!(concat!("data/", $name, ".output.bin")),
-            },
-        )*]
-    };
-}
+macro_rules! new_test {
+    ($name:ident, $test_name:expr, $mac:ty) => {
+        #[test]
+        fn $name() {
+            use crypto_mac::{Mac, MacResult};
+            use crypto_mac::generic_array::GenericArray;
 
-pub fn run_tests<M: Mac>(tests: &[Test]) {
-    for test in tests.iter() {
-        let mut mac = M::new(test.key).unwrap();
-        mac.input(&test.input[..]);
-        mac.verify(test.output).unwrap();
-    }
+            fn run_test(key: &[u8], input: &[u8], tag: &[u8]) -> bool {
+                let mut mac = <$mac as Mac>::new(key).unwrap();
+                mac.input(&test.input[..]);
+                let result = mac.result();
+                let atag = GenericArray::clone_from_slice(tag);
+                if result != MacResult::new(atag) {
+                    return false;
+                }
+                // test if reset worked correctly
+                mac.input(&test.input[..]);
+                if mac.verify(&tag).is_err() {
+                    return false;
+                }
 
-    // incremental test
-    for test in tests.iter() {
-        let mut mac = M::new(test.key).unwrap();
-        for i in 0..test.input.len() {
-            mac.input(&test.input[i..i + 1]);
+                // test reading byte by byte
+                for i in 0..test.input.len() {
+                    mac.input(&test.input[i..i + 1]);
+                }
+                mac.verify(test.output).unwrap();
+            }
+
+            let keys = include_bytes!(
+                concat!("data/", $test_name, ".keys.bin"));
+            let inputs = include_bytes!(
+                concat!("data/", $test_name, ".plaintexts.bin"));
+            let tags = include_bytes!(
+                concat!("data/", $test_name, ".tags.bin"));
+            let index = include_bytes!(
+                concat!("data/", $test_name, ".index.bin"));
+
+            // u32 (2 bytes); start + end (x2); key, input, tag (x3)
+            assert_eq!(index.len() % (2*3*2), 0, "invlaid index length");
+            for (i, chunk) in index.chunks(2*3*2).enumerate() {
+                // proper aligment is assumed here
+                let mut idx = unsafe {
+                    *(chunk.as_ptr() as *const [[u16; 2]; 3])
+                };
+                // convert to LE for BE machine
+                for val in idx.iter_mut() {
+                    for i in val.iter_mut() { *i = i.to_le(); }
+                }
+                let key = &keys[(idx[0][0] as usize)..(idx[0][1] as usize)];
+                let input = &inputs[
+                    (idx[1][0] as usize)..(idx[1][1] as usize)];
+                let tag = &tags[
+                    (idx[2][0] as usize)..(idx[2][1] as usize)];
+                if !run_test(key, input, tag) {
+                    panic!("\n\
+                        Failed test №{}\n\
+                        key: [{}..{}]\t{:?}\n\
+                        input: [{}..{}]\t{:?}\n\
+                        tag: [{}..{}]\t{:?}\n",
+                        i, idx[0][0], idx[0][1], key,
+                        idx[1][0], idx[1][1], input,
+                        idx[2][0], idx[2][1], tag,
+                    );
+                }
+            }
+
         }
-        mac.verify(test.output).unwrap();
     }
 }
 

--- a/crypto-mac/src/dev.rs
+++ b/crypto-mac/src/dev.rs
@@ -8,7 +8,7 @@ pub struct Test {
 }
 
 #[macro_export]
-macro_rules! new_mac_tests {
+macro_rules! new_tests {
     ( $( $name:expr ),*  ) => {
         [$(
             Test {
@@ -21,7 +21,7 @@ macro_rules! new_mac_tests {
     };
 }
 
-pub fn mac_test<M: Mac>(tests: &[Test]) {
+pub fn run_tests<M: Mac>(tests: &[Test]) {
     for test in tests.iter() {
         let mut mac = M::new(test.key).unwrap();
         mac.input(&test.input[..]);
@@ -60,8 +60,9 @@ macro_rules! bench {
         use test::Bencher;
         use crypto_mac::Mac;
 
-        bench!(bench1_100, $engine, $key_size, 100);
-        bench!(bench2_1000, $engine, $key_size, 1000);
+        bench!(bench1_10,    $engine, $key_size, 10);
+        bench!(bench2_100,   $engine, $key_size, 100);
+        bench!(bench3_1000,  $engine, $key_size, 1000);
         bench!(bench3_10000, $engine, $key_size, 10000);
     }
 }

--- a/crypto-mac/src/dev.rs
+++ b/crypto-mac/src/dev.rs
@@ -32,7 +32,7 @@ macro_rules! new_test {
             let keys = include_bytes!(
                 concat!("data/", $test_name, ".keys.bin"));
             let inputs = include_bytes!(
-                concat!("data/", $test_name, ".plaintexts.bin"));
+                concat!("data/", $test_name, ".inputs.bin"));
             let tags = include_bytes!(
                 concat!("data/", $test_name, ".tags.bin"));
             let index = include_bytes!(

--- a/crypto-mac/src/dev.rs
+++ b/crypto-mac/src/dev.rs
@@ -71,10 +71,10 @@ macro_rules! new_test {
 
 #[macro_export]
 macro_rules! bench {
-    ($name:ident, $engine:path, $key_size:expr, $bs:expr) => {
+    ($name:ident, $engine:path, $bs:expr) => {
         #[bench]
         fn $name(b: &mut Bencher) {
-            let mut m = <$engine>::new(&[0; $key_size]).unwrap();
+            let mut m = <$engine>::new(&key);
             let data = [0; $bs];
 
             b.iter(|| {
@@ -85,7 +85,7 @@ macro_rules! bench {
         }
     };
 
-    ($engine:path, $key_size:expr) => {
+    ($engine:path) => {
         extern crate test;
 
         use test::Bencher;

--- a/crypto-mac/src/dev.rs
+++ b/crypto-mac/src/dev.rs
@@ -4,8 +4,7 @@ macro_rules! new_test {
     ($name:ident, $test_name:expr, $mac:ty) => {
         #[test]
         fn $name() {
-            use crypto_mac::{Mac, MacResult};
-            use crypto_mac::generic_array::GenericArray;
+            use crypto_mac::Mac;
 
             fn run_test(key: &[u8], input: &[u8], tag: &[u8]) -> bool {
                 let mut mac = <$mac as Mac>::new_varkey(key).unwrap();

--- a/crypto-mac/src/dev.rs
+++ b/crypto-mac/src/dev.rs
@@ -91,9 +91,9 @@ macro_rules! bench {
         use test::Bencher;
         use crypto_mac::Mac;
 
-        bench!(bench1_10,    $engine, $key_size, 10);
-        bench!(bench2_100,   $engine, $key_size, 100);
-        bench!(bench3_1000,  $engine, $key_size, 1000);
-        bench!(bench3_10000, $engine, $key_size, 10000);
+        bench!(bench1_10,    $engine, 10);
+        bench!(bench2_100,   $engine, 100);
+        bench!(bench3_1000,  $engine, 1000);
+        bench!(bench3_10000, $engine, 10000);
     }
 }

--- a/crypto-mac/src/dev.rs
+++ b/crypto-mac/src/dev.rs
@@ -10,23 +10,23 @@ macro_rules! new_test {
 
             fn run_test(key: &[u8], input: &[u8], tag: &[u8]) -> bool {
                 let mut mac = <$mac as Mac>::new(key).unwrap();
-                mac.input(&test.input[..]);
+                mac.input(input);
                 let result = mac.result();
                 let atag = GenericArray::clone_from_slice(tag);
                 if result != MacResult::new(atag) {
                     return false;
                 }
                 // test if reset worked correctly
-                mac.input(&test.input[..]);
+                mac.input(input);
                 if mac.verify(&tag).is_err() {
                     return false;
                 }
 
                 // test reading byte by byte
-                for i in 0..test.input.len() {
-                    mac.input(&test.input[i..i + 1]);
+                for i in 0..input.len() {
+                    mac.input(&input[i..i + 1]);
                 }
-                mac.verify(test.output).unwrap();
+                mac.verify(tag).unwrap();
             }
 
             let keys = include_bytes!(

--- a/crypto-mac/src/dev.rs
+++ b/crypto-mac/src/dev.rs
@@ -1,4 +1,3 @@
-use super::Mac;
 
 #[macro_export]
 macro_rules! new_test {
@@ -9,11 +8,10 @@ macro_rules! new_test {
             use crypto_mac::generic_array::GenericArray;
 
             fn run_test(key: &[u8], input: &[u8], tag: &[u8]) -> bool {
-                let mut mac = <$mac as Mac>::new(key).unwrap();
+                let mut mac = <$mac as Mac>::new_varkey(key).unwrap();
                 mac.input(input);
                 let result = mac.result();
-                let atag = GenericArray::clone_from_slice(tag);
-                if result != MacResult::new(atag) {
+                if !result.is_equal(tag) {
                     return false;
                 }
                 // test if reset worked correctly
@@ -27,6 +25,7 @@ macro_rules! new_test {
                     mac.input(&input[i..i + 1]);
                 }
                 mac.verify(tag).unwrap();
+                true
             }
 
             let keys = include_bytes!(

--- a/crypto-mac/src/lib.rs
+++ b/crypto-mac/src/lib.rs
@@ -1,14 +1,14 @@
 //! This crate provides trait for Message Authentication Code (MAC) algorithms.
 #![no_std]
 extern crate constant_time_eq;
-extern crate generic_array;
+pub extern crate generic_array;
 
 use constant_time_eq::constant_time_eq;
 use generic_array::{GenericArray, ArrayLength};
 use generic_array::typenum::Unsigned;
 
-//#[cfg(feature = "dev")]
-//pub mod dev;
+#[cfg(feature = "dev")]
+pub mod dev;
 
 /// Error type for signaling failed MAC verification
 #[derive(Default, Debug, Copy, Clone, Eq, PartialEq)]

--- a/crypto-mac/src/lib.rs
+++ b/crypto-mac/src/lib.rs
@@ -7,8 +7,8 @@ use constant_time_eq::constant_time_eq;
 use generic_array::{GenericArray, ArrayLength};
 use generic_array::typenum::Unsigned;
 
-#[cfg(feature = "dev")]
-pub mod dev;
+//#[cfg(feature = "dev")]
+//pub mod dev;
 
 /// Error type for signaling failed MAC verification
 #[derive(Default, Debug, Copy, Clone, Eq, PartialEq)]

--- a/crypto-mac/src/lib.rs
+++ b/crypto-mac/src/lib.rs
@@ -23,10 +23,13 @@ pub trait Mac: core::marker::Sized {
     type OutputSize: ArrayLength<u8>;
     type KeySize: ArrayLength<u8>;
 
-    /// Create a new MAC instance from key with fixed size.
+    /// Create new MAC instance from key with fixed size.
     fn new(key: &GenericArray<u8, Self::KeySize>) -> Self;
 
-    /// Create a new MAC instance from variable sized key.
+    /// Create new MAC instance from key with variable size.
+    ///
+    /// Default implementation will accept only keys with length equal to
+    /// `KeySize`, but some MACs can accept range of key lengths.
     fn new_varkey(key: &[u8]) -> Result<Self, InvalidKeyLength> {
         if key.len() != Self::KeySize::to_usize() {
             Err(InvalidKeyLength)

--- a/digest/Cargo.toml
+++ b/digest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "digest"
-version = "0.7.2"
+version = "0.8.0"
 authors = ["RustCrypto Developers"]
 license = "MIT/Apache-2.0"
 description = "Traits for cryptographic hash functions"

--- a/digest/src/dev.rs
+++ b/digest/src/dev.rs
@@ -9,7 +9,7 @@ pub struct Test {
 
 #[macro_export]
 macro_rules! new_tests {
-    ( $( $name:expr ),*  ) => {
+    [ $( $name:expr ),*  ] => {
         [$(
             Test {
                 name: $name,
@@ -18,7 +18,7 @@ macro_rules! new_tests {
             },
         )*]
     };
-    ( $( $name:expr ),+, ) => (new_tests!($($name),+))
+    [ $( $name:expr ),+, ] => (new_tests!($($name),+))
 }
 
 pub fn main_test<D: Digest + Debug + Clone>(tests: &[Test]) {
@@ -140,7 +140,7 @@ pub fn one_million_a<D: Digest + Default + Debug + Clone>(expected: &[u8]) {
 
 
 #[macro_export]
-macro_rules! bench_digest {
+macro_rules! bench {
     ($name:ident, $engine:path, $bs:expr) => {
         #[bench]
         fn $name(b: &mut Bencher) {

--- a/digest/src/dev.rs
+++ b/digest/src/dev.rs
@@ -18,10 +18,10 @@ macro_rules! new_tests {
             },
         )*]
     };
-    [ $( $name:expr ),+, ] => (new_tests!($($name),+))
+    [ $( $name:expr ),+, ] => (new_tests![$($name),+])
 }
 
-pub fn main_test<D: Digest + Debug + Clone>(tests: &[Test]) {
+pub fn run_digest_tests<D: Digest + Debug + Clone>(tests: &[Test]) {
     // Test that it works when accepting the message all at once
     for t in tests.iter() {
         let mut sh = D::default();
@@ -49,7 +49,7 @@ pub fn main_test<D: Digest + Debug + Clone>(tests: &[Test]) {
     }
 }
 
-pub fn variable_test<D>(tests: &[Test])
+pub fn run_variable_tests<D>(tests: &[Test])
     where D: Input + VariableOutput + Clone + Debug
 {
     let mut buf = [0u8; 1024];
@@ -81,7 +81,7 @@ pub fn variable_test<D>(tests: &[Test])
 }
 
 
-pub fn xof_test<D>(tests: &[Test])
+pub fn run_xof_tests<D>(tests: &[Test])
     where D: Input + ExtendableOutput + Default + Debug + Clone
 {
     let mut buf = [0u8; 1024];
@@ -128,12 +128,12 @@ pub fn xof_test<D>(tests: &[Test])
     }
 }
 
-pub fn one_million_a<D: Digest + Default + Debug + Clone>(expected: &[u8]) {
+pub fn run_1mil_a_test<D: Digest + Default + Debug + Clone>(expected: &[u8]) {
     let mut sh = D::default();
-    for _ in 0..50000 {
+    for _ in 0..50_000 {
         sh.input(&[b'a'; 10]);
     }
-    sh.input(&[b'a'; 500000]);
+    sh.input(&[b'a'; 500_000]);
     let out = sh.result();
     assert_eq!(out[..], expected[..]);
 }
@@ -161,11 +161,9 @@ macro_rules! bench {
         use test::Bencher;
         use digest::Digest;
 
-        bench_digest!(bench1_16, $engine, 1<<4);
-        bench_digest!(bench2_64, $engine, 1<<6);
-        bench_digest!(bench3_256, $engine, 1<<8);
-        bench_digest!(bench4_1k, $engine, 1<<10);
-        bench_digest!(bench5_4k, $engine, 1<<12);
-        bench_digest!(bench6_16k, $engine, 1<<14);
+        bench_digest!(bench1_10,    $engine, 10);
+        bench_digest!(bench2_100,   $engine, 100);
+        bench_digest!(bench3_1000,  $engine, 1000);
+        bench_digest!(bench4_10000, $engine, 10000);
     }
 }

--- a/digest/src/digest.rs
+++ b/digest/src/digest.rs
@@ -1,4 +1,4 @@
-use super::{Input, BlockInput, FixedOutput};
+use super::{Input, FixedOutput};
 use generic_array::GenericArray;
 #[cfg(feature = "std")]
 use std::io;
@@ -9,7 +9,7 @@ type Output<N> = GenericArray<u8, N>;
 ///
 /// It's a convinience wrapper around `Input`, `FixedOutput`, `BlockInput` and
 /// `Default` traits. It also provides additional convinience methods.
-pub trait Digest: Input + BlockInput + FixedOutput + Default {
+pub trait Digest: Input + FixedOutput + Default {
     /// Create new hasher instance
     fn new() -> Self {
         Self::default()
@@ -82,4 +82,4 @@ pub trait Digest: Input + BlockInput + FixedOutput + Default {
     }
 }
 
-impl<D: Input + FixedOutput + BlockInput + Default> Digest for D {}
+impl<D: Input + FixedOutput + Default> Digest for D {}

--- a/digest/src/digest.rs
+++ b/digest/src/digest.rs
@@ -21,8 +21,8 @@ pub trait Digest: Input + BlockInput + FixedOutput + Default {
         self.process(input);
     }
 
-    /// Retrieve the digest result. This method consumes digest instance.
-    fn result(self) -> Output<Self::OutputSize> {
+    /// Retrieve result and reset hasher instance
+    fn result(&mut self) -> Output<Self::OutputSize> {
         self.fixed_result()
     }
 
@@ -44,7 +44,7 @@ pub trait Digest: Input + BlockInput + FixedOutput + Default {
     /// Convinience function to compute hash of the string. It's equivalent to
     /// `digest(input_string.as_bytes())`.
     #[inline]
-    fn digest_str(str: &str) -> Output<Self::OutputSize> {
+    fn input_str(str: &str) -> Output<Self::OutputSize> {
         Self::digest(str.as_bytes())
     }
 

--- a/digest/src/digest.rs
+++ b/digest/src/digest.rs
@@ -7,8 +7,8 @@ type Output<N> = GenericArray<u8, N>;
 
 /// The `Digest` trait specifies an interface common for digest functions.
 ///
-/// It's a convinience wrapper around `Input`, `FixedOutput`, `BlockInput` and
-/// `Default` traits. It also provides additional convinience methods.
+/// It's a convinience wrapper around `Input`, `FixedOutput` and `Default`
+/// traits. It also provides additional convinience methods.
 pub trait Digest: Input + FixedOutput + Default {
     /// Create new hasher instance
     fn new() -> Self {


### PR DESCRIPTION
It adds [reset functionality](https://github.com/RustCrypto/traits/issues/6) to tratis from `digest` and `crypto-mac` traits. Additionally it changes `Mac` and `BlockCipher` initialization methods.