### PR TITLE
signature: add RandomizedSigner trait

### DIFF
--- a/signature/Cargo.toml
+++ b/signature/Cargo.toml
@@ -16,6 +16,11 @@ version = "0.8"
 optional = true
 default-features = false
 
+[dependencies.rand_core]
+version = "0.5"
+optional = true
+default-features = false
+
 [dependencies.signature_derive]
 version = "1.0.0-pre.0"
 optional = true
@@ -29,6 +34,7 @@ sha2 = { version = "0.8", default-features = false }
 default = ["std"]
 derive-preview = ["digest-preview", "signature_derive"]
 digest-preview = ["digest"]
+rand-preview = ["rand_core"]
 std = []
 
 [package.metadata.docs.rs]

--- a/signature/src/lib.rs
+++ b/signature/src/lib.rs
@@ -52,7 +52,7 @@
 //!
 //! [BB'06]: https://en.wikipedia.org/wiki/Daniel_Bleichenbacher
 //!
-//! # Implementation
+//! ## Implementation
 //!
 //! To accomplish the above goals, the [`Signer`] and [`Verifier`] traits
 //! provided by this are generic over a [`Signature`] return value, and use
@@ -70,7 +70,7 @@
 //! similar simplicity by minimizing the number of steps involved to obtain
 //! a serializable signature.
 //!
-//! # Alternatives considered
+//! ## Alternatives considered
 //!
 //! This crate is based on over two years of exploration of how to encapsulate
 //! digital signature systems in the most flexible, developer-friendly way.
@@ -118,7 +118,30 @@
 //!   for these types (particularly things like `From` or `Borrow` bounds).
 //!   This may be more interesting to explore after const generics.
 //!
+//! ## Unstable features
 //!
+//! Despite being post-1.0, this crate includes a number of off-by-default
+//! unstable features named `*-preview`, each of which depends on a pre-1.0
+//! crate. These features are as follows:
+//!
+//! - `derive-preview`: for implementers of signature systems using
+//!   [`DigestSigner`] and [`DigestVerifier`], the `derive-preview` feature
+//!   can be used to derive [`Signer`] and [`Verifier`] traits which prehash
+//!   the input message using the [`DigestSignature::Digest`] function for
+//!   a given [`Signature`] type. When the `derive-preview` feature is enabled
+//!   import the proc macros with `use signature::{Signer, Verifier}` and then
+//!   add a `derive(Signer)` or `derive(Verifier)` attribute to the given
+//!   digest signer/verifier type.
+//! - `digest-preview`: enables the [`DigestSigner`] and [`DigestVerifier`]
+//!   traits which are based on the `Digest` trait from the `digest` crate.
+//!   These traits are used for representing signature systems based on the
+//!   [Fiat-Shamir heuristic] which compute a random challenge value to sign
+//!   by computing a cryptographically secure digest of the input message.
+//! - `rand-preview`: enables the [`RandomizedSigner`] trait for signature
+//!   systems which rely on a cryptographically secure random number generator
+//!   for security.
+//!
+//! [Fiat-Shamir heuristic]: https://en.wikipedia.org/wiki/Fiat%E2%80%93Shamir_heuristic
 
 #![no_std]
 #![doc(
@@ -143,11 +166,13 @@ extern crate std;
 extern crate signature_derive;
 
 #[cfg(feature = "derive-preview")]
-#[doc(hidden)]
 pub use signature_derive::{Signer, Verifier};
 
 #[cfg(feature = "digest-preview")]
 pub use digest;
+
+#[cfg(feature = "rand-preview")]
+pub use rand_core;
 
 mod error;
 mod signature;

--- a/signature/src/verifier.rs
+++ b/signature/src/verifier.rs
@@ -1,8 +1,9 @@
 //! Trait for verifying digital signatures
 
+use crate::{error::Error, Signature};
+
 #[cfg(feature = "digest-preview")]
 use crate::digest::Digest;
-use crate::{error::Error, Signature};
 
 /// Verify the provided message bytestring using `Self` (e.g. a public key)
 pub trait Verifier<S: Signature> {


### PR DESCRIPTION
Adds a trait which allows passing a `rand_core::CryptoRng` to the signing operation, which is useful for signature algorithms which rely on a source of randomness, e.g. RSASSA-PSS and traditional ECDSA (with a random `k` value)

Presently gated under the `rand-preview` feature (since `rand_core` is presently pre-1.0).