### PR TITLE
aead: Add From impls between (&[u8], &[u8]) and Payload

### DIFF
--- a/aead/src/lib.rs
+++ b/aead/src/lib.rs
@@ -160,3 +160,15 @@ impl<'msg, 'aad> From<&'msg [u8]> for Payload<'msg, 'aad> {
         Self { msg, aad: b"" }
     }
 }
+
+impl<'msg, 'aad> From<(&'msg [u8], &'aad [u8])> for Payload<'msg, 'aad> {
+    fn from(tuple: (&'msg [u8], &'aad [u8])) -> Self {
+        Self { msg: tuple.0, aad: tuple.1 }
+    }
+}
+
+impl<'msg, 'aad> From<Payload<'msg, 'aad>> for (&'msg [u8], &'aad [u8]) {
+    fn from(payload: Payload<'msg, 'aad>) -> Self {
+        (payload.msg, payload.aad)
+    }
+}


### PR DESCRIPTION
Random idea I had: I thought there might be scenarios where these conversions are convenient.

They do eliminate the nice labels you get out of a struct though, so they seem like used incorrectly they could be a footgun.

I'm on the fence, but I thought I'd throw them up for a second look.