### PR TITLE
cryptography v0.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,7 +77,7 @@ dependencies = [
 
 [[package]]
 name = "cryptography"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "aead",
  "block-cipher",

--- a/cryptography/CHANGELOG.md
+++ b/cryptography/CHANGELOG.md
@@ -5,5 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.2 (2020-06-21)
+### Fixed
+- Rustdoc link rendering for https://docs.rs ([#200]) 
+
+[#200]: https://github.com/RustCrypto/traits/pull/200
+
 ## 0.1.1 (2020-06-21)
 - Initial release

--- a/cryptography/Cargo.toml
+++ b/cryptography/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cryptography"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["The RustCrypto Project Developers"]
 license = "Apache-2.0 OR MIT"
 description = "Facade crate for the RustCrypto project's traits"


### PR DESCRIPTION
### Fixed
- Rustdoc link rendering for https://docs.rs ([#200]) 

[#200]: https://github.com/RustCrypto/traits/pull/200