### PR TITLE
Add Error and Display impls for error types

### DIFF
--- a/block-cipher-trait/Cargo.toml
+++ b/block-cipher-trait/Cargo.toml
@@ -14,6 +14,7 @@ generic-array = "0.9"
 
 [features]
 dev = []
+std = []
 
 [badges]
 travis-ci = { repository = "RustCrypto/traits" }

--- a/block-cipher-trait/src/lib.rs
+++ b/block-cipher-trait/src/lib.rs
@@ -1,10 +1,17 @@
 //! This crate defines a set of simple traits used to define functionality of
 //! block ciphers.
-#![no_std]
+#![cfg_attr(not(feature = "std"), no_std)]
 pub extern crate generic_array;
+
+#[cfg(feature = "std")]
+use std as core;
 
 use generic_array::{GenericArray, ArrayLength};
 use generic_array::typenum::Unsigned;
+
+use core::fmt;
+#[cfg(feature = "std")]
+use std::{error::Error};
 
 #[cfg(feature = "dev")]
 pub mod dev;
@@ -67,5 +74,18 @@ pub trait BlockCipher: core::marker::Sized {
         blocks: &mut ParBlocks<Self::BlockSize, Self::ParBlocks>)
     {
         for block in blocks.iter_mut() { self.decrypt_block(block); }
+    }
+}
+
+impl fmt::Display for InvalidKeyLength {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str("invalid key length")
+    }
+}
+
+#[cfg(feature = "std")]
+impl Error for InvalidKeyLength {
+    fn description(&self) -> &str {
+        "invalid key length"
     }
 }

--- a/crypto-mac/Cargo.toml
+++ b/crypto-mac/Cargo.toml
@@ -15,6 +15,7 @@ constant_time_eq = "0.1"
 
 [features]
 dev = []
+std = []
 
 [badges]
 travis-ci = { repository = "RustCrypto/traits" }

--- a/crypto-mac/src/lib.rs
+++ b/crypto-mac/src/lib.rs
@@ -1,7 +1,14 @@
 //! This crate provides trait for Message Authentication Code (MAC) algorithms.
-#![no_std]
+#![cfg_attr(not(feature = "std"), no_std)]
 extern crate constant_time_eq;
 pub extern crate generic_array;
+
+use core::fmt;
+#[cfg(feature = "std")]
+use std::{error::Error};
+
+#[cfg(feature = "std")]
+use std as core;
 
 use constant_time_eq::constant_time_eq;
 use generic_array::{GenericArray, ArrayLength};
@@ -62,6 +69,32 @@ pub trait Mac: core::marker::Sized {
 #[derive(Clone)]
 pub struct MacResult<N: ArrayLength<u8>> {
     code: GenericArray<u8, N>
+}
+
+impl fmt::Display for MacError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str("failed MAC verification")
+    }
+}
+
+impl fmt::Display for InvalidKeyLength {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str("invalid key length")
+    }
+}
+
+#[cfg(feature = "std")]
+impl Error for MacError {
+    fn description(&self) -> &str {
+        "failed MAC verification"
+    }
+}
+
+#[cfg(feature = "std")]
+impl Error for InvalidKeyLength {
+    fn description(&self) -> &str {
+        "invalid key length"
+    }
 }
 
 impl<N> MacResult<N> where N: ArrayLength<u8> {

--- a/digest/src/lib.rs
+++ b/digest/src/lib.rs
@@ -91,13 +91,13 @@ pub trait ExtendableOutput {
 
 impl fmt::Display for InvalidOutputSize {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "invalid output size")
+        f.write_str("invalid output size")
     }
 }
 
 impl fmt::Display for InvalidBufferLength {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "invalid buffer length")
+        f.write_str("invalid buffer length")
     }
 }
 

--- a/digest/src/lib.rs
+++ b/digest/src/lib.rs
@@ -11,6 +11,10 @@ pub extern crate generic_array;
 use std as core;
 use generic_array::{GenericArray, ArrayLength};
 
+use core::fmt;
+#[cfg(feature = "std")]
+use std::{error::Error};
+
 mod digest;
 #[cfg(feature = "dev")]
 pub mod dev;
@@ -83,4 +87,30 @@ pub trait ExtendableOutput {
 
     /// Retrieve XOF reader and reset hasher instance.
     fn xof_result(&mut self) -> Self::Reader;
+}
+
+impl fmt::Display for InvalidOutputSize {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "invalid output size")
+    }
+}
+
+impl fmt::Display for InvalidBufferLength {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "invalid buffer length")
+    }
+}
+
+#[cfg(feature = "std")]
+impl Error for InvalidBufferLength {
+    fn description(&self) -> &str {
+        "invalid output size"
+    }
+}
+
+#[cfg(feature = "std")]
+impl Error for InvalidOutputSize {
+    fn description(&self) -> &str {
+        "invalid output size"
+    }
 }


### PR DESCRIPTION
Add Error and Display impls for error types, while still ensuring no_std compatibility.