### PR TITLE
Add NonceSize to FromBlockCipher

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,7 +45,7 @@ dependencies = [
 name = "block-cipher"
 version = "0.7.1"
 dependencies = [
- "blobby 0.1.2",
+ "blobby 0.2.0",
  "generic-array 0.14.2",
 ]
 
@@ -71,14 +71,14 @@ checksum = "6d375c433320f6c5057ae04a04376eef4d04ce2801448cf8863a78da99107be4"
 name = "crypto-mac"
 version = "0.8.0"
 dependencies = [
- "blobby 0.1.2",
+ "blobby 0.2.0",
  "generic-array 0.14.2",
  "subtle",
 ]
 
 [[package]]
 name = "cryptography"
-version = "0.1.4"
+version = "0.2.0"
 dependencies = [
  "aead",
  "block-cipher",
@@ -93,7 +93,7 @@ dependencies = [
 name = "digest"
 version = "0.9.0"
 dependencies = [
- "blobby 0.1.2",
+ "blobby 0.2.0",
  "generic-array 0.14.2",
 ]
 
@@ -252,9 +252,9 @@ checksum = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 
 [[package]]
 name = "stream-cipher"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
- "blobby 0.1.2",
+ "blobby 0.2.0",
  "block-cipher",
  "generic-array 0.14.2",
 ]

--- a/cryptography/CHANGELOG.md
+++ b/cryptography/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.0 (2020-07-03)
+### Changed
+- Bump `stream-cipher` to v0.5 ([#209])
+
+[#209]: https://github.com/RustCrypto/traits/pull/209
+
 ## 0.1.4 (2020-06-21)
 ### Added
 - rustdoc improvements ([#205])

--- a/cryptography/Cargo.toml
+++ b/cryptography/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cryptography"
-version = "0.1.4"
+version = "0.2.0"
 authors = ["The RustCrypto Project Developers"]
 license = "Apache-2.0 OR MIT"
 description = "Facade crate for the RustCrypto project's traits"
@@ -17,7 +17,7 @@ block-cipher = { version = "0.7", optional = true, path = "../block-cipher" }
 digest = { version = "0.9", optional = true, path = "../digest" }
 mac = { version = "0.8", package = "crypto-mac", optional = true, path = "../crypto-mac" }
 signature = { version = "1.1.0", optional = true, default-features = false, path = "../signature" }
-stream-cipher = { version = "0.4", optional = true, path = "../stream-cipher" }
+stream-cipher = { version = "0.5", optional = true, path = "../stream-cipher" }
 universal-hash = { version = "0.4", optional = true, path = "../universal-hash" }
 
 [package.metadata.docs.rs]

--- a/stream-cipher/CHANGELOG.md
+++ b/stream-cipher/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.5.0 (2020-07-03)
+### Changed
+- Add `NonceSize` associated type to the `FromBlockCipher` trait ([#209])
+
+[#209]: https://github.com/RustCrypto/traits/pull/209
+
 ## 0.4.1 (2020-06-10)
 ### Added
 - `Key` and `Nonce` type aliases ([#188])

--- a/stream-cipher/Cargo.toml
+++ b/stream-cipher/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "stream-cipher"
 description = "Stream cipher traits"
-version = "0.4.1"
+version = "0.5.0"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
@@ -21,6 +21,7 @@ optional = true
 path = "../block-cipher"
 
 [features]
+default = ["block-cipher"]
 std = []
 dev = ["blobby"]
 


### PR DESCRIPTION
This change is needed for RustCrypto/block-ciphers#134. GOST modes are somewhat peculiar  as they allow additional flexibility, thus breaking the assumption used in the `FromBlockCipher` trait. Additionally this PR improves the blanket impl by overwriting the `new_var` method.

Unfortunately it's a breaking change, so a minor release will be needed.