### PR TITLE
stream-cipher: add FromBlockCipher trait (fixes #32)

### DIFF
--- a/.github/workflows/stream-cipher.yml
+++ b/.github/workflows/stream-cipher.yml
@@ -51,6 +51,7 @@ jobs:
         toolchain: ${{ matrix.rust }}
     - run: cargo check --all-features
     - run: cargo test --release
+    - run: cargo test --features block-cipher
     - run: cargo test --features dev --release
     - run: cargo test --features std --release
     - run: cargo test --all-features --release

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -248,6 +248,7 @@ name = "stream-cipher"
 version = "0.4.0-pre"
 dependencies = [
  "blobby",
+ "block-cipher",
  "generic-array 0.14.1",
 ]
 

--- a/stream-cipher/Cargo.toml
+++ b/stream-cipher/Cargo.toml
@@ -15,9 +15,15 @@ categories = ["cryptography", "no-std"]
 generic-array = "0.14"
 blobby = { version = "0.1", optional = true }
 
+[dependencies.block-cipher]
+version = "= 0.7.0-pre"
+optional = true
+path = "../block-cipher"
+
 [features]
 std = []
 dev = ["blobby"]
 
 [package.metadata.docs.rs]
-features = [ "std" ]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/stream-cipher/src/dev.rs
+++ b/stream-cipher/src/dev.rs
@@ -4,6 +4,7 @@ pub use blobby;
 
 /// Test core functionality of synchronous stream cipher
 #[macro_export]
+#[cfg_attr(docsrs, doc(cfg(feature = "dev")))]
 macro_rules! new_sync_test {
     ($name:ident, $cipher:ty, $test_name:expr) => {
         #[test]
@@ -43,6 +44,7 @@ macro_rules! new_sync_test {
 
 /// Test stream synchronous stream cipher seeking capabilities
 #[macro_export]
+#[cfg_attr(docsrs, doc(cfg(feature = "dev")))]
 macro_rules! new_seek_test {
     ($name:ident, $cipher:ty, $test_name:expr) => {
         #[test]
@@ -85,6 +87,7 @@ macro_rules! new_seek_test {
 
 /// Test core functionality of asynchronous stream cipher
 #[macro_export]
+#[cfg_attr(docsrs, doc(cfg(feature = "dev")))]
 macro_rules! new_async_test {
     ($name:ident, $test_name:expr, $cipher:ty) => {
         #[test]
@@ -149,6 +152,7 @@ macro_rules! new_async_test {
 
 /// Create synchronous stream cipher benchmarks
 #[macro_export]
+#[cfg_attr(docsrs, doc(cfg(feature = "dev")))]
 macro_rules! bench_sync {
     ($name:ident, $cipher:path, $data_len:expr) => {
         #[bench]
@@ -187,6 +191,7 @@ macro_rules! bench_sync {
 
 /// Create synchronous stream cipher benchmarks
 #[macro_export]
+#[cfg_attr(docsrs, doc(cfg(feature = "dev")))]
 macro_rules! bench_async {
     ($enc_name:ident, $dec_name:ident, $cipher:path, $data_len:expr) => {
         #[bench]


### PR DESCRIPTION
Support for instantiating a stream cipher from a block cipher