### PR TITLE
Remove deprecated std::error::Error::description() and bump MSRV from 1.21 to 1.31

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ sudo: required
 
 matrix:
   include:
-    - rust: 1.21.0
+    - rust: 1.31.0
       script: cargo test --verbose --all --exclude aead --exclude universal-hash --release
     - rust: 1.36.0
       script: cargo test --verbose --package aead --package universal-hash --release
@@ -13,7 +13,7 @@ matrix:
     - rust: nightly
       script: cargo test --verbose --all --release
     # tests if crates can be built with std feature
-    - rust: 1.21.0
+    - rust: 1.31.0
       script: ./build_std.sh
 
     - env: TARGET=i686-unknown-linux-gnu

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Collection of traits which describe functionality of cryptographic primitives.
 | [`stream-cipher`](https://en.wikipedia.org/wiki/Stream_cipher) | [![crates.io](https://img.shields.io/crates/v/stream-cipher.svg)](https://crates.io/crates/stream-cipher) | [![Documentation](https://docs.rs/stream-cipher/badge.svg)](https://docs.rs/stream-cipher) |
 
 ### Minimum Rust version
-All crates in this repository support Rust 1.21 or higher. In future minimally
+All crates in this repository support Rust 1.31 or higher. In future minimally
 supported version of Rust can be changed, but it will be done with the minor
 version bump.
 

--- a/crypto-mac/src/errors.rs
+++ b/crypto-mac/src/errors.rs
@@ -23,15 +23,7 @@ impl fmt::Display for InvalidKeyLength {
 }
 
 #[cfg(feature = "std")]
-impl error::Error for MacError {
-    fn description(&self) -> &str {
-        "failed MAC verification"
-    }
-}
+impl error::Error for MacError {}
 
 #[cfg(feature = "std")]
-impl error::Error for InvalidKeyLength {
-    fn description(&self) -> &str {
-        "invalid key length"
-    }
-}
+impl error::Error for InvalidKeyLength {}


### PR DESCRIPTION
It’s been deprecated since Rust 1.41, and we already have a Display implementation anyway.