### PR TITLE
cryptography: add explicit rustdoc links

### DIFF
--- a/cryptography/src/lib.rs
+++ b/cryptography/src/lib.rs
@@ -32,6 +32,14 @@
 //!
 //! [1]: https://github.com/RustCrypto/traits
 //! [2]: https://github.com/RustCrypto
+//!
+//! [`aead`]: https://docs.rs/aead
+//! [`block_cipher`]: https://docs.rs/block-cipher
+//! [`mac`]: https://docs.rs/crypto-mac
+//! [`digest`]: https://docs.rs/digest
+//! [`signature`]: https://docs.rs/signature
+//! [`stream_cipher`]: https://docs.rs/stream-cipher
+//! [`universal_hash`]: https://docs.rs/universal-hash
 
 #![no_std]
 #![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png")]


### PR DESCRIPTION
For whatever reason https://docs.rs did not render the links to the various trait crates (despite `cargo +nightly doc` rendering them fine for me).

https://docs.rs/cryptography/0.1.1/cryptography/

<img width="833" alt="Screen Shot 2020-06-21 at 8 25 06 AM" src="https://user-images.githubusercontent.com/797/85228653-6be8ab80-b399-11ea-8af5-cc9fbcc261c2.png">

Even stranger still, there was one exception: it was happy with the `signature` crate (possibly because it's post-1.0?)

Regardless, this commit adds direct links for the various crates to https://docs.rs so users can easily find the relevant documentation.