### PR TITLE
stream-cipher v0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -245,7 +245,7 @@ checksum = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 
 [[package]]
 name = "stream-cipher"
-version = "0.4.0-pre"
+version = "0.4.0"
 dependencies = [
  "blobby",
  "block-cipher",

--- a/stream-cipher/CHANGELOG.md
+++ b/stream-cipher/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.0 (2020-06-04)
+### Added
+- `FromBlockCipher` trait ([#164])
+
+### Changed
+- Update to 2018 edition ([#110])
+- Bump `generic-array` dependency to v0.14 ([#95])
+
+[#164]: https://github.com/RustCrypto/traits/issues/164
+[#110]: https://github.com/RustCrypto/traits/issues/110
+[#95]: https://github.com/RustCrypto/traits/pull/95
+
 ## 0.3.2 (2019-08-18)
 
 ## 0.3.1 (2019-08-17)

--- a/stream-cipher/Cargo.toml
+++ b/stream-cipher/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "stream-cipher"
 description = "Stream cipher traits"
-version = "0.4.0-pre"
+version = "0.4.0"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
### Added
- `FromBlockCipher` trait ([#164])

### Changed
- Update to 2018 edition ([#110])
- Bump `generic-array` dependency to v0.14 ([#95])

[#164]: https://github.com/RustCrypto/traits/issues/164
[#110]: https://github.com/RustCrypto/traits/issues/110
[#95]: https://github.com/RustCrypto/traits/pull/95