### PR TITLE
block-cipher v0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "block-cipher"
-version = "0.7.0-pre"
+version = "0.7.0"
 dependencies = [
  "blobby",
  "generic-array 0.14.1",

--- a/block-cipher/CHANGELOG.md
+++ b/block-cipher/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.7.0 (2020-06-04)
+### Changed
+- Crate renamed from `block-cipher-trait` to `block-cipher` ([#139])
+- Split `BlockCipher` initialization into  `NewBlockCipher` trait ([#132])
+- Update to Rust 2018 edition ([#107])
+- Bump `generic-array` dependency to v0.14 ([#95])
+
+[#139]: https://github.com/RustCrypto/traits/issues/139
+[#132]: https://github.com/RustCrypto/traits/issues/132
+[#107]: https://github.com/RustCrypto/traits/issues/107
+[#95]: https://github.com/RustCrypto/traits/pull/95
+
 ## 0.6.2 (2018-11-14)
 
 ## 0.6.1 (2018-10-04)

--- a/block-cipher/Cargo.toml
+++ b/block-cipher/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "block-cipher"
 description = "Traits for description of block ciphers"
-version = "0.7.0-pre"
+version = "0.7.0"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/stream-cipher/Cargo.toml
+++ b/stream-cipher/Cargo.toml
@@ -16,7 +16,7 @@ generic-array = "0.14"
 blobby = { version = "0.1", optional = true }
 
 [dependencies.block-cipher]
-version = "= 0.7.0-pre"
+version = "0.7"
 optional = true
 path = "../block-cipher"
 


### PR DESCRIPTION
### Changed
- Crate renamed from `block-cipher-trait` to `block-cipher` ([#139])
- Split `BlockCipher` initialization into  `NewBlockCipher` trait ([#132])
- Update to Rust 2018 edition ([#107])
- Bump `generic-array` dependency to v0.14 ([#95])

[#139]: https://github.com/RustCrypto/traits/issues/139
[#132]: https://github.com/RustCrypto/traits/issues/132
[#107]: https://github.com/RustCrypto/traits/issues/107
[#95]: https://github.com/RustCrypto/traits/pull/95