### PR TITLE
signature v1.1.0

### DIFF
--- a/.github/workflows/signature.yml
+++ b/.github/workflows/signature.yml
@@ -52,5 +52,4 @@ jobs:
     - run: cargo check --all-features
     - run: cargo test --no-default-features --release
     - run: cargo test --release
-# TODO: fix support for the `digest-preview` feature
-#    - run: cargo test --all-features --release
+    - run: cargo test --all-features --release

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,14 +30,14 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.7.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
+checksum = "dbcf92448676f82bb7a334c58bbce8b0d43580fb5362a9d608b18879d12a3d31"
 dependencies = [
  "block-padding",
  "byte-tools",
  "byteorder",
- "generic-array 0.12.3",
+ "generic-array 0.14.1",
 ]
 
 [[package]]
@@ -80,18 +80,18 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
+version = "0.9.0"
 dependencies = [
- "generic-array 0.12.3",
+ "blobby",
+ "generic-array 0.14.1",
 ]
 
 [[package]]
 name = "digest"
 version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
- "blobby",
  "generic-array 0.14.1",
 ]
 
@@ -206,21 +206,21 @@ checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 
 [[package]]
 name = "sha2"
-version = "0.8.2"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a256f46ea78a0c0d9ff00077504903ac881a1dafdc20da66545699e7776b3e69"
+checksum = "72377440080fd008550fe9b441e854e43318db116f90181eef92e9ae9aedab48"
 dependencies = [
  "block-buffer",
- "digest 0.8.1",
+ "digest 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fake-simd",
  "opaque-debug",
 ]
 
 [[package]]
 name = "signature"
-version = "1.1.0-pre"
+version = "1.1.0"
 dependencies = [
- "digest 0.9.0",
+ "digest 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex-literal",
  "rand_core",
  "sha2",

--- a/signature/CHANGELOG.md
+++ b/signature/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.1.0 (2020-06-09)
+### Changed
+- Upgrade `digest` to v0.9; MSRV 1.41+ ([#186])
+
+[#186]: https://github.com/RustCrypto/traits/pull/186
+
 ## 1.0.1 (2020-04-19)
 ### Changed
 - Upgrade `signature_derive` to v1.0.0-pre.2 ([#98])

--- a/signature/Cargo.toml
+++ b/signature/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name          = "signature"
 description   = "Traits for cryptographic signature algorithms (e.g. ECDSA, Ed25519)"
-version       = "1.1.0-pre" # Also update html_root_url in lib.rs when bumping this
+version       = "1.1.0" # Also update html_root_url in lib.rs when bumping this
 authors       = ["RustCrypto Developers"]
 license       = "Apache-2.0 OR MIT"
 documentation = "https://docs.rs/signature"
@@ -15,7 +15,6 @@ categories    = ["cryptography", "no-std"]
 version = "0.9"
 optional = true
 default-features = false
-path = "../digest"
 
 [dependencies.rand_core]
 version = "0.5"
@@ -29,7 +28,7 @@ path = "derive"
 
 [dev-dependencies]
 hex-literal = "0.2"
-sha2 = { version = "0.8", default-features = false }
+sha2 = { version = "0.9", default-features = false }
 
 [features]
 default = ["std"]

--- a/signature/src/lib.rs
+++ b/signature/src/lib.rs
@@ -155,7 +155,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/ferris_signer.png",
-    html_root_url = "https://docs.rs/signature/1.1.0-pre"
+    html_root_url = "https://docs.rs/signature/1.1.0"
 )]
 #![forbid(unsafe_code)]
 #![warn(

--- a/signature/tests/signature_derive.rs
+++ b/signature/tests/signature_derive.rs
@@ -57,7 +57,7 @@ mod tests {
     impl DigestVerifier<Sha256, DummySignature> for DummyVerifier {
         fn verify_digest(&self, digest: Sha256, signature: &DummySignature) -> Result<(), Error> {
             let actual_digest = digest.finalize();
-            assert_eq!(signature.as_ref(), actual_digest.as_ref());
+            assert_eq!(signature.as_ref(), actual_digest.as_slice());
             Ok(())
         }
     }


### PR DESCRIPTION
### Changed
- Upgrade `digest` to v0.9; MSRV 1.41+ ([#186])

[#186]: https://github.com/RustCrypto/traits/pull/186