### PR TITLE
Forbid unsafe code in all crates

### DIFF
--- a/aead/src/lib.rs
+++ b/aead/src/lib.rs
@@ -13,6 +13,7 @@
 //! [RustCrypto/AEADs]: https://github.com/RustCrypto/AEADs
 
 #![no_std]
+#![forbid(unsafe_code)]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/block-cipher-trait/src/lib.rs
+++ b/block-cipher-trait/src/lib.rs
@@ -1,6 +1,7 @@
 //! This crate defines a set of simple traits used to define functionality of
 //! block ciphers.
 #![no_std]
+#![forbid(unsafe_code)]
 #![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png")]
 #[cfg(feature = "dev")]
 pub extern crate blobby;

--- a/crypto-mac/src/lib.rs
+++ b/crypto-mac/src/lib.rs
@@ -1,5 +1,6 @@
 //! This crate provides trait for Message Authentication Code (MAC) algorithms.
 #![no_std]
+#![forbid(unsafe_code)]
 #![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png")]
 pub extern crate generic_array;
 extern crate subtle;

--- a/digest/src/lib.rs
+++ b/digest/src/lib.rs
@@ -13,6 +13,7 @@
 //!
 //! The `Digest` trait is the most commonly used trait.
 #![no_std]
+#![forbid(unsafe_code)]
 #![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png")]
 pub extern crate generic_array;
 #[cfg(feature = "std")]

--- a/stream-cipher/src/lib.rs
+++ b/stream-cipher/src/lib.rs
@@ -4,6 +4,7 @@
 //! See [RustCrypto/stream-ciphers](https://github.com/RustCrypto/stream-ciphers)
 //! for ciphers implementation.
 #![no_std]
+#![forbid(unsafe_code)]
 #![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png")]
 #[cfg(feature = "dev")]
 pub extern crate blobby;

--- a/universal-hash/src/lib.rs
+++ b/universal-hash/src/lib.rs
@@ -14,6 +14,7 @@
 //! [Universal Hash Functions]: https://en.wikipedia.org/wiki/Universal_hashing
 
 #![no_std]
+#![forbid(unsafe_code)]
 #![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png")]
 #![warn(missing_docs, rust_2018_idioms)]
 


### PR DESCRIPTION
`#![forbid(unsafe_code)]` attributes make rustc abort compilation if
there are any unsafe blocks in the crate, and exceptions cannot be made
with allow/warn attributes.

Didn't add badges to the readme because signature already has this attribute and no badge had been added.