### PR TITLE
chore: no-change generic-array 0.12 -> 0.13

### DIFF
--- a/aead/Cargo.toml
+++ b/aead/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["crypto", "encryption"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-generic-array = { version = "0.12", default-features = false }
+generic-array = { version = "0.13", default-features = false }
 heapless = { version = "0.5", optional = true }
 
 [features]

--- a/block-cipher-trait/Cargo.toml
+++ b/block-cipher-trait/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["crypto", "block-cipher", "trait"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-generic-array = "0.12"
+generic-array = "0.13"
 blobby = { version = "0.1", optional = true }
 
 [features]

--- a/crypto-mac/Cargo.toml
+++ b/crypto-mac/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["crypto", "mac"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-generic-array = "0.12"
+generic-array = "0.13"
 subtle = { version = "2", default-features = false }
 blobby = { version = "0.1", optional = true }
 

--- a/digest/Cargo.toml
+++ b/digest/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["digest", "crypto", "hash"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-generic-array = "0.12"
+generic-array = "0.13"
 blobby = { version = "0.1", optional = true }
 
 [features]

--- a/stream-cipher/Cargo.toml
+++ b/stream-cipher/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["crypto", "stream-cipher", "trait"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-generic-array = "0.12"
+generic-array = "0.13"
 blobby = { version = "0.1", optional = true }
 
 [features]

--- a/universal-hash/Cargo.toml
+++ b/universal-hash/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["cryptography", "no-std"]
 edition = "2018"
 
 [dependencies]
-generic-array = "0.12"
+generic-array = "0.13"
 subtle = { version = "2", default-features = false }
 
 [features]


### PR DESCRIPTION
> One of my projects has a bunch of duplicate versions of generic-array, through block-buffer (from sha-2), crypto-mac (through hmac) and digest (through hmac and sha2) -- all of them through usage in postgres-protocol. Here's a start at fixing this up.

I'm using chacha20poly1305 and sha2 directly and end up with *six* dependencies on the old generic-array.

c.f. https://github.com/RustCrypto/utils/pull/39