### PR TITLE
crypto-mac/digest: rename `input` to `update`

### DIFF
--- a/crypto-mac/src/lib.rs
+++ b/crypto-mac/src/lib.rs
@@ -28,10 +28,10 @@ pub trait Mac: Clone {
     /// Keys size of the [`Mac`]
     type KeySize: ArrayLength<u8>;
 
-    /// Create new MAC instance from key with fixed size.
+    /// Initialize new MAC instance from key with fixed size.
     fn new(key: &GenericArray<u8, Self::KeySize>) -> Self;
 
-    /// Create new MAC instance from key with variable size.
+    /// Initialize new MAC instance from key with variable size.
     ///
     /// Default implementation will accept only keys with length equal to
     /// `KeySize`, but some MACs can accept range of key lengths.
@@ -43,8 +43,8 @@ pub trait Mac: Clone {
         }
     }
 
-    /// Process input data.
-    fn input(&mut self, data: &[u8]);
+    /// Update MAC state with the given data.
+    fn update(&mut self, data: &[u8]);
 
     /// Reset `Mac` instance.
     fn reset(&mut self);

--- a/digest/src/dyn_digest.rs
+++ b/digest/src/dyn_digest.rs
@@ -1,7 +1,7 @@
 #![cfg(feature = "std")]
 use std::boxed::Box;
 
-use super::{FixedOutput, Input, Reset};
+use super::{FixedOutput, Reset, Update};
 use generic_array::typenum::Unsigned;
 
 /// The `DynDigest` trait is a modification of `Digest` trait suitable
@@ -10,7 +10,7 @@ pub trait DynDigest {
     /// Digest input data.
     ///
     /// This method can be called repeatedly for use with streaming messages.
-    fn input(&mut self, data: &[u8]);
+    fn update(&mut self, data: &[u8]);
 
     /// Retrieve result and reset hasher instance
     fn result_reset(&mut self) -> Box<[u8]>;
@@ -28,9 +28,9 @@ pub trait DynDigest {
     fn box_clone(&self) -> Box<dyn DynDigest>;
 }
 
-impl<D: Input + FixedOutput + Reset + Clone + 'static> DynDigest for D {
-    fn input(&mut self, data: &[u8]) {
-        Input::input(self, data);
+impl<D: Update + FixedOutput + Reset + Clone + 'static> DynDigest for D {
+    fn update(&mut self, data: &[u8]) {
+        Update::update(self, data);
     }
 
     fn result_reset(&mut self) -> Box<[u8]> {

--- a/digest/src/lib.rs
+++ b/digest/src/lib.rs
@@ -41,20 +41,20 @@ use generic_array::{ArrayLength, GenericArray};
 #[cfg(feature = "std")]
 use std::vec::Vec;
 
-/// Trait for processing input data
-pub trait Input {
+/// Trait for updating digest state with input data.
+pub trait Update {
     /// Digest input data.
     ///
     /// This method can be called repeatedly, e.g. for processing streaming
     /// messages.
-    fn input<B: AsRef<[u8]>>(&mut self, data: B);
+    fn update<B: AsRef<[u8]>>(&mut self, data: B);
 
     /// Digest input data in a chained manner.
     fn chain<B: AsRef<[u8]>>(mut self, data: B) -> Self
     where
         Self: Sized,
     {
-        self.input(data);
+        self.update(data);
         self
     }
 }


### PR DESCRIPTION
As discussed in #43, following "Initialize-Update-Finalize" (IUF) nomenclature, this renames the `input` methods in `crypto-mac` and `digest` to be `update` instead, and also renames the `digest::Input` trait to `digest::Update`.