### PR TITLE
block-cipher v0.7.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "block-cipher"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "blobby",
  "generic-array 0.14.1",

--- a/block-cipher/CHANGELOG.md
+++ b/block-cipher/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.7.1 (2020-06-10)
+### Added
+- `BlockCipherMut` trait ([#179])
+
+[#179]: https://github.com/RustCrypto/traits/issues/179
+
 ## 0.7.0 (2020-06-04)
 ### Changed
 - Crate renamed from `block-cipher-trait` to `block-cipher` ([#139])

--- a/block-cipher/Cargo.toml
+++ b/block-cipher/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "block-cipher"
 description = "Traits for description of block ciphers"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
### Added
- `BlockCipherMut` trait ([#179])

[#179]: https://github.com/RustCrypto/traits/issues/179