### PR TITLE
Bump all crates to `-pre` versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,7 +2,7 @@
 # It is not intended for manual editing.
 [[package]]
 name = "aead"
-version = "0.2.0"
+version = "0.3.0-pre"
 dependencies = [
  "generic-array 0.14.1",
  "heapless",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "block-cipher-trait"
-version = "0.6.2"
+version = "0.7.0-pre"
 dependencies = [
  "blobby",
  "generic-array 0.14.1",
@@ -71,7 +71,7 @@ checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
 
 [[package]]
 name = "crypto-mac"
-version = "0.8.0"
+version = "0.9.0-pre"
 dependencies = [
  "blobby",
  "generic-array 0.13.2",
@@ -81,18 +81,18 @@ dependencies = [
 [[package]]
 name = "digest"
 version = "0.8.1"
-dependencies = [
- "blobby",
- "generic-array 0.14.1",
-]
-
-[[package]]
-name = "digest"
-version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
 dependencies = [
  "generic-array 0.12.3",
+]
+
+[[package]]
+name = "digest"
+version = "0.9.0-pre"
+dependencies = [
+ "blobby",
+ "generic-array 0.14.1",
 ]
 
 [[package]]
@@ -211,16 +211,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27044adfd2e1f077f649f59deb9490d3941d674002f7d062870a60ebe9bd47a0"
 dependencies = [
  "block-buffer",
- "digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "digest 0.8.1",
  "fake-simd",
  "opaque-debug",
 ]
 
 [[package]]
 name = "signature"
-version = "1.0.1"
+version = "1.1.0-pre"
 dependencies = [
- "digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "digest 0.9.0-pre",
  "hex-literal",
  "rand_core",
  "sha2",
@@ -245,7 +245,7 @@ checksum = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 
 [[package]]
 name = "stream-cipher"
-version = "0.3.2"
+version = "0.4.0-pre"
 dependencies = [
  "blobby",
  "generic-array 0.14.1",
@@ -294,7 +294,7 @@ checksum = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 
 [[package]]
 name = "universal-hash"
-version = "0.3.0"
+version = "0.4.0-pre"
 dependencies = [
  "generic-array 0.14.1",
  "subtle",

--- a/aead/Cargo.toml
+++ b/aead/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aead"
-version = "0.2.0"
+version = "0.3.0-pre"
 authors = ["RustCrypto Developers"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/block-cipher-trait/Cargo.toml
+++ b/block-cipher-trait/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "block-cipher-trait"
 description = "Traits for description of block ciphers"
-version = "0.6.2"
+version = "0.7.0-pre"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/crypto-mac/Cargo.toml
+++ b/crypto-mac/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "crypto-mac"
 description = "Trait for Message Authentication Code (MAC) algorithms"
-version = "0.8.0"
+version = "0.9.0-pre"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/digest/Cargo.toml
+++ b/digest/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "digest"
 description = "Traits for cryptographic hash functions"
-version = "0.8.1"
+version = "0.9.0-pre"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/signature/Cargo.toml
+++ b/signature/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name          = "signature"
 description   = "Traits for cryptographic signature algorithms (e.g. ECDSA, Ed25519)"
-version       = "1.0.1" # Also update html_root_url in lib.rs when bumping this
+version       = "1.1.0-pre" # Also update html_root_url in lib.rs when bumping this
 authors       = ["RustCrypto Developers"]
 license       = "Apache-2.0 OR MIT"
 documentation = "https://docs.rs/signature"
@@ -12,9 +12,10 @@ keywords      = ["crypto", "ecdsa", "ed25519", "signature", "signing"]
 categories    = ["cryptography", "no-std"]
 
 [dependencies.digest]
-version = "0.8"
+version = "= 0.9.0-pre"
 optional = true
 default-features = false
+path = "../digest"
 
 [dependencies.rand_core]
 version = "0.5"

--- a/signature/src/lib.rs
+++ b/signature/src/lib.rs
@@ -155,7 +155,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/ferris_signer.png",
-    html_root_url = "https://docs.rs/signature/1.0.1"
+    html_root_url = "https://docs.rs/signature/1.1.0-pre"
 )]
 #![forbid(unsafe_code)]
 #![warn(

--- a/stream-cipher/Cargo.toml
+++ b/stream-cipher/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "stream-cipher"
 description = "Stream cipher traits"
-version = "0.3.2"
+version = "0.4.0-pre"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/universal-hash/Cargo.toml
+++ b/universal-hash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "universal-hash"
-version = "0.3.0"
+version = "0.4.0-pre"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 description = "Trait for universal hash functions"


### PR DESCRIPTION
This commit does an across-the-board version bump of all traits, since they've all been migrated (vicariously) to `generic-array` v0.14.

There's no intention of releasing them yet, and if I do release preleases they'll be as `-pre.0` and so forth. This just makes it clear what's presently on HEAD is very much SemVer incompatible with the current releases.

After this, I'll try updating the various repos which consume these traits to use the latest git versions of these crates before cutting a final release.