### PR TITLE
cryptography v0.1.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,7 +77,7 @@ dependencies = [
 
 [[package]]
 name = "cryptography"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "aead",
  "block-cipher",

--- a/cryptography/CHANGELOG.md
+++ b/cryptography/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.4 (2020-06-21)
+### Added
+- rustdoc improvements ([#205])
+- `mac` feature ([#204])
+
+[#205]: https://github.com/RustCrypto/traits/pull/205
+[#204]: https://github.com/RustCrypto/traits/pull/204
+
 ## 0.1.3 (2020-06-21)
 ### Fixed
 - Link rendering on https://docs.rs ([#202]) 

--- a/cryptography/Cargo.toml
+++ b/cryptography/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cryptography"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["The RustCrypto Project Developers"]
 license = "Apache-2.0 OR MIT"
 description = "Facade crate for the RustCrypto project's traits"


### PR DESCRIPTION
### Added
- rustdoc improvements ([#205])
- `mac` feature ([#204])

[#205]: https://github.com/RustCrypto/traits/pull/205
[#204]: https://github.com/RustCrypto/traits/pull/204