### PR TITLE
signature: design documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Collection of traits which describe functionality of cryptographic primitives.
 ## Crates
 | Name    | Crates.io  | Documentation  |
 | ------- | :---------:| :-------------:|
-| [`aead`](hhttps://en.wikipedia.org/wiki/Authenticated_encryption)| [![crates.io](https://img.shields.io/crates/v/aead.svg)](https://crates.io/crates/aead) | [![Documentation](https://docs.rs/aead/badge.svg)](https://docs.rs/aead) |
+| [`aead`](https://en.wikipedia.org/wiki/Authenticated_encryption)| [![crates.io](https://img.shields.io/crates/v/aead.svg)](https://crates.io/crates/aead) | [![Documentation](https://docs.rs/aead/badge.svg)](https://docs.rs/aead) |
 | [`block-cipher-trait`](https://en.wikipedia.org/wiki/Block_cipher)| [![crates.io](https://img.shields.io/crates/v/block-cipher-trait.svg)](https://crates.io/crates/block-cipher-trait) | [![Documentation](https://docs.rs/block-cipher-trait/badge.svg)](https://docs.rs/block-cipher-trait) |
 | [`crypto-mac`](https://en.wikipedia.org/wiki/Message_authentication_code) | [![crates.io](https://img.shields.io/crates/v/crypto-mac.svg)](https://crates.io/crates/crypto-mac) | [![Documentation](https://docs.rs/crypto-mac/badge.svg)](https://docs.rs/crypto-mac) |
 | [`digest`](https://en.wikipedia.org/wiki/Cryptographic_hash_function) | [![crates.io](https://img.shields.io/crates/v/digest.svg)](https://crates.io/crates/digest) | [![Documentation](https://docs.rs/digest/badge.svg)](https://docs.rs/digest) |

--- a/signature/README.md
+++ b/signature/README.md
@@ -1,4 +1,4 @@
-# `signature` crate
+# RustCrypto: `signature` crate
 
 [![crate][crate-image]][crate-link]
 [![Docs][docs-image]][docs-link]

--- a/signature/src/error.rs
+++ b/signature/src/error.rs
@@ -31,6 +31,7 @@ impl Error {
     /// cases are for propagating errors related to external signers, e.g.
     /// communication/authentication errors with HSMs, KMS, etc.
     #[cfg(feature = "std")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     pub fn from_source(source: impl Into<BoxError>) -> Self {
         Self {
             source: Some(source.into()),

--- a/signature/src/signature.rs
+++ b/signature/src/signature.rs
@@ -3,6 +3,14 @@
 use crate::error::Error;
 use core::fmt::Debug;
 
+/// For intra-doc link resolution
+#[cfg(feature = "digest-preview")]
+#[allow(unused_imports)]
+use crate::{
+    signer::{DigestSigner, Signer},
+    verifier::{DigestVerifier, Verifier},
+};
+
 /// Trait impl'd by concrete types that represent digital signatures
 pub trait Signature: AsRef<[u8]> + Debug + Sized {
     /// Parse a signature from its byte representation
@@ -20,11 +28,16 @@ pub trait Signature: AsRef<[u8]> + Debug + Sized {
 /// - `H`: hash (a.k.a. digest) function
 /// - `m`: message
 ///
+/// i.e. a traditional application of the [Fiat-Shamir heuristic].
+///
 /// For signature types that implement this trait, when the `derive-preview`
-/// Cargo feature is enabled a custom derive for `Signer` is available for any
-/// types that impl `DigestSigner`, and likewise for deriving `Verifier` for
-/// types which impl `DigestVerifier`.
-#[cfg(feature = "digest")]
+/// Cargo feature is enabled a custom derive for [`Signer`] is available for any
+/// types that impl [`DigestSigner`], and likewise for deriving [`Verifier`] for
+/// types which impl [`DigestVerifier`].
+///
+/// [Fiat-Shamir heuristic]: https://en.wikipedia.org/wiki/Fiat%E2%80%93Shamir_heuristic
+#[cfg(feature = "digest-preview")]
+#[cfg_attr(docsrs, doc(cfg(feature = "digest-preview")))]
 pub trait DigestSignature: Signature {
     /// Preferred `Digest` algorithm to use when computing this signature type.
     type Digest: digest::Digest;

--- a/signature/src/signer.rs
+++ b/signature/src/signer.rs
@@ -22,9 +22,25 @@ pub trait Signer<S: Signature> {
 
 /// Sign the given prehashed message `Digest` using `Self`.
 ///
-/// This trait is only available when the `digest-preview` cargo feature is
-/// enabled.
+/// ## Notes
+///
+/// This trait is primarily intended for signature algorithms based on the
+/// [Fiat-Shamir heuristic], a method for converting an interactive
+/// challenge/response-based proof-of-knowledge protocol into an offline
+/// digital signature through the use of a random oracle, i.e. a digest
+/// function.
+///
+/// The security of such protocols critically rests upon the inability of
+/// an attacker to solve for the output of the random oracle, as generally
+/// otherwise such signature algorithms are a system of linear equations and
+/// therefore doing so would allow the attacker to trivially forge signatures.
+///
+/// To prevent misuse which would potentially allow this to be possible, this
+/// API accepts a [`Digest`] instance, rather than a raw digest value.
+///
+/// [Fiat-Shamir heuristic]: https://en.wikipedia.org/wiki/Fiat%E2%80%93Shamir_heuristic
 #[cfg(feature = "digest-preview")]
+#[cfg_attr(docsrs, doc(cfg(feature = "digest-preview")))]
 pub trait DigestSigner<D, S>
 where
     D: Digest,

--- a/signature/src/verifier.rs
+++ b/signature/src/verifier.rs
@@ -16,15 +16,25 @@ pub trait Verifier<S: Signature> {
 /// Verify the provided signature for the given prehashed message `Digest`
 /// is authentic.
 ///
-/// This trait is only available when the `digest-preview` cargo feature is
-/// enabled.
+/// ## Notes
 ///
-/// It accepts a [`Digest`] instance, as opposed to a raw digest byte array,
-/// as the security of signature algorithms built on hash functions often
-/// depends critically on the input being a random oracle as opposed to a
-/// value an attacker can choose and solve for. This is enforced at the API
-/// level by taking a [`Digest`] instance in order to better resist misuse.
+/// This trait is primarily intended for signature algorithms based on the
+/// [Fiat-Shamir heuristic], a method for converting an interactive
+/// challenge/response-based proof-of-knowledge protocol into an offline
+/// digital signature through the use of a random oracle, i.e. a digest
+/// function.
+///
+/// The security of such protocols critically rests upon the inability of
+/// an attacker to solve for the output of the random oracle, as generally
+/// otherwise such signature algorithms are a system of linear equations and
+/// therefore doing so would allow the attacker to trivially forge signatures.
+///
+/// To prevent misuse which would potentially allow this to be possible, this
+/// API accepts a [`Digest`] instance, rather than a raw digest value.
+///
+/// [Fiat-Shamir heuristic]: https://en.wikipedia.org/wiki/Fiat%E2%80%93Shamir_heuristic
 #[cfg(feature = "digest-preview")]
+#[cfg_attr(docsrs, doc(cfg(feature = "digest-preview")))]
 pub trait DigestVerifier<D, S>
 where
     D: Digest,


### PR DESCRIPTION
This commit adds high-level descriptions of how the `signature` crate is designed, including alternatives considered, and hopefully details why it is the way it is.

These notes also include a rough sketch of potential additional future traits which could better optimize for implementers of signature traits, rather than consumers (with a blanket impl to link the two).