### PR TITLE
aead: have NewAead borrow the key

### DIFF
--- a/aead/src/lib.rs
+++ b/aead/src/lib.rs
@@ -74,7 +74,7 @@ pub trait NewAead {
     type KeySize: ArrayLength<u8>;
 
     /// Construct a new stateful instance for the given key.
-    fn new(key: GenericArray<u8, Self::KeySize>) -> Self;
+    fn new(key: &GenericArray<u8, Self::KeySize>) -> Self;
 }
 
 /// Authenticated Encryption with Associated Data (AEAD) algorithm.


### PR DESCRIPTION
In many AEAD implementations we pass the key directly onto `NewBlockCipher`, e.g. in the `aes-gcm` crate:

https://github.com/RustCrypto/AEADs/blob/af9926e/aes-gcm/src/lib.rs#L183

This makes an unnecessary copy of the key which therefore necessitates zeroing it out.

If we borrow the key at the time the cipher is initialized, we can avoid making this copy.