### PR TITLE
signature 1.0.0-pre.4

### DIFF
--- a/signature/CHANGES.md
+++ b/signature/CHANGES.md
@@ -4,6 +4,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.0.0-pre.4 (2020-03-15)
+### Added
+- Mark preview features as unstable in `Cargo.toml` ([#82])
+
+### Changed
+- Have `Signature::from_bytes` take a byte slice ([#84])
+- Ensure `Error::new()` is mandatory ([#83])
+
+### Removed
+- `BoxError` type alias ([#81])
+
+[#84]: https://github.com/RustCrypto/traits/pull/84
+[#83]: https://github.com/RustCrypto/traits/pull/83
+[#82]: https://github.com/RustCrypto/traits/pull/82
+[#81]: https://github.com/RustCrypto/traits/pull/81
+
 ## 1.0.0-pre.3 (2020-03-08)
 ### Fixed
 - docs.rs rendering ([#76])

--- a/signature/Cargo.toml
+++ b/signature/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name          = "signature"
 description   = "Traits for cryptographic signature algorithms (e.g. ECDSA, Ed25519)"
-version       = "1.0.0-pre.3" # Also update html_root_url in lib.rs when bumping this
+version       = "1.0.0-pre.4" # Also update html_root_url in lib.rs when bumping this
 authors       = ["RustCrypto Developers"]
 license       = "Apache-2.0 OR MIT"
 documentation = "https://docs.rs/signature"


### PR DESCRIPTION
### Added
- Mark preview features as unstable in `Cargo.toml` ([#82])

### Changed
- Have `Signature::from_bytes` take a byte slice ([#84])
- Ensure `Error::new()` is mandatory ([#83])

### Removed
- `BoxError` type alias ([#81])

[#84]: https://github.com/RustCrypto/traits/pull/84
[#83]: https://github.com/RustCrypto/traits/pull/83
[#82]: https://github.com/RustCrypto/traits/pull/82
[#81]: https://github.com/RustCrypto/traits/pull/81