### PR TITLE
digest: use impl Trait notation for AsRef<[u8]>

### DIFF
--- a/digest/src/digest.rs
+++ b/digest/src/digest.rs
@@ -16,10 +16,10 @@ pub trait Digest {
     /// Digest data, updating the internal state.
     ///
     /// This method can be called repeatedly for use with streaming messages.
-    fn update<B: AsRef<[u8]>>(&mut self, data: B);
+    fn update(&mut self, data: impl AsRef<[u8]>);
 
     /// Digest input data in a chained manner.
-    fn chain<B: AsRef<[u8]>>(self, data: B) -> Self
+    fn chain(self, data: impl AsRef<[u8]>) -> Self
     where
         Self: Sized;
 
@@ -56,11 +56,11 @@ impl<D: Update + FixedOutput + Reset + Clone + Default> Digest for D {
         Self::default()
     }
 
-    fn update<B: AsRef<[u8]>>(&mut self, data: B) {
+    fn update(&mut self, data: impl AsRef<[u8]>) {
         Update::update(self, data);
     }
 
-    fn chain<B: AsRef<[u8]>>(self, data: B) -> Self
+    fn chain(self, data: impl AsRef<[u8]>) -> Self
     where
         Self: Sized,
     {

--- a/digest/src/lib.rs
+++ b/digest/src/lib.rs
@@ -47,10 +47,10 @@ pub trait Update {
     ///
     /// This method can be called repeatedly, e.g. for processing streaming
     /// messages.
-    fn update<B: AsRef<[u8]>>(&mut self, data: B);
+    fn update(&mut self, data: impl AsRef<[u8]>);
 
     /// Digest input data in a chained manner.
-    fn chain<B: AsRef<[u8]>>(mut self, data: B) -> Self
+    fn chain(mut self, data: impl AsRef<[u8]>) -> Self
     where
         Self: Sized,
     {


### PR DESCRIPTION
Replaces generic parameters on methods which take an `AsRef<[u8]>` bound with `impl AsRef<[u8]>`.

This syntax is semantically equivalent but eliminates a generic parameter, which (IMO) makes the method signature easier to read, and in general seems to be preferred after the introduction of `impl Trait`.