### PR TITLE
digest: docs.rs documentation improvements + doc_cfg

### DIFF
--- a/digest/Cargo.toml
+++ b/digest/Cargo.toml
@@ -22,4 +22,5 @@ dev = ["blobby"]
 travis-ci = { repository = "RustCrypto/traits" }
 
 [package.metadata.docs.rs]
-features = ["std"]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/digest/src/dev.rs
+++ b/digest/src/dev.rs
@@ -5,6 +5,7 @@ use core::fmt::Debug;
 
 /// Define test
 #[macro_export]
+#[cfg_attr(docsrs, doc(cfg(feature = "dev")))]
 macro_rules! new_test {
     ($name:ident, $test_name:expr, $hasher:ty, $test_func:ident) => {
         #[test]
@@ -214,6 +215,7 @@ where
 
 /// Define benchmark
 #[macro_export]
+#[cfg_attr(docsrs, doc(cfg(feature = "dev")))]
 macro_rules! bench {
     ($name:ident, $engine:path, $bs:expr) => {
         #[bench]

--- a/digest/src/digest.rs
+++ b/digest/src/digest.rs
@@ -4,8 +4,8 @@ use generic_array::{ArrayLength, GenericArray};
 
 /// The `Digest` trait specifies an interface common for digest functions.
 ///
-/// It's a convenience wrapper around `Input`, `FixedOutput`, `Reset`, `Clone`,
-/// and `Default` traits. It also provides additional convenience methods.
+/// It's a convenience wrapper around [`Update`], [`FixedOutput`], [`Reset`],
+/// [`Clone`], and [`Default`] traits. It also provides additional convenience methods.
 pub trait Digest {
     /// Output size for `Digest`
     type OutputSize: ArrayLength<u8>;

--- a/digest/src/lib.rs
+++ b/digest/src/lib.rs
@@ -14,6 +14,7 @@
 //! The [`Digest`] trait is the most commonly used trait.
 
 #![no_std]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![forbid(unsafe_code)]
 #![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png")]
 #![warn(missing_docs, rust_2018_idioms)]
@@ -23,6 +24,7 @@
 extern crate std;
 
 #[cfg(feature = "dev")]
+#[cfg_attr(docsrs, doc(cfg(feature = "dev")))]
 pub mod dev;
 
 mod digest;
@@ -34,6 +36,7 @@ pub use crate::errors::InvalidOutputSize;
 pub use generic_array;
 
 #[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 pub use dyn_digest::DynDigest;
 
 use generic_array::{ArrayLength, GenericArray};
@@ -97,6 +100,7 @@ pub trait VariableOutput: core::marker::Sized {
 
     /// Retrieve result into vector and consume hasher.
     #[cfg(feature = "std")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     fn vec_result(self) -> Vec<u8> {
         let mut buf = Vec::with_capacity(self.output_size());
         self.variable_result(|res| buf.extend_from_slice(res));
@@ -121,6 +125,7 @@ pub trait ExtendableOutput: core::marker::Sized {
 
     /// Retrieve result into vector of specified length.
     #[cfg(feature = "std")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     fn vec_result(self, n: usize) -> Vec<u8> {
         let mut buf = vec![0u8; n];
         self.xof_result().read(&mut buf);
@@ -134,18 +139,20 @@ pub trait Reset {
     fn reset(&mut self);
 }
 
+#[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 #[macro_export]
-/// Implements `std::io::Write` trait for implementer of `Input`
+/// Implements `std::io::Write` trait for implementer of [`Update`]
 macro_rules! impl_write {
     ($hasher:ident) => {
         #[cfg(feature = "std")]
-        impl ::std::io::Write for $hasher {
-            fn write(&mut self, buf: &[u8]) -> ::std::io::Result<usize> {
-                Input::input(self, buf);
+        impl std::io::Write for $hasher {
+            fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+                Update::update(self, buf);
                 Ok(buf.len())
             }
 
-            fn flush(&mut self) -> ::std::io::Result<()> {
+            fn flush(&mut self) -> std::io::Result<()> {
                 Ok(())
             }
         }


### PR DESCRIPTION
Adds a `--cfg docsrs` option enabled in `package.metadata.docs.rs` which toggles on `doc_cfg` support.

This can be used for tagging what cargo features must be enabled to use certain API features.

Example output:

<img width="740" alt="Screen Shot 2020-05-23 at 9 28 56 AM" src="https://user-images.githubusercontent.com/797/82735712-7d765f00-9cd8-11ea-89c0-63186537bb01.png">
