### PR TITLE
signature: Error cleanups

### DIFF
--- a/signature/src/error.rs
+++ b/signature/src/error.rs
@@ -41,16 +41,14 @@ impl Error {
 
 impl Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "signature error")?;
+        f.write_str("signature error")
+    }
+}
 
-        #[cfg(feature = "std")]
-        {
-            if let Some(ref source) = self.source {
-                write!(f, ": {}", source)?;
-            }
-        }
-
-        Ok(())
+#[cfg(feature = "std")]
+impl From<BoxError> for Error {
+    fn from(source: BoxError) -> Error {
+        Self::from_source(source)
     }
 }
 

--- a/signature/src/lib.rs
+++ b/signature/src/lib.rs
@@ -131,7 +131,8 @@
 //!   a given [`Signature`] type. When the `derive-preview` feature is enabled
 //!   import the proc macros with `use signature::{Signer, Verifier}` and then
 //!   add a `derive(Signer)` or `derive(Verifier)` attribute to the given
-//!   digest signer/verifier type.
+//!   digest signer/verifier type. Enabling this feature also enables `digest`
+//!   support (see immediately below).
 //! - `digest-preview`: enables the [`DigestSigner`] and [`DigestVerifier`]
 //!   traits which are based on the `Digest` trait from the `digest` crate.
 //!   These traits are used for representing signature systems based on the
@@ -157,7 +158,6 @@
 )]
 
 #[cfg(feature = "std")]
-#[macro_use]
 extern crate std;
 
 #[cfg(feature = "derive-preview")]


### PR DESCRIPTION
- Don't print `Error::source` in the `Display` impl for `Error`   as this information is available as `Error::source`'s `Display`
- Adds a `From` impl for creating an `Error` from a `BoxError`.