### PR TITLE
Mark preview feature as unstable in Cargo.toml

### DIFF
--- a/signature/Cargo.toml
+++ b/signature/Cargo.toml
@@ -32,10 +32,13 @@ sha2 = { version = "0.8", default-features = false }
 
 [features]
 default = ["std"]
+std = []
+
+# Preview features are unstable and exempt from semver.
+# See https://docs.rs/signature/latest/signature/#unstable-features for more information.
 derive-preview = ["digest-preview", "signature_derive"]
 digest-preview = ["digest"]
 rand-preview = ["rand_core"]
-std = []
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
I (and I'm sure a few others) often look at the Cargo.toml to find out what a crate's features are. It might be a good idea to explicitly point out there that the preview features are unstable.