### PR TITLE
crypto-mac: bump version to v0.8.0-pre

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,7 +71,7 @@ checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
 
 [[package]]
 name = "crypto-mac"
-version = "0.9.0-pre"
+version = "0.8.0-pre"
 dependencies = [
  "blobby",
  "generic-array 0.13.2",

--- a/crypto-mac/Cargo.toml
+++ b/crypto-mac/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "crypto-mac"
 description = "Trait for Message Authentication Code (MAC) algorithms"
-version = "0.9.0-pre"
+version = "0.8.0-pre"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
It seems it was previously bumped to v0.8.0:

https://github.com/RustCrypto/traits/commit/128e557120632b623f55356a539b1c9c991d6626

...but never released, so this bumps it back with the intent of releasing a v0.8.0.