### PR TITLE
aead v0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,7 +2,7 @@
 # It is not intended for manual editing.
 [[package]]
 name = "aead"
-version = "0.3.0-pre"
+version = "0.3.0"
 dependencies = [
  "generic-array 0.14.1",
  "heapless",

--- a/aead/CHANGELOG.md
+++ b/aead/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.3.0 (2019-06-04)
+### Added
+- Type aliases for `Key`, `Nonce`, and `Tag` ([#125])
+- Optional `std` feature ([#63])
+
+### Changed
+- `NewAead` now borrows the key ([#124])
+- Split `Aead`/`AeadMut` into `AeadInPlace`/`AeadMutInPlace` ([#120])
+- Bump `generic-array` dependency to v0.14 ([#95])
+
+[#125]: https://github.com/RustCrypto/traits/pull/125
+[#124]: https://github.com/RustCrypto/traits/pull/124
+[#120]: https://github.com/RustCrypto/traits/pull/120
+[#95]: https://github.com/RustCrypto/traits/pull/95
+[#63]: https://github.com/RustCrypto/traits/pull/63
+
 ## 0.2.0 (2019-11-17)
 
 ## 0.1.2 (2019-11-17) [YANKED]

--- a/aead/Cargo.toml
+++ b/aead/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aead"
-version = "0.3.0-pre"
+version = "0.3.0"
 authors = ["RustCrypto Developers"]
 edition = "2018"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
### Added
- Type aliases for `Key`, `Nonce`, and `Tag` ([#125])
- Optional `std` feature ([#63])

### Changed
- `NewAead` now borrows the key ([#124])
- Split `Aead`/`AeadMut` into `AeadInPlace`/`AeadMutInPlace` ([#120])
- Bump `generic-array` dependency to v0.14 ([#95])

[#125]: https://github.com/RustCrypto/traits/pull/125
[#124]: https://github.com/RustCrypto/traits/pull/124
[#120]: https://github.com/RustCrypto/traits/pull/120
[#95]: https://github.com/RustCrypto/traits/pull/95
[#63]: https://github.com/RustCrypto/traits/pull/63