### PR TITLE
.github: use `defaults` to set `working-directory`

### DIFF
--- a/.github/workflows/aead.yml
+++ b/.github/workflows/aead.yml
@@ -7,9 +7,10 @@ on:
       - "Cargo.*"
   push:
     branches: master
-    paths:
-      - "aead/**"
-      - "Cargo.*"
+
+defaults:
+  run:
+    working-directory: aead
 
 env:
   CARGO_INCREMENTAL: 0
@@ -34,8 +35,7 @@ jobs:
           toolchain: ${{ matrix.rust }}
           target: ${{ matrix.target }}
           override: true
-      - working-directory: aead
-        run: cargo build --no-default-features --release --target ${{ matrix.target }}
+      - run: cargo build --no-default-features --release --target ${{ matrix.target }}
   test:
     runs-on: ubuntu-latest
     strategy:
@@ -50,10 +50,6 @@ jobs:
         profile: minimal
         toolchain: ${{ matrix.rust }}
     - run: cargo check --all-features
-      working-directory: aead
     - run: cargo test --no-default-features --release
-      working-directory: aead
     - run: cargo test --release
-      working-directory: aead
     - run: cargo test --all-features --release
-      working-directory: aead

--- a/.github/workflows/block-cipher.yml
+++ b/.github/workflows/block-cipher.yml
@@ -7,9 +7,10 @@ on:
       - "Cargo.*"
   push:
     branches: master
-    paths:
-    - "block-cipher/**"
-    - "Cargo.*"
+
+defaults:
+  run:
+    working-directory: block-cipher
 
 env:
   CARGO_INCREMENTAL: 0
@@ -34,8 +35,7 @@ jobs:
           toolchain: ${{ matrix.rust }}
           target: ${{ matrix.target }}
           override: true
-      - working-directory: block-cipher
-        run: cargo build --no-default-features --release --target ${{ matrix.target }}
+      - run: cargo build --no-default-features --release --target ${{ matrix.target }}
   test:
     runs-on: ubuntu-latest
     strategy:
@@ -50,12 +50,7 @@ jobs:
         profile: minimal
         toolchain: ${{ matrix.rust }}
     - run: cargo check --all-features
-      working-directory: block-cipher
     - run: cargo test --release
-      working-directory: block-cipher
     - run: cargo test --features dev --release
-      working-directory: block-cipher
     - run: cargo test --features std --release
-      working-directory: block-cipher
     - run: cargo test --all-features --release
-      working-directory: block-cipher

--- a/.github/workflows/crypto-mac.yml
+++ b/.github/workflows/crypto-mac.yml
@@ -7,9 +7,10 @@ on:
       - "Cargo.*"
   push:
     branches: master
-    paths:
-    - "crypto-mac/**"
-    - "Cargo.*"
+
+defaults:
+  run:
+    working-directory: crypto-mac
 
 env:
   CARGO_INCREMENTAL: 0
@@ -34,8 +35,7 @@ jobs:
           toolchain: ${{ matrix.rust }}
           target: ${{ matrix.target }}
           override: true
-      - working-directory: crypto-mac
-        run: cargo build --no-default-features --release --target ${{ matrix.target }}
+      - run: cargo build --no-default-features --release --target ${{ matrix.target }}
   test:
     runs-on: ubuntu-latest
     strategy:
@@ -50,12 +50,7 @@ jobs:
         profile: minimal
         toolchain: ${{ matrix.rust }}
     - run: cargo check --all-features
-      working-directory: crypto-mac
     - run: cargo test --release
-      working-directory: crypto-mac
     - run: cargo test --features dev --release
-      working-directory: crypto-mac
     - run: cargo test --features std --release
-      working-directory: crypto-mac
     - run: cargo test --all-features --release
-      working-directory: crypto-mac

--- a/.github/workflows/digest.yml
+++ b/.github/workflows/digest.yml
@@ -7,9 +7,10 @@ on:
         - "Cargo.*"
   push:
     branches: master
-    paths:
-    - "digest/**"
-    - "Cargo.*"
+
+defaults:
+  run:
+    working-directory: digest
 
 env:
   CARGO_INCREMENTAL: 0
@@ -34,8 +35,7 @@ jobs:
           toolchain: ${{ matrix.rust }}
           target: ${{ matrix.target }}
           override: true
-      - working-directory: digest
-        run: cargo build --no-default-features --release --target ${{ matrix.target }}
+      - run: cargo build --no-default-features --release --target ${{ matrix.target }}
   test:
     runs-on: ubuntu-latest
     strategy:
@@ -50,12 +50,7 @@ jobs:
         profile: minimal
         toolchain: ${{ matrix.rust }}
     - run: cargo check --all-features
-      working-directory: digest
     - run: cargo test --release
-      working-directory: digest
     - run: cargo test --features dev --release
-      working-directory: digest
     - run: cargo test --features std --release
-      working-directory: digest
     - run: cargo test --all-features --release
-      working-directory: digest

--- a/.github/workflows/signature.yml
+++ b/.github/workflows/signature.yml
@@ -7,9 +7,10 @@ on:
       - "Cargo.*"
   push:
     branches: master
-    paths:
-      - "signature/**"
-      - "Cargo.*"
+
+defaults:
+  run:
+    working-directory: signature
 
 env:
   CARGO_INCREMENTAL: 0
@@ -34,8 +35,7 @@ jobs:
           toolchain: ${{ matrix.rust }}
           target: ${{ matrix.target }}
           override: true
-      - working-directory: signature
-        run: cargo build --no-default-features --release --target ${{ matrix.target }}
+      - run: cargo build --no-default-features --release --target ${{ matrix.target }}
   test:
     runs-on: ubuntu-latest
     strategy:
@@ -50,11 +50,7 @@ jobs:
         profile: minimal
         toolchain: ${{ matrix.rust }}
     - run: cargo check --all-features
-      working-directory: signature
     - run: cargo test --no-default-features --release
-      working-directory: signature
     - run: cargo test --release
-      working-directory: signature
 # TODO: fix support for the `digest-preview` feature
 #    - run: cargo test --all-features --release
-#      working-directory: signature

--- a/.github/workflows/stream-cipher.yml
+++ b/.github/workflows/stream-cipher.yml
@@ -7,9 +7,10 @@ on:
       - "Cargo.*"
   push:
     branches: master
-    paths:
-      - "stream-cipher/**"
-      - "Cargo.*"
+
+defaults:
+  run:
+    working-directory: stream-cipher
 
 env:
   CARGO_INCREMENTAL: 0
@@ -34,8 +35,7 @@ jobs:
           toolchain: ${{ matrix.rust }}
           target: ${{ matrix.target }}
           override: true
-      - working-directory: stream-cipher
-        run: cargo build --no-default-features --release --target ${{ matrix.target }}
+      - run: cargo build --no-default-features --release --target ${{ matrix.target }}
   test:
     runs-on: ubuntu-latest
     strategy:
@@ -50,12 +50,7 @@ jobs:
         profile: minimal
         toolchain: ${{ matrix.rust }}
     - run: cargo check --all-features
-      working-directory: stream-cipher
     - run: cargo test --release
-      working-directory: stream-cipher
     - run: cargo test --features dev --release
-      working-directory: stream-cipher
     - run: cargo test --features std --release
-      working-directory: stream-cipher
     - run: cargo test --all-features --release
-      working-directory: stream-cipher

--- a/.github/workflows/universal-hash.yml
+++ b/.github/workflows/universal-hash.yml
@@ -7,9 +7,10 @@ on:
       - "Cargo.*"
   push:
     branches: master
-    paths:
-      - "universal-hash/**"
-      - "Cargo.*"
+
+defaults:
+  run:
+    working-directory: universal-hash
 
 env:
   CARGO_INCREMENTAL: 0
@@ -34,8 +35,7 @@ jobs:
           toolchain: ${{ matrix.rust }}
           target: ${{ matrix.target }}
           override: true
-      - working-directory: universal-hash
-        run: cargo build --no-default-features --release --target ${{ matrix.target }}
+      - run: cargo build --no-default-features --release --target ${{ matrix.target }}
   test:
     runs-on: ubuntu-latest
     strategy:
@@ -50,10 +50,6 @@ jobs:
         profile: minimal
         toolchain: ${{ matrix.rust }}
     - run: cargo check --all-features
-      working-directory: universal-hash
     - run: cargo test --no-default-features --release
-      working-directory: universal-hash
     - run: cargo test --release
-      working-directory: universal-hash
     - run: cargo test --all-features --release
-      working-directory: universal-hash

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -299,3 +299,4 @@ dependencies = [
  "generic-array 0.14.1",
  "subtle",
 ]
+


### PR DESCRIPTION
This should eliminate redundantly specifying it on a per-job basis.