### PR TITLE
README.md(s): add supplemental links

### DIFF
--- a/block-cipher-trait/README.md
+++ b/block-cipher-trait/README.md
@@ -6,7 +6,9 @@
 ![Rust Version][rustc-image]
 [![Build Status][build-image]][build-link]
 
-Traits which define functionality of block ciphers.
+Traits which define functionality of [block ciphers].
+
+See [RustCrypto/block-ciphers] for implementations which use this trait.
 
 [Documentation][docs-link]
 
@@ -47,3 +49,8 @@ dual licensed as above, without any additional terms or conditions.
 [rustc-image]: https://img.shields.io/badge/rustc-1.41+-blue.svg
 [build-image]: https://github.com/RustCrypto/traits/workflows/block-cipher-trait/badge.svg?branch=master&event=push
 [build-link]: https://github.com/RustCrypto/traits/actions?query=workflow%3Ablock-cipher-trait
+
+[//]: # (general links)
+
+[block ciphers]: https://en.wikipedia.org/wiki/Block_cipher
+[RustCrypto/block-ciphers]: https://github.com/RustCrypto/block-ciphers

--- a/crypto-mac/README.md
+++ b/crypto-mac/README.md
@@ -6,7 +6,9 @@
 ![Rust Version][rustc-image]
 [![Build Status][build-image]][build-link]
 
-Traits for Message Authentication Code (MAC) algorithms.
+Traits for [Message Authentication Code] (MAC) algorithms.
+
+See [RustCrypto/MACs] for implementations which use this trait.
 
 [Documentation][docs-link]
 
@@ -47,3 +49,8 @@ dual licensed as above, without any additional terms or conditions.
 [rustc-image]: https://img.shields.io/badge/rustc-1.41+-blue.svg
 [build-image]: https://github.com/RustCrypto/traits/workflows/crypto-mac/badge.svg?branch=master&event=push
 [build-link]: https://github.com/RustCrypto/traits/actions?query=workflow%3Acrypto-mac
+
+[//]: # (general links)
+
+[Message Authentication Code]: https://en.wikipedia.org/wiki/Message_authentication_code
+[RustCrypto/MACs]: https://github.com/RustCrypto/MACs

--- a/digest/README.md
+++ b/digest/README.md
@@ -6,8 +6,10 @@
 ![Rust Version][rustc-image]
 [![Build Status][build-image]][build-link]
 
-Traits which describe functionality of cryptographic hash functions, a.k.a.
+Traits which describe functionality of [cryptographic hash functions], a.k.a.
 digest algorithms.
+
+See [RustCrypto/hashes] for implementations which use this trait.
 
 [Documentation][docs-link]
 
@@ -48,3 +50,8 @@ dual licensed as above, without any additional terms or conditions.
 [rustc-image]: https://img.shields.io/badge/rustc-1.41+-blue.svg
 [build-image]: https://github.com/RustCrypto/traits/workflows/digest/badge.svg?branch=master&event=push
 [build-link]: https://github.com/RustCrypto/traits/actions?query=workflow%3Adigest
+
+[//]: # (general links)
+
+[cryptographic hash functions]: https://en.wikipedia.org/wiki/Cryptographic_hash_function
+[RustCrypto/hashes]: https://github.com/RustCrypto/hashes

--- a/signature/README.md
+++ b/signature/README.md
@@ -12,6 +12,10 @@ generating and verifying [digital signatures][1].
 Used by the [`ecdsa`][2] and [`ed25519`][3] crates, with forthcoming support
 in the [`rsa`][4] crate.
 
+See also the [Signatory][5] project for trait wrappers for using these traits
+with many popular Rust cryptography crates, including `ed25519-dalek`, *ring*,
+`secp256k1-rs`, and `sodiumoxide`.
+
 [Documentation][docs-link]
 
 ## Minimum Supported Rust Version
@@ -62,3 +66,4 @@ dual licensed as above, without any additional terms or conditions.
 [2]: https://github.com/RustCrypto/signatures/tree/master/ecdsa
 [3]: https://github.com/RustCrypto/signatures/tree/master/ed25519
 [4]: https://github.com/RustCrypto/RSA
+[5]: https://docs.rs/signatory

--- a/stream-cipher/README.md
+++ b/stream-cipher/README.md
@@ -6,7 +6,9 @@
 ![Rust Version][rustc-image]
 [![Build Status][build-image]][build-link]
 
-Traits which define functionality of stream ciphers.
+Traits which define functionality of [stream ciphers].
+
+See [RustCrypto/stream-ciphers] for implementations which use this trait.
 
 [Documentation][docs-link]
 
@@ -47,3 +49,8 @@ dual licensed as above, without any additional terms or conditions.
 [rustc-image]: https://img.shields.io/badge/rustc-1.41+-blue.svg
 [build-image]: https://github.com/RustCrypto/traits/workflows/stream-cipher/badge.svg?branch=master&event=push
 [build-link]: https://github.com/RustCrypto/traits/actions?query=workflow%3Astream-cipher
+
+[//]: # (general links)
+
+[stream ciphers]: https://en.wikipedia.org/wiki/Stream_cipher
+[RustCrypto/stream-ciphers]: https://github.com/RustCrypto/stream-ciphers

--- a/universal-hash/README.md
+++ b/universal-hash/README.md
@@ -6,7 +6,9 @@
 ![Rust Version][rustc-image]
 [![Build Status][build-image]][build-link]
 
-Traits which define functionality of universal hash functions.
+Traits which define functionality of [universal hash functions].
+
+See [RustCrypto/universal-hashes] for implementations which use this trait.
 
 [Documentation][docs-link]
 
@@ -47,3 +49,8 @@ dual licensed as above, without any additional terms or conditions.
 [rustc-image]: https://img.shields.io/badge/rustc-1.41+-blue.svg
 [build-image]: https://github.com/RustCrypto/traits/workflows/universal-hash/badge.svg?branch=master&event=push
 [build-link]: https://github.com/RustCrypto/traits/actions?query=workflow%3Auniversal-hash
+
+[//]: # (general links)
+
+[universal hash functions]: https://en.wikipedia.org/wiki/Universal_hashing
+[RustCrypto/universal-hashes]: https://github.com/RustCrypto/universal-hashes


### PR DESCRIPTION
Adds links to the Wikipedia definitions of various algorithms, as well as the RustCrypto repositories where various algorithm-specific implementations of the traits are located.