### PR TITLE
universal-hash: OutputSize -> BlockSize

### DIFF
--- a/universal-hash/src/lib.rs
+++ b/universal-hash/src/lib.rs
@@ -31,14 +31,14 @@ use subtle::{Choice, ConstantTimeEq};
 pub trait UniversalHash: Clone {
     /// Size of the key for the universal hash function
     type KeySize: ArrayLength<u8>;
-    /// Size of the output from the universal hash function
-    type OutputSize: ArrayLength<u8>;
+    /// Size of the inputs to and outputs from the universal hash function
+    type BlockSize: ArrayLength<u8>;
 
     /// Instantiate a universal hash function with the given key
     fn new(key: &GenericArray<u8, Self::KeySize>) -> Self;
 
     /// Input a block into the universal hash function
-    fn update_block(&mut self, block: &GenericArray<u8, Self::OutputSize>);
+    fn update_block(&mut self, block: &GenericArray<u8, Self::BlockSize>);
 
     /// Input data into the universal hash function. If the length of the
     /// data is not a multiple of the block size, the remaining data is
@@ -47,7 +47,7 @@ pub trait UniversalHash: Clone {
     /// This approach is frequently used by AEAD modes which use
     /// Message Authentication Codes (MACs) based on universal hashing.
     fn update_padded(&mut self, data: &[u8]) {
-        let mut chunks = data.chunks_exact(Self::OutputSize::to_usize());
+        let mut chunks = data.chunks_exact(Self::BlockSize::to_usize());
 
         for chunk in &mut chunks {
             self.update_block(GenericArray::from_slice(chunk));
@@ -66,11 +66,11 @@ pub trait UniversalHash: Clone {
     fn reset(&mut self);
 
     /// Obtain the [`Output`] of a `UniversalHash` function and consume it.
-    fn result(self) -> Output<Self::OutputSize>;
+    fn result(self) -> Output<Self::BlockSize>;
 
     /// Obtain the [`Output`] of a `UniversalHash` computation and reset it back
     /// to its initial state.
-    fn result_reset(&mut self) -> Output<Self::OutputSize> {
+    fn result_reset(&mut self) -> Output<Self::BlockSize> {
         let res = self.clone().result();
         self.reset();
         res
@@ -79,7 +79,7 @@ pub trait UniversalHash: Clone {
     /// Verify the `UniversalHash` of the processed input matches a given [`Output`].
     /// This is useful when constructing Message Authentication Codes (MACs)
     /// from universal hash functions.
-    fn verify(self, other: &GenericArray<u8, Self::OutputSize>) -> Result<(), Error> {
+    fn verify(self, other: &GenericArray<u8, Self::BlockSize>) -> Result<(), Error> {
         if self.result() == other.into() {
             Ok(())
         } else {


### PR DESCRIPTION
In #55 I split the `UniversalHash::BlockSize` associated type into:

- [`UniversalHash::KeySize`](https://docs.rs/universal-hash/0.2.0/universal_hash/trait.UniversalHash.html#associatedtype.KeySize)
- [`UniversalHash::OutputSize`](https://docs.rs/universal-hash/0.2.0/universal_hash/trait.UniversalHash.html#associatedtype.OutputSize)

However, "OutputSize" is also used as the size of inputs by the `update_block` method:

https://docs.rs/universal-hash/0.2.0/universal_hash/trait.UniversalHash.html#tymethod.update_block

```rust
fn update_block(&mut self, block: &GenericArray<u8, Self::OutputSize>)
```

Since it's used for both inputs and outputs, I think `BlockSize` probably makes more sense (there and back again).

Obviously a semver breaking change.