### PR TITLE
signature: have Signature::from_bytes take a byte slice

### DIFF
--- a/signature/src/signature.rs
+++ b/signature/src/signature.rs
@@ -14,7 +14,7 @@ use crate::{
 /// Trait impl'd by concrete types that represent digital signatures
 pub trait Signature: AsRef<[u8]> + Debug + Sized {
     /// Parse a signature from its byte representation
-    fn from_bytes(bytes: impl AsRef<[u8]>) -> Result<Self, Error>;
+    fn from_bytes(bytes: &[u8]) -> Result<Self, Error>;
 
     /// Borrow this signature as serialized bytes
     fn as_slice(&self) -> &[u8] {


### PR DESCRIPTION
...rather than `impl AsRef<[u8]>`, which both breaks object safety, and in many cases is less convenient (e.g. when deref coercion would allow types that don't `impl AsRef` to work)