### PR TITLE
universal-hash: Split KeySize/OutputSize

### DIFF
--- a/universal-hash/CHANGELOG.md
+++ b/universal-hash/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.0 (2019-08-31)
+### Changed
+- Split KeySize/OutputSize ([#55])
+
+[#55]: https://github.com/RustCrypto/traits/pull/55
+
 ## 0.1.0 (2019-08-30)
 
 - Initial release

--- a/universal-hash/Cargo.toml
+++ b/universal-hash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "universal-hash"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 description = "Trait for universal hash functions"


### PR DESCRIPTION
Of course the minute I go to actually impl `UniversalHash` on `poly1305` I discovered it uses a 32-bit key size and a 16-bit output size...

This splits the `BlockSize` associated type  accordingly into `KeySize` and `OutputSize`.