### PR TITLE
crypto-mac v0.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,7 +71,7 @@ checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
 
 [[package]]
 name = "crypto-mac"
-version = "0.8.0-pre"
+version = "0.8.0"
 dependencies = [
  "blobby",
  "generic-array 0.14.1",

--- a/block-cipher/CHANGELOG.md
+++ b/block-cipher/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## 0.7.0 (2020-06-04)
 ### Changed
 - Crate renamed from `block-cipher-trait` to `block-cipher` ([#139])
-- Split `BlockCipher` initialization into  `NewBlockCipher` trait ([#132])
+- Split `BlockCipher` initialization into `NewBlockCipher` trait ([#132])
 - Update to Rust 2018 edition ([#107])
 - Bump `generic-array` dependency to v0.14 ([#95])
 

--- a/crypto-mac/CHANGELOG.md
+++ b/crypto-mac/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.8.0 (2020-06-04)
+### Added
+- `impl_write!` macro ([#134])
+
+### Changed
+- Bump `generic-array` dependency to v0.14 ([#144])
+- Split `Mac` initialization into `NewMac` trait ([#133])
+- Rename `MacResult` => `Output`, `code` => `into_bytes` ([#114])
+- Rename `Input::input` to `Update::update` ([#111])
+- Update to 2018 edition ([#108])
+- Bump `subtle` dependency from v1.0 to v2.0 ([#33])
+
+[#144]: https://github.com/RustCrypto/traits/pull/95
+[#134]: https://github.com/RustCrypto/traits/pull/134
+[#133]: https://github.com/RustCrypto/traits/pull/133
+[#114]: https://github.com/RustCrypto/traits/pull/114
+[#111]: https://github.com/RustCrypto/traits/pull/111
+[#108]: https://github.com/RustCrypto/traits/pull/108
+[#33]: https://github.com/RustCrypto/traits/pull/33
+
 ## 0.7.0 (2018-10-01)
 
 ## 0.6.2 (2018-06-21)

--- a/crypto-mac/Cargo.toml
+++ b/crypto-mac/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "crypto-mac"
 description = "Trait for Message Authentication Code (MAC) algorithms"
-version = "0.8.0-pre"
+version = "0.8.0"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
### Added
- `impl_write!` macro ([#134])

### Changed
- Bump `generic-array` dependency to v0.14 ([#144])
- Split `Mac` initialization into `NewMac` trait ([#133])
- Rename `MacResult` => `Output`, `code` => `into_bytes` ([#114])
- Rename `Input::input` to `Update::update` ([#111])
- Update to 2018 edition ([#108])
- Bump `subtle` dependency from v1.0 to v2.0 ([#33])

[#144]: https://github.com/RustCrypto/traits/pull/95
[#134]: https://github.com/RustCrypto/traits/pull/134
[#133]: https://github.com/RustCrypto/traits/pull/133
[#114]: https://github.com/RustCrypto/traits/pull/114
[#111]: https://github.com/RustCrypto/traits/pull/111
[#108]: https://github.com/RustCrypto/traits/pull/108
[#33]: https://github.com/RustCrypto/traits/pull/33