### PR TITLE
aead: Add detached in-place encrypt/decrypt API; make alloc optional

### DIFF
--- a/aead/Cargo.toml
+++ b/aead/Cargo.toml
@@ -12,3 +12,7 @@ categories = ["cryptography", "no-std"]
 
 [dependencies]
 generic-array = { version = "0.12", default-features = false }
+
+[features]
+default = ["alloc"]
+alloc = []


### PR DESCRIPTION
This commit adds `encrypt_in_place_detached()` and `decrypt_in_place_detached()` methods to `Aead` and `AeadMut`, along with default implementations of `encrypt()` and `decrypt()` which assume a postfix authentication tag.

Presently all of the AEAD implementations in `RustCrypto/AEADs` use this pattern. This PR exposes the detached interface as a public API:

https://github.com/RustCrypto/AEADs/pull/21

Note that this need not be the only in-place API (hence the long name with `_detached` on the end. I plan on doing a follow-up PR for adding an in-place API which does not depend on `alloc` but also handles ciphertext message assembly/parsing, which would be more useful for end
users.

That said, this API isn't just useful for AEAD implementers: there are genuine use cases for a detached API from an end user perspective, e.g encrypted filesystems.

With the addition of this API, we can also make `alloc` an optional (but
enabled-by-default) feature, allowing use of AEADs on truly `#![no_std]`
targets.