### PR TITLE
digest: add `Output` type alias

### DIFF
--- a/digest/src/digest.rs
+++ b/digest/src/digest.rs
@@ -24,13 +24,13 @@ pub trait Digest {
         Self: Sized;
 
     /// Retrieve result and consume hasher instance.
-    fn result(self) -> GenericArray<u8, Self::OutputSize>;
+    fn result(self) -> Output<Self>;
 
     /// Retrieve result and reset hasher instance.
     ///
     /// This method sometimes can be more efficient compared to hasher
     /// re-creation.
-    fn result_reset(&mut self) -> GenericArray<u8, Self::OutputSize>;
+    fn result_reset(&mut self) -> Output<Self>;
 
     /// Reset hasher instance to its initial state.
     fn reset(&mut self);
@@ -46,7 +46,7 @@ pub trait Digest {
     /// ```rust,ignore
     /// println!("{:x}", sha2::Sha256::digest(b"Hello world"));
     /// ```
-    fn digest(data: &[u8]) -> GenericArray<u8, Self::OutputSize>;
+    fn digest(data: &[u8]) -> Output<Self>;
 }
 
 impl<D: Update + FixedOutput + Reset + Clone + Default> Digest for D {
@@ -67,11 +67,11 @@ impl<D: Update + FixedOutput + Reset + Clone + Default> Digest for D {
         Update::chain(self, data)
     }
 
-    fn result(self) -> GenericArray<u8, Self::OutputSize> {
+    fn result(self) -> Output<Self> {
         self.fixed_result()
     }
 
-    fn result_reset(&mut self) -> GenericArray<u8, Self::OutputSize> {
+    fn result_reset(&mut self) -> Output<Self> {
         let res = self.clone().fixed_result();
         self.reset();
         res
@@ -85,9 +85,12 @@ impl<D: Update + FixedOutput + Reset + Clone + Default> Digest for D {
         Self::OutputSize::to_usize()
     }
 
-    fn digest(data: &[u8]) -> GenericArray<u8, Self::OutputSize> {
+    fn digest(data: &[u8]) -> Output<Self> {
         let mut hasher = Self::default();
         Update::update(&mut hasher, data);
         hasher.fixed_result()
     }
 }
+
+/// Output of a [`Digest`] function
+pub type Output<D> = GenericArray<u8, <D as Digest>::OutputSize>;

--- a/digest/src/lib.rs
+++ b/digest/src/lib.rs
@@ -2,16 +2,16 @@
 //! functions.
 //!
 //! Traits in this repository can be separated into two levels:
-//! - Low level traits: `Input`, `BlockInput`, `Reset`, `FixedOutput`,
-//! `VariableOutput`, `ExtendableOutput`. These traits atomically describe
+//! - Low level traits: [`Update`], [`BlockInput`], [`Reset`], [`FixedOutput`],
+//! [`VariableOutput`], [`ExtendableOutput`]. These traits atomically describe
 //! available functionality of hash function implementations.
-//! - Convenience trait: `Digest`, `DynDigest`. They are wrappers around
+//! - Convenience trait: [`Digest`], [`DynDigest`]. They are wrappers around
 //! low level traits for most common hash-function use-cases.
 //!
 //! Additionally hash functions implement traits from `std`: `Default`, `Clone`,
 //! `Write`. (the latter depends on enabled-by-default `std` crate feature)
 //!
-//! The `Digest` trait is the most commonly used trait.
+//! The [`Digest`] trait is the most commonly used trait.
 
 #![no_std]
 #![forbid(unsafe_code)]
@@ -29,7 +29,7 @@ mod digest;
 mod dyn_digest;
 mod errors;
 
-pub use crate::digest::Digest;
+pub use crate::digest::{Digest, Output};
 pub use crate::errors::InvalidOutputSize;
 pub use generic_array;
 


### PR DESCRIPTION
Adds a `digest::Output<D>` type alias for a `GenericArray<u8; N>`, which is less unwieldy to remember/type.