### PR TITLE
Use subtle v2

### DIFF
--- a/crypto-mac/Cargo.toml
+++ b/crypto-mac/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["cryptography", "no-std"]
 
 [dependencies]
 generic-array = "0.12"
-subtle = { version = "1", default-features = false }
+subtle = { version = "2", default-features = false }
 blobby = { version = "0.1", optional = true }
 
 [features]


### PR DESCRIPTION
Hi, we released version `2.0.0` of `subtle`.

There are no changes to the parts used by `crypto-mac`, but the `ConditionallySelectable` trait was redesigned to fix some design issues that made it difficult to customize the implementation (this had no security content, just ergonomics / interaction with orphan rules). Unfortunately this meant bumping the semver major version.

Changing to version 2 should have no impact on any of the uses inside of `crypto-mac`, or any of the users of `crypto-mac`, so the practical impact should be small, but since it is part of the public API I believe that this is a breaking change and would require a version bump for `crypto-mac`.