### PR TITLE
Re-export `typenum::consts` as `consts`

### DIFF
--- a/aead/src/lib.rs
+++ b/aead/src/lib.rs
@@ -25,14 +25,16 @@ extern crate alloc;
 #[cfg(feature = "std")]
 extern crate std;
 
-pub use generic_array;
+pub use generic_array::{self, typenum::consts};
+
 #[cfg(feature = "heapless")]
 pub use heapless;
 
-#[cfg(feature = "alloc")]
-use alloc::vec::Vec;
 use core::fmt;
 use generic_array::{typenum::Unsigned, ArrayLength, GenericArray};
+
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
 
 /// Error type
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]

--- a/block-cipher-trait/src/lib.rs
+++ b/block-cipher-trait/src/lib.rs
@@ -15,7 +15,7 @@ pub mod dev;
 mod errors;
 
 pub use crate::errors::InvalidKeyLength;
-pub use generic_array;
+pub use generic_array::{self, typenum::consts};
 
 use generic_array::typenum::Unsigned;
 use generic_array::{ArrayLength, GenericArray};

--- a/crypto-mac/src/lib.rs
+++ b/crypto-mac/src/lib.rs
@@ -14,7 +14,7 @@ pub mod dev;
 mod errors;
 
 pub use crate::errors::{InvalidKeyLength, MacError};
-pub use generic_array;
+pub use generic_array::{self, typenum::consts};
 
 use generic_array::typenum::Unsigned;
 use generic_array::{ArrayLength, GenericArray};

--- a/digest/src/lib.rs
+++ b/digest/src/lib.rs
@@ -33,7 +33,7 @@ mod errors;
 
 pub use crate::digest::{Digest, Output};
 pub use crate::errors::InvalidOutputSize;
-pub use generic_array;
+pub use generic_array::{self, typenum::consts};
 
 #[cfg(feature = "std")]
 #[cfg_attr(docsrs, doc(cfg(feature = "std")))]

--- a/stream-cipher/src/lib.rs
+++ b/stream-cipher/src/lib.rs
@@ -18,7 +18,7 @@ pub mod dev;
 mod errors;
 
 pub use crate::errors::{InvalidKeyNonceLength, LoopError};
-pub use generic_array;
+pub use generic_array::{self, typenum::consts};
 
 use generic_array::typenum::Unsigned;
 use generic_array::{ArrayLength, GenericArray};

--- a/universal-hash/src/lib.rs
+++ b/universal-hash/src/lib.rs
@@ -21,7 +21,7 @@
 #[cfg(feature = "std")]
 extern crate std;
 
-pub use generic_array;
+pub use generic_array::{self, typenum::consts};
 
 use generic_array::typenum::Unsigned;
 use generic_array::{ArrayLength, GenericArray};
@@ -32,6 +32,7 @@ use subtle::{Choice, ConstantTimeEq};
 pub trait UniversalHash: Clone {
     /// Size of the key for the universal hash function
     type KeySize: ArrayLength<u8>;
+
     /// Size of the inputs to and outputs from the universal hash function
     type BlockSize: ArrayLength<u8>;
 


### PR DESCRIPTION
Inspired by the `heapless` crate:

https://github.com/RustCrypto/traits/issues/43#issuecomment-633109800

This re-export provides convenient access to the type-level numeric constants provided by `typenum`, which should make using `generic-array` less annoying.