### PR TITLE
aead: Add optional `std` feature

### DIFF
--- a/aead/Cargo.toml
+++ b/aead/Cargo.toml
@@ -17,6 +17,7 @@ heapless = { version = "0.5", optional = true }
 [features]
 default = ["alloc"]
 alloc = []
+std = ["alloc"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/aead/src/lib.rs
+++ b/aead/src/lib.rs
@@ -17,16 +17,29 @@
 #[cfg(feature = "alloc")]
 extern crate alloc;
 
+#[cfg(feature = "std")]
+extern crate std;
+
 pub use generic_array;
 #[cfg(feature = "heapless")]
 pub use heapless;
 
 #[cfg(feature = "alloc")]
 use alloc::vec::Vec;
+use core::fmt;
 use generic_array::{typenum::Unsigned, ArrayLength, GenericArray};
 
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct Error;
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str("aead::Error")
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for Error {}
 
 /// Implement the `decrypt_in_place` method on `Aead` and `AeadMut`.
 /// Uses a macro to gloss over `&self` vs `&mut self`.


### PR DESCRIPTION
...with `std::error::Error` impl for `aead::Error`.

This is the least-common-bound for `std` users using a type erasure strategy for error handling, so it's helpful for error types to impl this trait when users want that.