### PR TITLE
universal-hash: Initial crate implementation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ sudo: required
 matrix:
   include:
     - rust: 1.21.0
-      script: cargo test --verbose --all --exclude aead --release
+      script: cargo test --verbose --all --exclude aead --exclude universal-hash --release
     - rust: 1.36.0
-      script: cargo test --verbose --package aead --release
+      script: cargo test --verbose --package aead --package universal-hash --release
     - rust: stable
       script: cargo test --verbose --all --release
     - rust: nightly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,4 +5,5 @@ members = [
     "crypto-mac",
     "digest",
     "stream-cipher",
+    "universal-hash",
 ]

--- a/build_std.sh
+++ b/build_std.sh
@@ -7,7 +7,7 @@ TARGET="thumbv7em-none-eabi"
 cargo clean
 
 for DIR in $DIRS; do
-    if [ $DIR = "target/" -o $DIR = "aead/" ]
+    if [ $DIR = "target/" -o $DIR = "aead/" -o $DIR = "universal-hash/" ]
     then
         continue
     fi

--- a/universal-hash/CHANGELOG.md
+++ b/universal-hash/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/universal-hash/Cargo.toml
+++ b/universal-hash/Cargo.toml
@@ -8,6 +8,7 @@ documentation = "https://docs.rs/universal-hash"
 repository = "https://github.com/RustCrypto/traits"
 keywords = ["crypto", "mac"]
 categories = ["cryptography", "no-std"]
+edition = "2018"
 
 [dependencies]
 generic-array = "0.12"

--- a/universal-hash/Cargo.toml
+++ b/universal-hash/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "universal-hash"
+version = "0.0.0"
+authors = ["RustCrypto Developers"]
+license = "MIT OR Apache-2.0"
+description = "Trait for universal hash functions"
+documentation = "https://docs.rs/universal-hash"
+repository = "https://github.com/RustCrypto/traits"
+keywords = ["crypto", "mac"]
+categories = ["cryptography", "no-std"]
+
+[dependencies]
+generic-array = "0.12"
+subtle = { version = "2", default-features = false }
+
+[features]
+std = []
+
+[badges]
+travis-ci = { repository = "RustCrypto/traits" }
+
+[package.metadata.docs.rs]
+all-features = true

--- a/universal-hash/LICENSE-APACHE
+++ b/universal-hash/LICENSE-APACHE
@@ -1,0 +1,201 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/universal-hash/LICENSE-MIT
+++ b/universal-hash/LICENSE-MIT
@@ -1,0 +1,25 @@
+Copyright (c) 2019 RustCrypto Developers
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/universal-hash/src/lib.rs
+++ b/universal-hash/src/lib.rs
@@ -15,13 +15,10 @@
 
 #![no_std]
 #![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png")]
-#![warn(missing_docs)]
+#![warn(missing_docs, rust_2018_idioms)]
 
 #[cfg(feature = "std")]
 extern crate std;
-
-pub extern crate generic_array;
-extern crate subtle;
 
 use generic_array::{ArrayLength, GenericArray};
 use generic_array::typenum::Unsigned;

--- a/universal-hash/src/lib.rs
+++ b/universal-hash/src/lib.rs
@@ -1,0 +1,167 @@
+//! Traits for [Universal Hash Functions].
+//!
+//! Universal hash functions select from a "universal family" of possible
+//! hash functions selected by a key. They are well suited to the purpose
+//! of "one time authenticators" for a sequence of bytestring inputs,
+//! as their construction has a number of desirable properties such as
+//! pairwise independence as well as amenability to efficient implementations,
+//! particularly when implemented using SIMD instructions.
+//!
+//! When combined with a cipher, such as in Galois/Counter Mode or the
+//! Salsa20 family AEAD constructions, they can provide the core functionality
+//! for a Message Authentication Code (MAC).
+
+#![no_std]
+#![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png")]
+#![warn(missing_docs)]
+
+#[cfg(feature = "std")]
+extern crate std;
+
+pub extern crate generic_array;
+extern crate subtle;
+
+use generic_array::{ArrayLength, GenericArray};
+use subtle::{Choice, ConstantTimeEq};
+
+/// The `UniversalHash` trait defines a generic interface for universal hash
+/// functions.
+pub trait UniversalHash<BlockSize: ArrayLength<u8>>: Clone
+where
+    BlockSize::ArrayType: Copy,
+{
+    /// Instantiate a universal hash function with the given key
+    fn new(key: Block<BlockSize>) -> Self;
+
+    /// Input a block into the universal hash function
+    fn input_block(&mut self, block: Block<BlockSize>);
+
+    /// Input data into the universal hash function. If the length of the
+    /// data is not a multiple of the block size, the remaining data is
+    /// padded with zeroes up to the `BlockSize`.
+    ///
+    /// This approach is frequently used by AEAD modes which use
+    /// Message Authentication Codes (MACs) based on universal hashing.
+    fn input_padded(&mut self, data: &[u8]) {
+        let block_size = BlockSize::to_usize();
+
+        for chunk in data.chunks(block_size) {
+            if chunk.len() == block_size {
+                let block_bytes = *GenericArray::from_slice(chunk);
+                self.input_block(block_bytes.into());
+            } else {
+                // Copy the non-aligned chunk into a zero-filled array
+                let mut padded_block = GenericArray::default();
+                padded_block[..chunk.len()].copy_from_slice(chunk);
+                self.input_block(padded_block.into());
+            }
+        }
+    }
+
+    /// Reset `UniversalHash` instance.
+    fn reset(&mut self);
+
+    /// Obtain the output `Block` of a `UniversalHash` function and consume it.
+    fn result(self) -> Block<BlockSize>;
+
+    /// Obtain the output `Block` of a `UniversalHash` computation and reset it back
+    /// to its initial state.
+    fn result_reset(&mut self) -> Block<BlockSize> {
+        let res = self.clone().result();
+        self.reset();
+        res
+    }
+
+    /// Verify the `UniversalHash` of the processed input matches a given output
+    /// `Block`. This is useful when constructing Message Authentication Codes (MACs)
+    /// from universal hash functions.
+    fn verify(self, output: Block<BlockSize>) -> Result<(), Error> {
+        if self.result() == output {
+            Ok(())
+        } else {
+            Err(Error)
+        }
+    }
+}
+
+/// The `Block` type is used as the input and output of a universal hash
+/// function and provides a thin wrapper around a byte array.
+///
+/// It provides a safe `Eq` implementation that runs in constant time, which
+/// is useful for implementing Message Authentication Codes (MACs) based on
+/// universal hashing.
+#[derive(Copy, Clone)]
+pub struct Block<N: ArrayLength<u8>>
+where
+    N::ArrayType: Copy,
+{
+    bytes: GenericArray<u8, N>,
+}
+
+impl<N> Block<N>
+where
+    N: ArrayLength<u8>,
+    N::ArrayType: Copy,
+{
+    /// Create a new `Block`.
+    pub fn new(bytes: GenericArray<u8, N>) -> Block<N> {
+        Block { bytes }
+    }
+}
+
+impl<N> From<GenericArray<u8, N>> for Block<N>
+where
+    N: ArrayLength<u8>,
+    N::ArrayType: Copy,
+{
+    fn from(bytes: GenericArray<u8, N>) -> Self {
+        Block { bytes }
+    }
+}
+
+impl<N> ConstantTimeEq for Block<N>
+where
+    N: ArrayLength<u8>,
+    N::ArrayType: Copy,
+{
+    fn ct_eq(&self, other: &Self) -> Choice {
+        self.bytes.ct_eq(&other.bytes)
+    }
+}
+
+impl<N> PartialEq for Block<N>
+where
+    N: ArrayLength<u8>,
+    N::ArrayType: Copy,
+{
+    fn eq(&self, x: &Block<N>) -> bool {
+        self.ct_eq(x).unwrap_u8() == 1
+    }
+}
+
+impl<N> Eq for Block<N>
+where
+    N: ArrayLength<u8>,
+    N::ArrayType: Copy,
+{
+}
+
+/// Error type for when the output `Block` of a `UniversalHash`
+/// is not equal to the expected value.
+#[derive(Default, Debug, Copy, Clone, Eq, PartialEq)]
+pub struct Error;
+
+#[cfg(feature = "std")]
+impl std::error::Error for Error {
+    fn description(&self) -> &'static str {
+        "UHF output mismatch"
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        use std::error::Error;
+        self.description().fmt(f)
+    }
+}

--- a/universal-hash/src/lib.rs
+++ b/universal-hash/src/lib.rs
@@ -103,6 +103,11 @@ where
     pub fn new(bytes: GenericArray<u8, N>) -> Output<N> {
         Output { bytes }
     }
+
+    /// Get the inner `GenericArray` this type wraps
+    pub fn into_bytes(self) -> GenericArray<u8, N> {
+        self.bytes
+    }
 }
 
 impl<N> From<GenericArray<u8, N>> for Output<N>

--- a/universal-hash/src/lib.rs
+++ b/universal-hash/src/lib.rs
@@ -20,8 +20,10 @@
 #[cfg(feature = "std")]
 extern crate std;
 
-use generic_array::{ArrayLength, GenericArray};
+pub use generic_array;
+
 use generic_array::typenum::Unsigned;
+use generic_array::{ArrayLength, GenericArray};
 use subtle::{Choice, ConstantTimeEq};
 
 /// The `UniversalHash` trait defines a generic interface for universal hash
@@ -75,7 +77,7 @@ pub trait UniversalHash: Clone {
     /// Verify the `UniversalHash` of the processed input matches a given [`Output`].
     /// This is useful when constructing Message Authentication Codes (MACs)
     /// from universal hash functions.
-    fn verify(self, other: impl Into<Output<Self::BlockSize>>) -> Result<(), Error> {
+    fn verify(self, other: &GenericArray<u8, Self::BlockSize>) -> Result<(), Error> {
         if self.result() == other.into() {
             Ok(())
         } else {


### PR DESCRIPTION
This crate contains a generic trait for [universal hash functions] (e.g. GHASH, POLYVAL, Poly1305) whose API is shaped by my experiences implementing both [Poly1305] and [POLYVAL] and trying to build a common abstraction with the things I want, which are the following:

- `Block` as the unified abstraction for all input and output values: performance implementations will immediately want to load these values into an XMM register on x86 architectures. For this reason this implementation enforces that all `Block` types impl `Copy`, which (empirically, by my own measurements) provides better performance than using references.
- Built-in `subtle` comparison support ala `crypto-mac`: let's not beat around the bush here, while a UHF is not a "MAC" in and of itself, we're really always going to be using them to implement MACs (possibly as an internal implementation detail of an AEAD mode that doesn't need to wrap it in the `crypto-mac` trait because it's only consuming it internally), so we may as well make it easy.
- An `input_padded()` API which inputs a byte slice block-by-block and zero pads the last "chunk" if necessary: this is pretty much the main API that any AEAD mode is going to want to use. Every RFC I've read for an AEAD mode built on a UHF-based MAC has a whole section describing a "zero pad to the block size" function, so let's define it once and be done with it.

cc @eternaleye @isislovecruft

[universal hash functions]: https://en.wikipedia.org/wiki/Universal_hashing
[Poly1305]: https://github.com/RustCrypto/MACs/tree/master/poly1305
[POLYVAL]: https://github.com/RustCrypto/MACs/tree/master/polyval