### PR TITLE
crypto-mac: add `impl_write!` macro

### DIFF
--- a/crypto-mac/src/lib.rs
+++ b/crypto-mac/src/lib.rs
@@ -114,3 +114,21 @@ impl<M: Mac> PartialEq for Output<M> {
 }
 
 impl<M: Mac> Eq for Output<M> {}
+
+#[macro_export]
+/// Implements `std::io::Write` trait for implementer of [`Mac`]
+macro_rules! impl_write {
+    ($mac:ident) => {
+        #[cfg(feature = "std")]
+        impl std::io::Write for $mac {
+            fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+                Mac::update(self, buf);
+                Ok(buf.len())
+            }
+
+            fn flush(&mut self) -> std::io::Result<()> {
+                Ok(())
+            }
+        }
+    };
+}

--- a/digest/src/lib.rs
+++ b/digest/src/lib.rs
@@ -139,8 +139,6 @@ pub trait Reset {
     fn reset(&mut self);
 }
 
-#[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 #[macro_export]
 /// Implements `std::io::Write` trait for implementer of [`Update`]
 macro_rules! impl_write {


### PR DESCRIPTION
As discussed on #43, similar to the one in `digest`.