### PR TITLE
signature_derive v1.0.0-pre.2

### DIFF
--- a/signature/Cargo.toml
+++ b/signature/Cargo.toml
@@ -22,7 +22,7 @@ optional = true
 default-features = false
 
 [dependencies.signature_derive]
-version = "= 1.0.0-pre.1"
+version = "= 1.0.0-pre.2"
 optional = true
 path = "signature_derive"
 

--- a/signature/signature_derive/CHANGES.md
+++ b/signature/signature_derive/CHANGES.md
@@ -4,8 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.0.0-pre.2 (2020-04-19)
+### Changed
+- Rename `DigestSignature` => `PrehashSignature` ([#96])
+
+[#96]: https://github.com/RustCrypto/traits/pull/96
+
 ## 1.0.0-pre.1 (2020-03-08)
-## Added
+### Added
 - Initial Changelog for `signature_derive`
 - Rustdoc ([#79])
 

--- a/signature/signature_derive/Cargo.toml
+++ b/signature/signature_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "signature_derive"
-version       = "1.0.0-pre.1"
+version       = "1.0.0-pre.2"
 authors       = ["RustCrypto Developers"]
 license       = "Apache-2.0 OR MIT"
 description   = "Custom derive support for the 'signature' crate"


### PR DESCRIPTION
### Changed
- Rename `DigestSignature` => `PrehashSignature` ([#96])

[#96]: https://github.com/RustCrypto/traits/pull/96