### PR TITLE
aead: Fix comments on Aead::encrypt/decrypt

### DIFF
--- a/aead/rustfmt.toml
+++ b/aead/rustfmt.toml
@@ -1,1 +1,0 @@
-merge_imports = true


### PR DESCRIPTION
I just noticed that in #49 I swapped the `Aead`/`AeadMut` names, but didn't update the comments accordingly, so `Aead` is documented as saying "Refer to the `Aead::encrypt`/`decrypt` docs. Oops.

This commit swaps the comments to match.