### PR TITLE
`cryptography` facade crate

### DIFF
--- a/.github/workflows/cryptography.yml
+++ b/.github/workflows/cryptography.yml
@@ -1,0 +1,55 @@
+name: cryptography
+
+on:
+  pull_request:
+    paths:
+      - "cryptography/**"
+      - "Cargo.*"
+  push:
+    branches: master
+
+defaults:
+  run:
+    working-directory: cryptography
+
+env:
+  CARGO_INCREMENTAL: 0
+  RUSTFLAGS: "-Dwarnings"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - 1.41.0 # MSRV
+          - stable
+        target:
+          - thumbv7em-none-eabi
+          - wasm32-unknown-unknown
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          target: ${{ matrix.target }}
+          override: true
+      - run: cargo build --no-default-features --release --target ${{ matrix.target }}
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - 1.41.0 # MSRV
+          - stable
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: ${{ matrix.rust }}
+    - run: cargo check --all-features
+    - run: cargo test --no-default-features --release
+    - run: cargo test --release
+    - run: cargo test --all-features --release

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,6 +76,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "cryptography"
+version = "0.1.0"
+dependencies = [
+ "aead",
+ "block-cipher",
+ "crypto-mac",
+ "digest 0.9.0",
+ "signature",
+ "stream-cipher",
+ "universal-hash",
+]
+
+[[package]]
 name = "digest"
 version = "0.9.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "aead",
     "block-cipher",
     "crypto-mac",
+    "cryptography",
     "digest",
     "signature",
     "stream-cipher",

--- a/README.md
+++ b/README.md
@@ -4,15 +4,21 @@ Collection of traits which describe functionality of cryptographic primitives.
 
 ## Crates
 
-| Name               | Algorithm                     | Crates.io | Documentation  | Build |
-|--------------------|-------------------------------|-----------|----------------|-------|
+| Crate name         | Algorithm                     | Crates.io | Docs  | Build Status |
+|--------------------|-------------------------------|-----------|-------|--------------|
 | [`aead`]           | [Authenticated encryption]    | [![crates.io](https://img.shields.io/crates/v/aead.svg)](https://crates.io/crates/aead) | [![Documentation](https://docs.rs/aead/badge.svg)](https://docs.rs/aead) | ![build](https://github.com/RustCrypto/traits/workflows/aead/badge.svg?branch=master&event=push) |
-| [`block‑cipher`] | [Block cipher]            | [![crates.io](https://img.shields.io/crates/v/block-cipher.svg)](https://crates.io/crates/block-cipher) | [![Documentation](https://docs.rs/block-cipher/badge.svg)](https://docs.rs/block-cipher) | ![build](https://github.com/RustCrypto/traits/workflows/block-cipher/badge.svg?branch=master&event=push) |
+| [`block‑cipher`]   | [Block cipher]                | [![crates.io](https://img.shields.io/crates/v/block-cipher.svg)](https://crates.io/crates/block-cipher) | [![Documentation](https://docs.rs/block-cipher/badge.svg)](https://docs.rs/block-cipher) | ![build](https://github.com/RustCrypto/traits/workflows/block-cipher/badge.svg?branch=master&event=push) |
 | [`crypto‑mac`]     | [Message authentication code] | [![crates.io](https://img.shields.io/crates/v/crypto-mac.svg)](https://crates.io/crates/crypto-mac) | [![Documentation](https://docs.rs/crypto-mac/badge.svg)](https://docs.rs/crypto-mac) | ![build](https://github.com/RustCrypto/traits/workflows/crypto-mac/badge.svg?branch=master&event=push) |
 | [`digest`]         | [Cryptographic hash function] | [![crates.io](https://img.shields.io/crates/v/digest.svg)](https://crates.io/crates/digest) | [![Documentation](https://docs.rs/digest/badge.svg)](https://docs.rs/digest) | ![build](https://github.com/RustCrypto/traits/workflows/digest/badge.svg?branch=master&event=push) |
 | [`signature`]      | [Digital signature]           | [![crates.io](https://img.shields.io/crates/v/signature.svg)](https://crates.io/crates/signature) | [![Documentation](https://docs.rs/signature/badge.svg)](https://docs.rs/signature) | ![build](https://github.com/RustCrypto/traits/workflows/signature/badge.svg?branch=master&event=push) |
 | [`stream‑cipher`]  | [Stream cipher]               | [![crates.io](https://img.shields.io/crates/v/stream-cipher.svg)](https://crates.io/crates/stream-cipher) | [![Documentation](https://docs.rs/stream-cipher/badge.svg)](https://docs.rs/stream-cipher) | ![build](https://github.com/RustCrypto/traits/workflows/stream-cipher/badge.svg?branch=master&event=push) |
 | [`universal‑hash`] | [Universal hash function]     | [![crates.io](https://img.shields.io/crates/v/universal-hash.svg)](https://crates.io/crates/universal-hash) | [![Documentation](https://docs.rs/universal-hash/badge.svg)](https://docs.rs/universal-hash) | ![build](https://github.com/RustCrypto/traits/workflows/universal-hash/badge.svg?branch=master&event=push) |
+
+### Additional crates
+
+| Crate name       | Description | Crates.io | Docs  | Build Status |
+|------------------|-------------|-----------|-------|--------------|
+| [`cryptography`] | Facade for trait crates | [![crates.io](https://img.shields.io/crates/v/cryptography.svg)](https://crates.io/crates/cryptography) | [![Documentation](https://docs.rs/cryptography/badge.svg)](https://docs.rs/cryptography) | ![build](https://github.com/RustCrypto/traits/workflows/cryptography/badge.svg?branch=master&event=push)
 
 ### Minimum Supported Rust Version
 
@@ -45,6 +51,7 @@ dual licensed as above, without any additional terms or conditions.
 [`aead`]: https://github.com/RustCrypto/traits/tree/master/aead
 [`block‑cipher`]: https://github.com/RustCrypto/traits/tree/master/block-cipher
 [`crypto‑mac`]: https://github.com/RustCrypto/traits/tree/master/crypto-mac
+[`cryptography`]: https://github.com/RustCrypto/traits/tree/master/cryptography
 [`digest`]: https://github.com/RustCrypto/traits/tree/master/digest
 [`signature`]: https://github.com/RustCrypto/traits/tree/master/signature
 [`stream‑cipher`]: https://github.com/RustCrypto/traits/tree/master/stream-cipher

--- a/cryptography/Cargo.toml
+++ b/cryptography/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "cryptography"
+version = "0.1.0"
+authors = ["The RustCrypto Project Developers"]
+license = "Apache-2.0 OR MIT"
+description = "Facade crate for the RustCrypto project's traits"
+documentation = "https://docs.rs/cryptography"
+repository = "https://github.com/RustCrypto/traits"
+keywords = ["crypto", "encryption", "rustcrypto"]
+categories = ["cryptography", "no-std"]
+readme = "README.md"
+edition = "2018"
+
+[dependencies]
+aead = { version = "0.3", optional = true, path = "../aead" }
+block-cipher = { version = "0.7", optional = true, path = "../block-cipher" }
+crypto-mac = { version = "0.8", optional = true, path = "../crypto-mac" }
+digest = { version = "0.9", optional = true, path = "../digest" }
+signature = { version = "1.1.0", optional = true, default-features = false, path = "../signature" }
+stream-cipher = { version = "0.4", optional = true, path = "../stream-cipher" }
+universal-hash = { version = "0.4", optional = true, path = "../universal-hash" }
+
+[package.metadata.docs.rs]
+all-features = true

--- a/cryptography/LICENSE-APACHE
+++ b/cryptography/LICENSE-APACHE
@@ -1,0 +1,202 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+

--- a/cryptography/LICENSE-MIT
+++ b/cryptography/LICENSE-MIT
@@ -1,0 +1,25 @@
+Copyright (c) 2020 The RustCrypto Project Developers
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/cryptography/README.md
+++ b/cryptography/README.md
@@ -1,0 +1,54 @@
+# RustCrypto: `cryptography` crate
+
+[![crate][crate-image]][crate-link]
+[![Docs][docs-image]][docs-link]
+![Apache2/MIT licensed][license-image]
+![Rust Version][rustc-image]
+[![Build Status][build-image]][build-link]
+
+Facade crate for [RustCrypto Traits][1], providing a single place to
+access compatible versions of all traits from the Rust Crypto project.
+
+[Documentation][docs-link]
+
+## Minimum Supported Rust Version
+
+Rust **1.41** or higher.
+
+Minimum supported Rust version can be changed in the future, but it will be
+done with a minor version bump.
+
+## SemVer Policy
+
+- All on-by-default features of this library are covered by SemVer
+- MSRV is considered exempt from SemVer as noted above
+
+## License
+
+Licensed under either of:
+
+ * [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0)
+ * [MIT license](http://opensource.org/licenses/MIT)
+
+at your option.
+
+### Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally submitted
+for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
+dual licensed as above, without any additional terms or conditions.
+
+[//]: # (badges)
+
+[crate-image]: https://img.shields.io/crates/v/cryptography.svg
+[crate-link]: https://crates.io/crates/cryptography
+[docs-image]: https://docs.rs/cryptography/badge.svg
+[docs-link]: https://docs.rs/cryptography/
+[license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.41+-blue.svg
+[build-image]: https://github.com/RustCrypto/traits/workflows/cryptography/badge.svg?branch=master&event=push
+[build-link]: https://github.com/RustCrypto/traits/actions?query=workflow%3Acryptography
+
+[//]: # (footnotes)
+
+[1]: https://github.com/RustCrypto/traits

--- a/cryptography/src/lib.rs
+++ b/cryptography/src/lib.rs
@@ -1,0 +1,60 @@
+//! Facade crate for [RustCrypto Traits][1], providing a single place to
+//! access compatible versions of all traits from the Rust Crypto project.
+//!
+//! # About
+//!
+//! The [RustCrypto Project][2] publishes and maintains independently versioned
+//! crates containing traits for many different kinds of cryptographic
+//! algorithms.
+//!
+//! However, these algorithms are often interdependent (e.g. many depend on digest
+//! algorithms), which requires figuring out which versions of the trait crates
+//! are compatible with each other.
+//!
+//! This crate will automatically pull in compatible versions of these crates,
+//! with each one gated under a cargo feature, providing a single place to both
+//! import and upgrade these crates while ensuring they remain compatible.
+//!
+//! # Traits
+//!
+//! - [`aead`] - Authenticated Encryption with Associated Data
+//!   (i.e. high-level symmetric encryption)
+//! - [`block_cipher`] - block-based cryptographic permutations
+//!   (i.e. low-level symmetric encryption)
+//! - [`mac`] - message authentication codes (i.e. symmetric message
+//!   authentication)
+//! - [`digest`] - cryptographic hash functions
+//! - [`signature`] - digital signatures (i.e. public key-based message
+//!   authentication)
+//! - [`stream_cipher`] - ciphers based on randomly generated keystreams
+//!   (i.e. low-level symmetric encryption)
+//! - [`universal_hash`] - universal hash functions (used to build MACs)
+//!
+//! [1]: https://github.com/RustCrypto/traits
+//! [2]: https://github.com/RustCrypto
+
+#![no_std]
+#![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png")]
+#![forbid(unsafe_code)]
+#![warn(rust_2018_idioms)]
+
+#[cfg(feature = "aead")]
+pub use aead;
+
+#[cfg(feature = "block-cipher")]
+pub use block_cipher;
+
+#[cfg(feature = "crypto-mac")]
+pub use crypto_mac as mac;
+
+#[cfg(feature = "digest")]
+pub use digest;
+
+#[cfg(feature = "signature")]
+pub use signature;
+
+#[cfg(feature = "stream-cipher")]
+pub use stream_cipher;
+
+#[cfg(feature = "universal-hash")]
+pub use universal_hash;


### PR DESCRIPTION
I've been given ownership of the [`cryptography`](https://crates.io/crates/cryptography) crate! 🎉 

This PR contains my suggested usage of it. If this sounds useful, I'll add @RustCrypto/traits as an owner.

---

Adds a `cryptography` crate which re-exports compatible versions of the other trait crates as a facade.

This should simplify cases where it's necessary to combine several cryptographic algorithms, by ensuring you have a single import to get compatible versions.