### PR TITLE
Remove deprecated `Error::description` methods

### DIFF
--- a/block-cipher-trait/src/errors.rs
+++ b/block-cipher-trait/src/errors.rs
@@ -1,6 +1,4 @@
 use core::fmt;
-#[cfg(feature = "std")]
-use std::error;
 
 /// Error struct which used with `NewVarKey`
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
@@ -13,8 +11,4 @@ impl fmt::Display for InvalidKeyLength {
 }
 
 #[cfg(feature = "std")]
-impl error::Error for InvalidKeyLength {
-    fn description(&self) -> &str {
-        "invalid key length"
-    }
-}
+impl std::error::Error for InvalidKeyLength {}

--- a/crypto-mac/src/errors.rs
+++ b/crypto-mac/src/errors.rs
@@ -1,6 +1,4 @@
 use core::fmt;
-#[cfg(feature = "std")]
-use std::error;
 
 /// Error type for signaling failed MAC verification
 #[derive(Default, Debug, Copy, Clone, Eq, PartialEq)]
@@ -23,7 +21,7 @@ impl fmt::Display for InvalidKeyLength {
 }
 
 #[cfg(feature = "std")]
-impl error::Error for MacError {}
+impl std::error::Error for MacError {}
 
 #[cfg(feature = "std")]
-impl error::Error for InvalidKeyLength {}
+impl std::error::Error for InvalidKeyLength {}

--- a/digest/src/errors.rs
+++ b/digest/src/errors.rs
@@ -1,6 +1,4 @@
 use core::fmt;
-#[cfg(feature = "std")]
-use std::error;
 
 /// The error type for variable hasher initialization
 #[derive(Clone, Copy, Debug, Default)]
@@ -13,8 +11,4 @@ impl fmt::Display for InvalidOutputSize {
 }
 
 #[cfg(feature = "std")]
-impl error::Error for InvalidOutputSize {
-    fn description(&self) -> &str {
-        "invalid output size"
-    }
-}
+impl std::error::Error for InvalidOutputSize {}

--- a/stream-cipher/src/errors.rs
+++ b/stream-cipher/src/errors.rs
@@ -1,6 +1,4 @@
 use core::fmt;
-#[cfg(feature = "std")]
-use std::error;
 
 /// Error which notifies that stream cipher has reached the end of a keystream.
 #[derive(Copy, Clone, Debug)]
@@ -13,11 +11,7 @@ impl fmt::Display for LoopError {
 }
 
 #[cfg(feature = "std")]
-impl error::Error for LoopError {
-    fn description(&self) -> &str {
-        "stream cipher loop detected"
-    }
-}
+impl std::error::Error for LoopError {}
 
 /// Error which notifies that key or/and nonce used in stream cipher
 /// initialization had an invalid length.
@@ -31,8 +25,4 @@ impl fmt::Display for InvalidKeyNonceLength {
 }
 
 #[cfg(feature = "std")]
-impl error::Error for InvalidKeyNonceLength {
-    fn description(&self) -> &str {
-        "stream cipher loop detected"
-    }
-}
+impl std::error::Error for InvalidKeyNonceLength {}


### PR DESCRIPTION
This method has been "soft-deprecated" since 1.27.0 and officially deprecated as of Rust 1.42.0.