### PR TITLE
aead v0.3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,7 +2,7 @@
 # It is not intended for manual editing.
 [[package]]
 name = "aead"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "generic-array 0.14.2",
  "heapless",

--- a/aead/CHANGELOG.md
+++ b/aead/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.3.0 (2019-06-04)
+## 0.3.1 (2020-06-12)
+### Added
+- `NewAead::new_varkey` method ([#191])
+
+[#191]: https://github.com/RustCrypto/traits/pull/191
+
+## 0.3.0 (2020-06-04)
 ### Added
 - Type aliases for `Key`, `Nonce`, and `Tag` ([#125])
 - Optional `std` feature ([#63])

--- a/aead/Cargo.toml
+++ b/aead/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aead"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["RustCrypto Developers"]
 edition = "2018"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
### Added
- `NewAead::new_varkey` method ([#191])

[#191]: https://github.com/RustCrypto/traits/pull/191