### PR TITLE
Uprev generic array to version 0.14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,16 +4,16 @@ sudo: required
 
 matrix:
   include:
-    - rust: 1.31.0
+    - rust: 1.41.0
       script: cargo test --verbose --all --exclude aead --exclude signature --exclude universal-hash --release
-    - rust: 1.36.0
+    - rust: 1.43.0
       script: cargo test --verbose --package aead --package signature --package universal-hash --release
     - rust: stable
       script: cargo test --verbose --all --release
     - rust: nightly
       script: cargo test --verbose --all --release
     # tests if crates can be built with std feature
-    - rust: 1.31.0
+    - rust: 1.41.0
       script: ./build_std.sh
 
     - env: TARGET=i686-unknown-linux-gnu

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Collection of traits which describe functionality of cryptographic primitives.
 | [`stream-cipher`](https://en.wikipedia.org/wiki/Stream_cipher) | [![crates.io](https://img.shields.io/crates/v/stream-cipher.svg)](https://crates.io/crates/stream-cipher) | [![Documentation](https://docs.rs/stream-cipher/badge.svg)](https://docs.rs/stream-cipher) |
 
 ### Minimum Rust version
-All crates in this repository support Rust 1.31 or higher unless otherwise noted.
+All crates in this repository support Rust 1.41 or higher unless otherwise noted.
 
 In future minimally supported version of Rust can be changed, but it will be done
 with the minor version bump.

--- a/aead/Cargo.toml
+++ b/aead/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["crypto", "encryption"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-generic-array = { version = "0.13", default-features = false }
+generic-array = { version = "0.14", default-features = false }
 heapless = { version = "0.5", optional = true }
 
 [features]

--- a/block-cipher-trait/Cargo.toml
+++ b/block-cipher-trait/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["crypto", "block-cipher", "trait"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-generic-array = "0.13"
+generic-array = "0.14"
 blobby = { version = "0.1", optional = true }
 
 [features]

--- a/digest/Cargo.toml
+++ b/digest/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["digest", "crypto", "hash"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-generic-array = "0.13"
+generic-array = "0.14"
 blobby = { version = "0.1", optional = true }
 
 [features]

--- a/stream-cipher/Cargo.toml
+++ b/stream-cipher/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["crypto", "stream-cipher", "trait"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-generic-array = "0.13"
+generic-array = "0.14"
 blobby = { version = "0.1", optional = true }
 
 [features]

--- a/universal-hash/Cargo.toml
+++ b/universal-hash/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["cryptography", "no-std"]
 edition = "2018"
 
 [dependencies]
-generic-array = "0.13"
+generic-array = "0.14"
 subtle = { version = "2", default-features = false }
 
 [features]


### PR DESCRIPTION
In 0.14 they added a pretty nice feature, which is that you can
now split not just arrays that you hold by value, but you can
split references to generic arrays, into a pair of references to
generic arrays corresponding to the subslices, where the size
calculations are done correctly at compile-time and the buffer
size information is all preserved.

https://docs.rs/generic-array/0.14.1/src/generic_array/sequence.rs.html#302-320

I have some ECIES code that looks like this, that builds on `aead` trait:

```
    fn decrypt_in_place_detached(
        &self,
        key: &RistrettoPrivate,
        footer: &GenericArray<u8, Self::FooterSize>,
        buffer: &mut [u8],
    ) -> Result<(), Error> {
        let (footer, version_data): (_, &GenericArray<u8, U2>) = footer.split();
```

Alternate version is like

```
    fn decrypt_in_place_detached(
        &self,
        key: &RistrettoPrivate,
        footer: &GenericArray<u8, Self::FooterSize>,
        buffer: &mut [u8],
    ) -> Result<(), Error> {
        let (footer, version_data) = Split::<u8, U48>::split(footer);
```

I think these are both expected to work generic array 0.14. There
are alternatives of course but they are less tidy :)

Since I'm getting the generic array pub export from you, I think
that to use this, I have to convince you that it's worth it to uprev.
LMK what you think! Thanks