### PR TITLE
digest v0.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,7 +89,7 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.9.0-pre"
+version = "0.9.0"
 dependencies = [
  "blobby",
  "generic-array 0.14.1",
@@ -220,7 +220,7 @@ dependencies = [
 name = "signature"
 version = "1.1.0-pre"
 dependencies = [
- "digest 0.9.0-pre",
+ "digest 0.9.0",
  "hex-literal",
  "rand_core",
  "sha2",

--- a/digest/CHANGELOG.md
+++ b/digest/CHANGELOG.md
@@ -5,6 +5,36 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.9.0 (2020-06-09)
+### Added
+- `ExtendableOutputDirty` and `VariableOutputDirty` traits ([#183])
+- `FixedOutputDirty` trait + `finalize_into*` ([#180])
+- `XofReader::read_boxed` method ([#178], [#181], [#182])
+- `alloc` feature ([#163])
+- Re-export `typenum::consts` as `consts` ([#123])
+- `Output` type alias ([#115])
+
+### Changed
+- Rename `*result*` methods to `finalize` ala IUF ([#161])
+- Use `impl AsRef<[u8]>` instead of generic params on methods ([#112])
+- Rename `Input::input` to `Update::update` ala IUF ([#111])
+- Upgrade to Rust 2018 edition ([#109])
+- Bump `generic-array` to v0.14 ([#95])
+
+[#183]: https://github.com/RustCrypto/traits/pull/183
+[#181]: https://github.com/RustCrypto/traits/pull/181
+[#182]: https://github.com/RustCrypto/traits/pull/182
+[#180]: https://github.com/RustCrypto/traits/pull/180
+[#178]: https://github.com/RustCrypto/traits/pull/178
+[#163]: https://github.com/RustCrypto/traits/pull/163
+[#161]: https://github.com/RustCrypto/traits/pull/161
+[#123]: https://github.com/RustCrypto/traits/pull/123
+[#115]: https://github.com/RustCrypto/traits/pull/115
+[#111]: https://github.com/RustCrypto/traits/pull/111
+[#112]: https://github.com/RustCrypto/traits/pull/112
+[#109]: https://github.com/RustCrypto/traits/pull/109
+[#95]: https://github.com/RustCrypto/traits/pull/95
+
 ## 0.8.1 (2019-06-30)
 
 ## 0.8.0 (2018-10-01)

--- a/digest/Cargo.toml
+++ b/digest/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "digest"
 description = "Traits for cryptographic hash functions"
-version = "0.9.0-pre"
+version = "0.9.0"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/signature/Cargo.toml
+++ b/signature/Cargo.toml
@@ -12,7 +12,7 @@ keywords      = ["crypto", "ecdsa", "ed25519", "signature", "signing"]
 categories    = ["cryptography", "no-std"]
 
 [dependencies.digest]
-version = "= 0.9.0-pre"
+version = "0.9"
 optional = true
 default-features = false
 path = "../digest"


### PR DESCRIPTION
### Added
- `ExtendableOutputDirty` and `VariableOutputDirty` traits ([#183])
- `FixedOutputDirty` trait + `finalize_into*` ([#180])
- `XofReader::read_boxed` method ([#178], [#181], [#182])
- `alloc` feature ([#163])
- Re-export `typenum::consts` as `consts` ([#123])
- `Output` type alias ([#115])

### Changed
- Rename `*result*` methods to `finalize` ala IUF ([#161])
- Use `impl AsRef<[u8]>` instead of generic params on methods ([#112])
- Rename `Input::input` to `Update::update` ala IUF ([#111])
- Upgrade to Rust 2018 edition ([#109])
- Bump `generic-array` to v0.14 ([#95])

[#183]: https://github.com/RustCrypto/traits/pull/183
[#181]: https://github.com/RustCrypto/traits/pull/181
[#182]: https://github.com/RustCrypto/traits/pull/182
[#180]: https://github.com/RustCrypto/traits/pull/180
[#178]: https://github.com/RustCrypto/traits/pull/178
[#163]: https://github.com/RustCrypto/traits/pull/163
[#161]: https://github.com/RustCrypto/traits/pull/161
[#123]: https://github.com/RustCrypto/traits/pull/123
[#115]: https://github.com/RustCrypto/traits/pull/115
[#111]: https://github.com/RustCrypto/traits/pull/111
[#112]: https://github.com/RustCrypto/traits/pull/112
[#109]: https://github.com/RustCrypto/traits/pull/109
[#95]: https://github.com/RustCrypto/traits/pull/95