### PR TITLE
signature: rename DigestSignature => PrehashSignature

### DIFF
--- a/signature/signature_derive/src/lib.rs
+++ b/signature/signature_derive/src/lib.rs
@@ -20,7 +20,7 @@ fn derive_signer(mut s: synstructure::Structure) -> TokenStream {
     s.gen_impl(quote! {
         gen impl<S> signature::Signer<S> for @Self
         where
-            S: signature::DigestSignature,
+            S: signature::PrehashSignature,
             Self: signature::DigestSigner<S::Digest, S>
         {
             fn try_sign(&self, msg: &[u8]) -> Result<S, signature::Error> {
@@ -35,10 +35,10 @@ decl_derive! {
     /// Derive the [`Signer`] trait for a type which impls [`DigestSigner`].
     ///
     /// When implementing the [`DigestSigner`] trait for a signature type which
-    /// itself impl's the [`DigestSignature`] trait (which marks signature
+    /// itself impl's the [`PrehashSignature`] trait (which marks signature
     /// algorithms which are computed using a [`Digest`]), signature providers
     /// can automatically derive the [`Signer`] trait when the digest algorithm
-    /// is [`DigestSignature::Digest`] (i.e. the "standard" digest algorithm
+    /// is [`PrehashSignature::Digest`] (i.e. the "standard" digest algorithm
     /// for a given signature type)
     ///
     /// This automates all of the digest computation otherwise needed for a
@@ -54,7 +54,7 @@ fn derive_verifier(mut s: synstructure::Structure) -> TokenStream {
     s.gen_impl(quote! {
         gen impl<S> signature::Verifier<S> for @Self
         where
-            S: signature::DigestSignature,
+            S: signature::PrehashSignature,
             Self: signature::DigestVerifier<S::Digest, S>
         {
             fn verify(&self, msg: &[u8], signature: &S) -> Result<(), signature::Error> {
@@ -69,10 +69,10 @@ decl_derive! {
     /// Derive the [`Verifier`] trait for a type which impls [`DigestVerifier`].
     ///
     /// When implementing the [`DigestVerifier`] trait for a signature type which
-    /// itself impl's the [`DigestSignature`] trait (which marks signature
+    /// itself impl's the [`PrehashSignature`] trait (which marks signature
     /// algorithms which are computed using a [`Digest`]), signature providers
     /// can automatically derive the [`Verifier`] trait when the digest algorithm
-    /// is [`DigestSignature::Digest`] (i.e. the "standard" digest algorithm
+    /// is [`PrehashSignature::Digest`] (i.e. the "standard" digest algorithm
     /// for a given signature type)
     ///
     /// This automates all of the digest computation otherwise needed for a
@@ -100,7 +100,7 @@ mod tests {
                 const _DERIVE_signature_Signer_S_FOR_MySigner: () = {
                     impl<S, C: EllipticCurve> signature::Signer<S> for MySigner<C>
                     where
-                        S: signature::DigestSignature,
+                        S: signature::PrehashSignature,
                         Self: signature::DigestSigner<S::Digest, S>
                     {
                         fn try_sign(&self, msg: &[u8]) -> Result <S, signature::Error> {
@@ -126,7 +126,7 @@ mod tests {
                 const _DERIVE_signature_Verifier_S_FOR_MyVerifier: () = {
                     impl<S, C: EllipticCurve> signature::Verifier<S> for MyVerifier<C>
                     where
-                        S: signature::DigestSignature,
+                        S: signature::PrehashSignature,
                         Self: signature::DigestVerifier<S::Digest, S>
                     {
                         fn verify(&self, msg: &[u8], signature: &S) -> Result<(), signature::Error> {

--- a/signature/src/lib.rs
+++ b/signature/src/lib.rs
@@ -46,7 +46,7 @@
 //! - Keep signature algorithm customizations / "knobs" out-of-band from the
 //!   signing/verification APIs, ideally pushing such concerns into the type
 //!   system so that algorithm mismatches are caught as type errors.
-//! - Opaque error type which minimizes information leaked from crxyptographic
+//! - Opaque error type which minimizes information leaked from cryptographic
 //!   failures, as "rich" error types in these scenarios are often a source
 //!   of sidechannel information for attackers (e.g. [BB'06])
 //!
@@ -132,7 +132,7 @@
 //! - `derive-preview`: for implementers of signature systems using
 //!   [`DigestSigner`] and [`DigestVerifier`], the `derive-preview` feature
 //!   can be used to derive [`Signer`] and [`Verifier`] traits which prehash
-//!   the input message using the [`DigestSignature::Digest`] function for
+//!   the input message using the [`PrehashSignature::Digest`] algorithm for
 //!   a given [`Signature`] type. When the `derive-preview` feature is enabled
 //!   import the proc macros with `use signature::{Signer, Verifier}` and then
 //!   add a `derive(Signer)` or `derive(Verifier)` attribute to the given

--- a/signature/src/signature.rs
+++ b/signature/src/signature.rs
@@ -42,13 +42,15 @@ pub trait Signature: AsRef<[u8]> + Debug + Sized {
     }
 }
 
-/// Marker trait for `Signature` types computable as `S(H(m))`
+/// Marker trait for `Signature` types computable as `S(H(m))`, i.e. ones which
+/// prehash a message to be signed as `H(m)`:
 ///
 /// - `S`: signature algorithm
 /// - `H`: hash (a.k.a. digest) function
 /// - `m`: message
 ///
-/// i.e. a traditional application of the [Fiat-Shamir heuristic].
+/// This approach is relatively common in signature schemes based on the
+/// [Fiat-Shamir heuristic].
 ///
 /// For signature types that implement this trait, when the `derive-preview`
 /// Cargo feature is enabled a custom derive for [`Signer`] is available for any
@@ -58,7 +60,7 @@ pub trait Signature: AsRef<[u8]> + Debug + Sized {
 /// [Fiat-Shamir heuristic]: https://en.wikipedia.org/wiki/Fiat%E2%80%93Shamir_heuristic
 #[cfg(feature = "digest-preview")]
 #[cfg_attr(docsrs, doc(cfg(feature = "digest-preview")))]
-pub trait DigestSignature: Signature {
+pub trait PrehashSignature: Signature {
     /// Preferred `Digest` algorithm to use when computing this signature type.
     type Digest: digest::Digest;
 }

--- a/signature/tests/signature_derive.rs
+++ b/signature/tests/signature_derive.rs
@@ -5,7 +5,7 @@ mod tests {
     use hex_literal::hex;
     use sha2::Sha256;
     use signature::{
-        DigestSignature, DigestSigner, DigestVerifier, Error, Signature, Signer, Verifier,
+        DigestSigner, DigestVerifier, Error, PrehashSignature, Signature, Signer, Verifier,
     };
 
     /// Test vector to compute SHA-256 digest of
@@ -33,7 +33,7 @@ mod tests {
         }
     }
 
-    impl DigestSignature for DummySignature {
+    impl PrehashSignature for DummySignature {
         type Digest = Sha256;
     }
 


### PR DESCRIPTION
The previous name poorly described what these signature types are: ones capable of producing a signature of a message which was hashed in advance.

The phrase "pre-hash" is a relatively common one and better describes this property.