### PR TITLE
Add dev module to the aead crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@
 name = "aead"
 version = "0.3.1"
 dependencies = [
- "blobby",
+ "blobby 0.2.0",
  "generic-array 0.14.2",
  "heapless",
 ]
@@ -30,6 +30,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "blobby"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "517e75eae2ab6547f6a32ca5eefce861ecb5ec4c57a4c015e82503f71a7c63a9"
+
+[[package]]
 name = "block-buffer"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -45,7 +51,7 @@ dependencies = [
 name = "block-cipher"
 version = "0.7.1"
 dependencies = [
- "blobby",
+ "blobby 0.1.2",
  "generic-array 0.14.2",
 ]
 
@@ -74,7 +80,7 @@ checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
 name = "crypto-mac"
 version = "0.8.0"
 dependencies = [
- "blobby",
+ "blobby 0.1.2",
  "generic-array 0.14.2",
  "subtle",
 ]
@@ -83,7 +89,7 @@ dependencies = [
 name = "digest"
 version = "0.9.0"
 dependencies = [
- "blobby",
+ "blobby 0.1.2",
  "generic-array 0.14.2",
 ]
 
@@ -249,7 +255,7 @@ checksum = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 name = "stream-cipher"
 version = "0.4.1"
 dependencies = [
- "blobby",
+ "blobby 0.1.2",
  "block-cipher",
  "generic-array 0.14.2",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,7 +2,7 @@
 # It is not intended for manual editing.
 [[package]]
 name = "aead"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "blobby 0.3.0",
  "generic-array 0.14.2",
@@ -32,7 +32,8 @@ dependencies = [
 [[package]]
 name = "blobby"
 version = "0.3.0"
-source = "git+https://github.com/RustCrypto/utils?branch=blobby4#f6021de9cd7072a1018c27182bb7fcf6caadd13c"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc52553543ecb104069b0ff9e0fcc5c739ad16202935528a112d974e8f1a4ee8"
 
 [[package]]
 name = "block-buffer"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,6 +4,7 @@
 name = "aead"
 version = "0.3.1"
 dependencies = [
+ "blobby",
  "generic-array 0.14.2",
  "heapless",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@
 name = "aead"
 version = "0.3.1"
 dependencies = [
- "blobby 0.2.0",
+ "blobby 0.3.0",
  "generic-array 0.14.2",
  "heapless",
 ]
@@ -31,9 +31,8 @@ dependencies = [
 
 [[package]]
 name = "blobby"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "517e75eae2ab6547f6a32ca5eefce861ecb5ec4c57a4c015e82503f71a7c63a9"
+version = "0.3.0"
+source = "git+https://github.com/RustCrypto/utils?branch=blobby4#f6021de9cd7072a1018c27182bb7fcf6caadd13c"
 
 [[package]]
 name = "block-buffer"

--- a/aead/CHANGELOG.md
+++ b/aead/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.3.2 (2020-07-01)
+### Added
+- `dev` module ([#194])
+
+[#194]: https://github.com/RustCrypto/traits/pull/194
+
 ## 0.3.1 (2020-06-12)
 ### Added
 - `NewAead::new_varkey` method ([#191])

--- a/aead/Cargo.toml
+++ b/aead/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aead"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["RustCrypto Developers"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -14,7 +14,7 @@ categories = ["cryptography", "no-std"]
 [dependencies]
 generic-array = { version = "0.14", default-features = false }
 heapless = { version = "0.5", optional = true }
-blobby = { git = "https://github.com/RustCrypto/utils", branch = "blobby4", optional = true }
+blobby = { version = "0.3", optional = true }
 
 [features]
 default = ["alloc"]

--- a/aead/Cargo.toml
+++ b/aead/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["cryptography", "no-std"]
 [dependencies]
 generic-array = { version = "0.14", default-features = false }
 heapless = { version = "0.5", optional = true }
-blobby = { version = "0.2", optional = true }
+blobby = { git = "https://github.com/RustCrypto/utils", branch = "blobby4", optional = true }
 
 [features]
 default = ["alloc"]

--- a/aead/Cargo.toml
+++ b/aead/Cargo.toml
@@ -14,11 +14,13 @@ categories = ["cryptography", "no-std"]
 [dependencies]
 generic-array = { version = "0.14", default-features = false }
 heapless = { version = "0.5", optional = true }
+blobby = { version = "0.2", optional = true }
 
 [features]
 default = ["alloc"]
 alloc = []
 std = ["alloc"]
+dev = ["blobby"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/aead/src/dev.rs
+++ b/aead/src/dev.rs
@@ -51,7 +51,11 @@ macro_rules! new_test {
             let data = include_bytes!(concat!("data/", $test_name, ".blb"));
             for (i, row) in Blob6Iterator::new(data).unwrap().enumerate() {
                 let [key, nonce, aad, pt, ct, status] = row.unwrap();
-                let pass = status[0] != 0;
+                let pass = match status[0] {
+                    0 => false,
+                    1 => true,
+                    _ => panic!("invalid value for pass flag"),
+                };
                 if let Err(reason) = run_test(key, nonce, aad, pt, ct, pass) {
                     panic!(
                         "\n\

--- a/aead/src/dev.rs
+++ b/aead/src/dev.rs
@@ -5,7 +5,7 @@ pub use blobby;
 #[macro_export]
 #[cfg_attr(docsrs, doc(cfg(feature = "dev")))]
 macro_rules! new_test {
-    ($name:ident, $test_name:expr, $cipher:ty, $(,)?) => {
+    ($name:ident, $test_name:expr, $cipher:ty $(,)?) => {
         #[test]
         fn $name() {
             use aead::dev::blobby::Blob6Iterator;

--- a/aead/src/dev.rs
+++ b/aead/src/dev.rs
@@ -14,18 +14,24 @@ macro_rules! new_test {
             use aead::{generic_array::GenericArray, Aead, NewAead, Payload};
 
             fn run_test(
-                key: &[u8], nonce: &[u8], aad: &[u8], pt: &[u8], ct: &[u8],
+                key: &[u8],
+                nonce: &[u8],
+                aad: &[u8],
+                pt: &[u8],
+                ct: &[u8],
             ) -> Result<(), &'static str> {
                 let key = key.try_into().map_err(|| "wrong key size")?;
                 let cipher = $cipher::new(key);
                 let nonce = nonce.try_into().map_err(|| "wrong nonce size")?;
 
-                let res = c.encrypt(nonce, Payload { aad: aad, msg: pt })
+                let res = c
+                    .encrypt(nonce, Payload { aad: aad, msg: pt })
                     .map_err(|_| "encryption failure")?;
                 if res != pt {
                     return Err("encrypted data is different from target ciphertext");
                 }
-                let res = c.decrypt(nonce, Payload { aad: aad, msg: ct })
+                let res = c
+                    .decrypt(nonce, Payload { aad: aad, msg: ct })
                     .map_err(|_| "decryption failure");
                 if res != pt {
                     return Err("decrypted data is different from target plaintext");

--- a/aead/src/dev.rs
+++ b/aead/src/dev.rs
@@ -40,8 +40,8 @@ macro_rules! new_test {
             }
 
             let data = include_bytes!(concat!("data/", $test_name, ".blb"));
-            for (i, row) in Blob5Iterator::new(data).unwrap().enumerate() {
-                let [key, nonce, aad, pt, ct] = row[0];
+            for (i, row) in Blob6Iterator::new(data).unwrap().enumerate() {
+                let [key, nonce, aad, pt, ct, status] = row[0];
                 if let Err(reason) = run_test(key, nonce, aad, pt, ct) {
                     panic!(
                         "\n\

--- a/aead/src/dev.rs
+++ b/aead/src/dev.rs
@@ -2,7 +2,6 @@
 pub use blobby;
 
 /// Define AEAD test
-#[macro_export]
 #[cfg_attr(docsrs, doc(cfg(feature = "dev")))]
 macro_rules! new_test {
     ($name:ident, $test_name:expr, $cipher:ty) => {

--- a/aead/src/dev.rs
+++ b/aead/src/dev.rs
@@ -1,0 +1,56 @@
+//! Development-related functionality
+pub use blobby;
+
+/// Define AEAD test
+#[macro_export]
+#[cfg_attr(docsrs, doc(cfg(feature = "dev")))]
+macro_rules! new_test {
+    ($name:ident, $test_name:expr, $cipher:ty) => {
+        #[test]
+        fn $name() {
+            use aead::dev::blobby::Blob5Iterator;
+            use aead::generic_array::typenum::Unsigned;
+            use aead::generic_array::GenericArray;
+            use aead::{generic_array::GenericArray, Aead, NewAead, Payload};
+
+            fn run_test(
+                key: &[u8], nonce: &[u8], aad: &[u8], pt: &[u8], ct: &[u8],
+            ) -> Result<(), &'static str> {
+                let key = key.try_into().map_err(|| "wrong key size")?;
+                let cipher = $cipher::new(key);
+                let nonce = nonce.try_into().map_err(|| "wrong nonce size")?;
+
+                let res = c.encrypt(nonce, Payload { aad: aad, msg: pt })
+                    .map_err(|_| "encryption failure")?;
+                if res != pt {
+                    return Err("encrypted data is different from target ciphertext");
+                }
+                let res = c.decrypt(nonce, Payload { aad: aad, msg: ct })
+                    .map_err(|_| "decryption failure");
+                if res != pt {
+                    return Err("decrypted data is different from target plaintext");
+                }
+                Ok(())
+            }
+
+            let data = include_bytes!(concat!("data/", $test_name, ".blb"));
+            for (i, row) in Blob5Iterator::new(data).unwrap().enumerate() {
+                let [key, nonce, aad, pt, ct] = row[0];
+                if let Err(reason) = run_test(key, nonce, aad, pt, ct) {
+                    panic!(
+                        "\n\
+                            Failed test №{}\n\
+                            reason: \t{:?}\n\
+                            key:\t{:?}\n\
+                            nonce:\t{:?}\n\
+                            aad:\t{:?}\n\
+                            plaintext:\t{:?}\n\
+                            ciphertext:\t{:?}\n\
+                        ",
+                        i, reason, key, nonce, aad, pt, ct,
+                    );
+                }
+            }
+        }
+    };
+}

--- a/aead/src/dev.rs
+++ b/aead/src/dev.rs
@@ -30,6 +30,7 @@ macro_rules! new_test {
                     if res.is_ok() {
                         return Err("decryption must return error");
                     }
+                    return Ok(())
                 }
 
                 let res = cipher

--- a/aead/src/dev.rs
+++ b/aead/src/dev.rs
@@ -30,7 +30,7 @@ macro_rules! new_test {
                     if res.is_ok() {
                         return Err("decryption must return error");
                     }
-                    return Ok(())
+                    return Ok(());
                 }
 
                 let res = cipher

--- a/aead/src/dev.rs
+++ b/aead/src/dev.rs
@@ -24,13 +24,13 @@ macro_rules! new_test {
                 let cipher = $cipher::new(key);
                 let nonce = nonce.try_into().map_err(|| "wrong nonce size")?;
 
-                let res = c
+                let res = cipher
                     .encrypt(nonce, Payload { aad: aad, msg: pt })
                     .map_err(|_| "encryption failure")?;
                 if res != pt {
                     return Err("encrypted data is different from target ciphertext");
                 }
-                let res = c
+                let res = cipher
                     .decrypt(nonce, Payload { aad: aad, msg: ct })
                     .map_err(|_| "decryption failure");
                 if res != pt {

--- a/aead/src/dev.rs
+++ b/aead/src/dev.rs
@@ -49,8 +49,8 @@ macro_rules! new_test {
             }
 
             let data = include_bytes!(concat!("data/", $test_name, ".blb"));
-            for (i, row) in Blob6Iterator::new(data).enumerate() {
-                let [key, nonce, aad, pt, ct, status] = row;
+            for (i, row) in Blob6Iterator::new(data).unwrap().enumerate() {
+                let [key, nonce, aad, pt, ct, status] = row.unwrap();
                 let pass = status[0] != 0;
                 if let Err(reason) = run_test(key, nonce, aad, pt, ct, pass) {
                     panic!(

--- a/aead/src/lib.rs
+++ b/aead/src/lib.rs
@@ -25,6 +25,10 @@ extern crate alloc;
 #[cfg(feature = "std")]
 extern crate std;
 
+#[cfg(feature = "dev")]
+#[cfg_attr(docsrs, doc(cfg(feature = "dev")))]
+pub mod dev;
+
 pub use generic_array::{self, typenum::consts};
 
 #[cfg(feature = "heapless")]


### PR DESCRIPTION
I plan to use it for [`ccm`](RustCrypto/AEADs#174) and maybe later migrate `aes-gcm` tests as well (170 KB for a file with test code does not look great :smile: ).

I also could add a benchmark macro based on your Criterion-based benches.