### PR TITLE
digest: add `FixedOutputDirty` trait + `finalize_into*`

### DIFF
--- a/digest/src/dyn_digest.rs
+++ b/digest/src/dyn_digest.rs
@@ -34,7 +34,7 @@ impl<D: Update + FixedOutput + Reset + Clone + 'static> DynDigest for D {
     }
 
     fn finalize_reset(&mut self) -> Box<[u8]> {
-        let res = self.clone().finalize_fixed().to_vec().into_boxed_slice();
+        let res = self.finalize_fixed_reset().to_vec().into_boxed_slice();
         Reset::reset(self);
         res
     }


### PR DESCRIPTION
Closes https://github.com/RustCrypto/hashes/issues/86

~~Replaces the `Reset` trait with a set of `_reset` methods on all of the various traits, and uses these as the default impl for the methods which consume hashers.~~

~~Also adds a set of methods to `FixedOutput` (`finalize_fixed_into*`) which eliminate copies by accepting an existing buffer as an argument.~~

Adds a `FixedOutputDirty` trait which writes the digest output to a provided byte array, but does not reset the internal state. This is intended for implementations to use in order to ensure that they are not reset in the event the instance is consumed.

Also adds a set of `finalize_into` and `finalize_into_reset` methods to `FixedOutput` whhich also write their input into a provided byte array, and changes the existing `finalize_fixed` (and newly added `finalize_fixed_reset`) methods to have a default implementation which returns a byte array allocated on the stack.

Finally, adds a blanket impl of `FixedOutput` for `FixedOutputDirty` + `Reset` types which handles safely invoking the underlying implementation by either consuming the instance (avoiding a reset) or borrowing the hasher, obtaining the output, and resetting.