### PR TITLE
cryptography: add `mac` feature; put docs in table

### DIFF
--- a/.github/workflows/cryptography.yml
+++ b/.github/workflows/cryptography.yml
@@ -35,7 +35,8 @@ jobs:
           toolchain: ${{ matrix.rust }}
           target: ${{ matrix.target }}
           override: true
-      - run: cargo build --no-default-features --release --target ${{ matrix.target }}
+      - run: cargo build --release --target ${{ matrix.target }}
+      - run: cargo build --all-features --release --target ${{ matrix.target }}
   test:
     runs-on: ubuntu-latest
     strategy:

--- a/cryptography/Cargo.toml
+++ b/cryptography/Cargo.toml
@@ -14,11 +14,8 @@ edition = "2018"
 [dependencies]
 aead = { version = "0.3", optional = true, path = "../aead" }
 block-cipher = { version = "0.7", optional = true, path = "../block-cipher" }
-crypto-mac = { version = "0.8", optional = true, path = "../crypto-mac" }
 digest = { version = "0.9", optional = true, path = "../digest" }
+mac = { version = "0.8", package = "crypto-mac", optional = true, path = "../crypto-mac" }
 signature = { version = "1.1.0", optional = true, default-features = false, path = "../signature" }
 stream-cipher = { version = "0.4", optional = true, path = "../stream-cipher" }
 universal-hash = { version = "0.4", optional = true, path = "../universal-hash" }
-
-[package.metadata.docs.rs]
-all-features = true

--- a/cryptography/src/lib.rs
+++ b/cryptography/src/lib.rs
@@ -15,22 +15,21 @@
 //! with each one gated under a cargo feature, providing a single place to both
 //! import and upgrade these crates while ensuring they remain compatible.
 //!
-//! # Traits
+//! # Trait re-exports
 //!
-//! - [`aead`](https://docs.rs/aead) -
-//!   Authenticated Encryption with Associated Data (i.e. high-level symmetric encryption)
-//! - [`block_cipher`](https://docs.rs/block-cipher) -
-//!   block-based cryptographic permutations (i.e. low-level symmetric encryption)
-//! - [`mac`](https://docs.rs/crypto-mac) -
-//!   message authentication codes (i.e. symmetric message authentication)
-//! - [`digest`](https://docs.rs/digest) -
-//!   cryptographic hash functions
-//! - [`signature`](https://docs.rs/signature) -
-//!   digital signatures (i.e. public key-based message authentication)
-//! - [`stream_cipher`](https://docs.rs/stream-cipher) -
-//!   ciphers based on randomly generated keystreams (i.e. low-level symmetric encryption)
-//! - [`universal_hash`](https://docs.rs/universal-hash) -
-//!   universal hash functions (used to build MACs)
+//! Below are the re-exports of the various RustCrypto crates available through
+//! this crate's facade. To access a particular re-export you (or a crate you
+//! depend on) must enable the associated Cargo feature named below.
+//!
+//! | Module name | Cargo feature | Description |
+//! |-------------|---------------|-------------|
+//! | [`aead`](https://docs.rs/aead) | `aead` | Authenticated Encryption with Associated Data (i.e. high-level symmetric encryption) |
+//! | [`block_cipher`](https://docs.rs/block-cipher) | `block-cipher` | Block-based cryptographic permutations (i.e. low-level symmetric encryption) |
+//! | [`digest`](https://docs.rs/digest) | `digest` | Cryptographic hash functions |
+//! | [`mac`](https://docs.rs/crypto-mac) | `mac` | Message Authentication Codes (i.e. symmetric message authentication) |
+//! | [`signature`](https://docs.rs/signature) | `signature` | Digital signatures (i.e. public key-based message authentication) |
+//! | [`stream_cipher`](https://docs.rs/stream-cipher) | `stream-cipher` | Ciphers based on randomly generated keystreams (i.e. low-level symmetric encryption) |
+//! | [`universal_hash`](https://docs.rs/universal-hash) | `universal-hash` | Universal Hash Functions (used to build MACs) |
 //!
 //! [1]: https://github.com/RustCrypto/traits
 //! [2]: https://github.com/RustCrypto
@@ -46,11 +45,11 @@ pub use aead;
 #[cfg(feature = "block-cipher")]
 pub use block_cipher;
 
-#[cfg(feature = "crypto-mac")]
-pub use crypto_mac as mac;
-
 #[cfg(feature = "digest")]
 pub use digest;
+
+#[cfg(feature = "mac")]
+pub use mac;
 
 #[cfg(feature = "signature")]
 pub use signature;


### PR DESCRIPTION
Imports `crypto-mac` as `mac` via a `package` directive in Cargo.toml rather than re-exporting it under another name.

Reorganizes the rustdoc into a table which shows both the module name and associated Cargo feature.