### PR TITLE
signature v1.0.1

### DIFF
--- a/signature/CHANGES.md
+++ b/signature/CHANGES.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.0.1 (2020-04-19)
+### Changed
+- Upgrade `signature_derive` to v1.0.0-pre.2 ([#98])
+
+[#98]: https://github.com/RustCrypto/traits/pull/98
+
 ## 1.0.0 (2020-04-18)
 
 Initial 1.0 release! 🎉

--- a/signature/Cargo.toml
+++ b/signature/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name          = "signature"
 description   = "Traits for cryptographic signature algorithms (e.g. ECDSA, Ed25519)"
-version       = "1.0.0" # Also update html_root_url in lib.rs when bumping this
+version       = "1.0.1" # Also update html_root_url in lib.rs when bumping this
 authors       = ["RustCrypto Developers"]
 license       = "Apache-2.0 OR MIT"
 documentation = "https://docs.rs/signature"

--- a/signature/src/lib.rs
+++ b/signature/src/lib.rs
@@ -155,7 +155,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/ferris_signer.png",
-    html_root_url = "https://docs.rs/signature/1.0.0"
+    html_root_url = "https://docs.rs/signature/1.0.1"
 )]
 #![forbid(unsafe_code)]
 #![warn(


### PR DESCRIPTION
### Changed
- Upgrade `signature_derive` to v1.0.0-pre.2 ([#98])

[#98]: https://github.com/RustCrypto/traits/pull/98