### PR TITLE
block-cipher/stream-cipher: more dev fixes

### DIFF
--- a/block-cipher/src/dev.rs
+++ b/block-cipher/src/dev.rs
@@ -1,12 +1,14 @@
 //! Development-related functionality
 
+pub use blobby;
+
 /// Define test
 #[macro_export]
 macro_rules! new_test {
     ($name:ident, $test_name:expr, $cipher:ty) => {
         #[test]
         fn $name() {
-            use block_cipher::blobby::Blob3Iterator;
+            use block_cipher::dev::blobby::Blob3Iterator;
             use block_cipher::generic_array::typenum::Unsigned;
             use block_cipher::generic_array::GenericArray;
             use block_cipher::{BlockCipher, NewBlockCipher};

--- a/block-cipher/src/lib.rs
+++ b/block-cipher/src/lib.rs
@@ -12,9 +12,6 @@ extern crate std;
 #[cfg(feature = "dev")]
 pub mod dev;
 
-#[cfg(feature = "dev")]
-pub use blobby;
-
 mod errors;
 
 pub use crate::errors::InvalidKeyLength;

--- a/stream-cipher/src/dev.rs
+++ b/stream-cipher/src/dev.rs
@@ -1,12 +1,14 @@
 //! Development-related functionality
 
+pub use blobby;
+
 /// Test core functionality of synchronous stream cipher
 #[macro_export]
 macro_rules! new_sync_test {
     ($name:ident, $cipher:ty, $test_name:expr) => {
         #[test]
         fn $name() {
-            use stream_cipher::blobby::Blob4Iterator;
+            use stream_cipher::dev::blobby::Blob4Iterator;
             use stream_cipher::generic_array::GenericArray;
             use stream_cipher::{NewStreamCipher, SyncStreamCipher};
 
@@ -45,7 +47,7 @@ macro_rules! new_seek_test {
     ($name:ident, $cipher:ty, $test_name:expr) => {
         #[test]
         fn $name() {
-            use stream_cipher::blobby::Blob4Iterator;
+            use stream_cipher::dev::blobby::Blob4Iterator;
             use stream_cipher::generic_array::GenericArray;
             use stream_cipher::{NewStreamCipher, SyncStreamCipher, SyncStreamCipherSeek};
 
@@ -87,7 +89,7 @@ macro_rules! new_async_test {
     ($name:ident, $test_name:expr, $cipher:ty) => {
         #[test]
         fn $name() {
-            use stream_cipher::blobby::Blob4Iterator;
+            use stream_cipher::dev::blobby::Blob4Iterator;
             use stream_cipher::generic_array::GenericArray;
             use stream_cipher::{NewStreamCipher, StreamCipher};
 


### PR DESCRIPTION
Re-exports blobby under the `dev` module in each crate, and updates the macros to use that.