### PR TITLE
signature v1.0.0

### DIFF
--- a/signature/CHANGES.md
+++ b/signature/CHANGES.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.0.0 (2020-04-18)
+
+Initial 1.0 release! 🎉
+
+### Changed
+- Rename `DigestSignature` => `PrehashSignature` ([#96])
+
+[#96]: https://github.com/RustCrypto/traits/pull/96
+
 ## 1.0.0-pre.5 (2020-03-16)
 ### Changed
 - Improve `Debug` impl on `Error` ([#89])

--- a/signature/Cargo.toml
+++ b/signature/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name          = "signature"
 description   = "Traits for cryptographic signature algorithms (e.g. ECDSA, Ed25519)"
-version       = "1.0.0-pre.5" # Also update html_root_url in lib.rs when bumping this
+version       = "1.0.0" # Also update html_root_url in lib.rs when bumping this
 authors       = ["RustCrypto Developers"]
 license       = "Apache-2.0 OR MIT"
 documentation = "https://docs.rs/signature"

--- a/signature/src/lib.rs
+++ b/signature/src/lib.rs
@@ -1,7 +1,7 @@
 //! RustCrypto: `signature` crate.
 //!
 //! Traits which provide generic, object-safe APIs for generating and verifying
-//! digital signatures: message authentication using public-key cryptography.
+//! digital signatures, i.e. message authentication using public-key cryptography.
 //!
 //! ## Minimum Supported Rust Version
 //!
@@ -12,8 +12,8 @@
 //!
 //! ## SemVer policy
 //!
-//! - All on-by-default features of this library are covered by SemVer
 //! - MSRV is considered exempt from SemVer as noted above
+//! - All on-by-default features of this library are covered by SemVer
 //! - Off-by-default features ending in `*-preview` (e.g. `derive-preview`,
 //!   `digest-preview`) are unstable "preview" features which are also
 //!   considered exempt from SemVer (typically because they rely on pre-1.0
@@ -154,8 +154,8 @@
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc(
-    html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png",
-    html_root_url = "https://docs.rs/signature/1.0.0-pre.5"
+    html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/ferris_signer.png",
+    html_root_url = "https://docs.rs/signature/1.0.0"
 )]
 #![forbid(unsafe_code)]
 #![warn(


### PR DESCRIPTION
Initial 1.0 release! 🎉

### Changed (since [1.0.0-pre.5](https://github.com/RustCrypto/traits/blob/master/signature/CHANGES.md#100-pre5-2020-03-16))
- Rename `DigestSignature` => `PrehashSignature` ([#96])

[#96]: https://github.com/RustCrypto/traits/pull/96