### PR TITLE
universal-hash v0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -295,7 +295,7 @@ checksum = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 
 [[package]]
 name = "universal-hash"
-version = "0.4.0-pre"
+version = "0.4.0"
 dependencies = [
  "generic-array 0.14.1",
  "subtle",

--- a/universal-hash/CHANGELOG.md
+++ b/universal-hash/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.0 (2020-06-04)
+### Added
+- `Key` and `Block` type aliases ([#128])
+
+### Changed
+- Split `UniversalHash` initialization into `NewUniversalHash` trait ([#135])
+- Rename `update_block` => `update` ([#129])
+- Bump `generic-array` dependency to v0.14 ([#95])
+
+[#135]: https://github.com/RustCrypto/traits/pull/135
+[#129]: https://github.com/RustCrypto/traits/pull/129
+[#128]: https://github.com/RustCrypto/traits/pull/128
+[#95]: https://github.com/RustCrypto/traits/pull/95
+
 ## 0.3.0 (2019-10-03)
 - Rename `OutputSize` -> `BlockSize` ([#57])
 

--- a/universal-hash/Cargo.toml
+++ b/universal-hash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "universal-hash"
-version = "0.4.0-pre"
+version = "0.4.0"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 description = "Trait for universal hash functions"


### PR DESCRIPTION
### Added
- `Key` and `Block` type aliases ([#128])

### Changed
- Split `UniversalHash` initialization into `NewUniversalHash` trait ([#135])
- Rename `update_block` => `update` ([#129])
- Bump `generic-array` dependency to v0.14 ([#95])

[#135]: https://github.com/RustCrypto/traits/pull/135
[#129]: https://github.com/RustCrypto/traits/pull/129
[#128]: https://github.com/RustCrypto/traits/pull/128
[#95]: https://github.com/RustCrypto/traits/pull/95