### PR TITLE
signature 1.0.0-pre.2

### DIFF
--- a/signature/CHANGES.md
+++ b/signature/CHANGES.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.0.0-pre.2 (2020-03-08)
+### Added
+- `RandomizedSigner` trait ([#73])
+- Design documentation ([#72])
+
+### Changed
+- Error cleanups ([#74])
+- Crate moved to `RustCrypto/traits` ([#71])
+
+[#74]: https://github.com/RustCrypto/traits/pull/74
+[#73]: https://github.com/RustCrypto/traits/pull/73
+[#72]: https://github.com/RustCrypto/traits/pull/72
+[#71]: https://github.com/RustCrypto/traits/pull/71
+
 ## 1.0.0-pre.1 (2019-10-27)
 ### Changed
 - Use `Error::source` instead of `::cause` ([RustCrypto/signatures#37])

--- a/signature/Cargo.toml
+++ b/signature/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name          = "signature"
 description   = "Traits for cryptographic signature algorithms (e.g. ECDSA, Ed25519)"
-version       = "1.0.0-pre.1" # Also update html_root_url in lib.rs when bumping this
+version       = "1.0.0-pre.2" # Also update html_root_url in lib.rs when bumping this
 authors       = ["RustCrypto Developers"]
 license       = "Apache-2.0 OR MIT"
 documentation = "https://docs.rs/signature"

--- a/signature/src/lib.rs
+++ b/signature/src/lib.rs
@@ -147,7 +147,7 @@
 #![no_std]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png",
-    html_root_url = "https://docs.rs/signature/1.0.0-pre.1"
+    html_root_url = "https://docs.rs/signature/1.0.0-pre.2"
 )]
 #![forbid(unsafe_code)]
 #![warn(


### PR DESCRIPTION
### Added
- `RandomizedSigner` trait ([#73])
- Design documentation ([#72])

### Changed
- Error cleanups ([#74])
- Crate moved to `RustCrypto/traits` ([#71])

[#74]: https://github.com/RustCrypto/traits/pull/74
[#73]: https://github.com/RustCrypto/traits/pull/73
[#72]: https://github.com/RustCrypto/traits/pull/72
[#71]: https://github.com/RustCrypto/traits/pull/71