### PR TITLE
digest: add `alloc` feature

### DIFF
--- a/.github/workflows/digest.yml
+++ b/.github/workflows/digest.yml
@@ -52,5 +52,6 @@ jobs:
     - run: cargo check --all-features
     - run: cargo test --release
     - run: cargo test --features dev --release
+    - run: cargo test --features alloc --release
     - run: cargo test --features std --release
     - run: cargo test --all-features --release

--- a/digest/Cargo.toml
+++ b/digest/Cargo.toml
@@ -16,7 +16,8 @@ generic-array = "0.14"
 blobby = { version = "0.1", optional = true }
 
 [features]
-std = []
+alloc = []
+std = ["alloc"]
 dev = ["blobby"]
 
 [package.metadata.docs.rs]

--- a/digest/src/dyn_digest.rs
+++ b/digest/src/dyn_digest.rs
@@ -1,5 +1,5 @@
-#![cfg(feature = "std")]
-use std::boxed::Box;
+#![cfg(feature = "alloc")]
+use alloc::boxed::Box;
 
 use super::{FixedOutput, Reset, Update};
 use generic_array::typenum::Unsigned;

--- a/digest/src/lib.rs
+++ b/digest/src/lib.rs
@@ -19,8 +19,11 @@
 #![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png")]
 #![warn(missing_docs, rust_2018_idioms)]
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 #[macro_use]
+extern crate alloc;
+
+#[cfg(feature = "std")]
 extern crate std;
 
 #[cfg(feature = "dev")]
@@ -35,14 +38,14 @@ pub use crate::digest::{Digest, Output};
 pub use crate::errors::InvalidOutputSize;
 pub use generic_array::{self, typenum::consts};
 
-#[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+#[cfg(feature = "alloc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 pub use dyn_digest::DynDigest;
 
 use generic_array::{ArrayLength, GenericArray};
 
-#[cfg(feature = "std")]
-use std::vec::Vec;
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
 
 /// Trait for updating digest state with input data.
 pub trait Update {
@@ -99,8 +102,8 @@ pub trait VariableOutput: core::marker::Sized {
     fn finalize_variable<F: FnOnce(&[u8])>(self, f: F);
 
     /// Retrieve result into vector and consume hasher.
-    #[cfg(feature = "std")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+    #[cfg(feature = "alloc")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     fn finalize_vec(self) -> Vec<u8> {
         let mut buf = Vec::with_capacity(self.output_size());
         self.finalize_variable(|res| buf.extend_from_slice(res));
@@ -124,8 +127,8 @@ pub trait ExtendableOutput: core::marker::Sized {
     fn finalize_xof(self) -> Self::Reader;
 
     /// Retrieve result into vector of specified length.
-    #[cfg(feature = "std")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+    #[cfg(feature = "alloc")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     fn finalize_vec(self, n: usize) -> Vec<u8> {
         let mut buf = vec![0u8; n];
         self.finalize_xof().read(&mut buf);


### PR DESCRIPTION
Allows `DynDigest` and `*_vec` methods to function in `no_std` + `alloc` environments.