### PR TITLE
aead: Add in-place API based on `Buffer` trait

### DIFF
--- a/aead/Cargo.toml
+++ b/aead/Cargo.toml
@@ -7,12 +7,16 @@ license = "MIT OR Apache-2.0"
 description = "Traits for Authenticated Encryption with Associated Data (AEAD) algorithms"
 documentation = "https://docs.rs/aead"
 repository = "https://github.com/RustCrypto/traits"
-keywords = ["digest", "crypto", "encryption"]
+keywords = ["crypto", "encryption"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
 generic-array = { version = "0.12", default-features = false }
+heapless = { version = "0.5", optional = true }
 
 [features]
 default = ["alloc"]
 alloc = []
+
+[package.metadata.docs.rs]
+all-features = true


### PR DESCRIPTION
NOTE: This PR includes the commit which adds the detached API from #58. It might make sense to review that first.

This PR adds a `Buffer` trait for `Vec`-like types which impl `AsRef<[u8]>`, `AsMut<[u8]>`, `extend_from_slice()`, and `truncate()`, and optionally impls it for `Vec<u8>` (when the `alloc` feature is enabled), along with the option to use `heapless::Vec` (when the `heapless` feature is enabled), providing a true `#![no_std]`-friendly option.

Uses `impl Buffer` as the argument for `encrypt_in_place` and `decrypt_in_place`, with default implementations that assume a postfix authentication tag. This allows these methods to handle ciphertext assembly and parsing, after which they can invoke the `_detached` APIs.