### PR TITLE
Add blanket trait impls for references

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,7 +45,7 @@ dependencies = [
 name = "block-cipher"
 version = "0.8.0"
 dependencies = [
- "blobby 0.2.0",
+ "blobby 0.3.0",
  "generic-array 0.14.2",
 ]
 
@@ -254,7 +254,7 @@ checksum = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 name = "stream-cipher"
 version = "0.6.0"
 dependencies = [
- "blobby 0.2.0",
+ "blobby 0.3.0",
  "block-cipher",
  "generic-array 0.14.2",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,7 +43,7 @@ dependencies = [
 
 [[package]]
 name = "block-cipher"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "blobby 0.2.0",
  "generic-array 0.14.2",
@@ -252,7 +252,7 @@ checksum = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 
 [[package]]
 name = "stream-cipher"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "blobby 0.2.0",
  "block-cipher",

--- a/block-cipher/Cargo.toml
+++ b/block-cipher/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "block-cipher"
 description = "Traits for description of block ciphers"
-version = "0.7.1"
+version = "0.8.0"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/block-cipher/Cargo.toml
+++ b/block-cipher/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["cryptography", "no-std"]
 
 [dependencies]
 generic-array = "0.14"
-blobby = { version = "0.2", optional = true }
+blobby = { version = "0.3", optional = true }
 
 [features]
 std = []

--- a/block-cipher/src/dev.rs
+++ b/block-cipher/src/dev.rs
@@ -73,30 +73,28 @@ macro_rules! new_test {
             let pb = <$cipher as BlockCipher>::ParBlocks::to_usize();
             let data = include_bytes!(concat!("data/", $test_name, ".blb"));
             for (i, row) in Blob3Iterator::new(data).unwrap().enumerate() {
-                let key = row[0];
-                let plaintext = row[1];
-                let ciphertext = row[2];
-                if !run_test(key, plaintext, ciphertext) {
+                let [key, pt, ct] = row.unwrap();
+                if !run_test(key, pt, ct) {
                     panic!(
                         "\n\
                          Failed test №{}\n\
                          key:\t{:?}\n\
                          plaintext:\t{:?}\n\
                          ciphertext:\t{:?}\n",
-                        i, key, plaintext, ciphertext,
+                        i, key, pt, ct,
                     );
                 }
 
                 // test parallel blocks encryption/decryption
                 if pb != 1 {
-                    if !run_par_test(key, plaintext) {
+                    if !run_par_test(key, pt) {
                         panic!(
                             "\n\
                              Failed parallel test №{}\n\
                              key:\t{:?}\n\
                              plaintext:\t{:?}\n\
                              ciphertext:\t{:?}\n",
-                            i, key, plaintext, ciphertext,
+                            i, key, pt, ct,
                         );
                     }
                 }

--- a/block-cipher/src/lib.rs
+++ b/block-cipher/src/lib.rs
@@ -118,12 +118,12 @@ pub trait BlockCipherMut {
 impl<Alg: BlockCipher> BlockCipherMut for Alg {
     type BlockSize = Alg::BlockSize;
 
-    /// Encrypt block in-place
+    #[inline]
     fn encrypt_block(&mut self, block: &mut GenericArray<u8, Self::BlockSize>) {
         <Self as BlockCipher>::encrypt_block(self, block);
     }
 
-    /// Decrypt block in-place
+    #[inline]
     fn decrypt_block(&mut self, block: &mut GenericArray<u8, Self::BlockSize>) {
         <Self as BlockCipher>::decrypt_block(self, block);
     }
@@ -135,21 +135,21 @@ impl<Alg: BlockCipher> BlockCipher for &Alg {
 
     #[inline]
     fn encrypt_block(&self, block: &mut Block<Self>) {
-        Alg::encrypt_block(*self, block);
+        Alg::encrypt_block(self, block);
     }
 
     #[inline]
     fn decrypt_block(&self, block: &mut Block<Self>) {
-        Alg::decrypt_block(*self, block);
+        Alg::decrypt_block(self, block);
     }
 
     #[inline]
     fn encrypt_blocks(&self, blocks: &mut ParBlocks<Self>) {
-        Alg::encrypt_blocks(*self, blocks);
+        Alg::encrypt_blocks(self, blocks);
     }
 
     #[inline]
     fn decrypt_blocks(&self, blocks: &mut ParBlocks<Self>) {
-        Alg::decrypt_blocks(*self, blocks);
+        Alg::decrypt_blocks(self, blocks);
     }
 }

--- a/block-cipher/src/lib.rs
+++ b/block-cipher/src/lib.rs
@@ -128,3 +128,28 @@ impl<Alg: BlockCipher> BlockCipherMut for Alg {
         <Self as BlockCipher>::decrypt_block(self, block);
     }
 }
+
+impl<Alg: BlockCipher> BlockCipher for &Alg {
+    type BlockSize = Alg::BlockSize;
+    type ParBlocks = Alg::ParBlocks;
+
+    #[inline]
+    fn encrypt_block(&self, block: &mut Block<Self>) {
+        Alg::encrypt_block(*self, block);
+    }
+
+    #[inline]
+    fn decrypt_block(&self, block: &mut Block<Self>) {
+        Alg::decrypt_block(*self, block);
+    }
+
+    #[inline]
+    fn encrypt_blocks(&self, blocks: &mut ParBlocks<Self>) {
+        Alg::encrypt_blocks(*self, blocks);
+    }
+
+    #[inline]
+    fn decrypt_blocks(&self, blocks: &mut ParBlocks<Self>) {
+        Alg::decrypt_blocks(*self, blocks);
+    }
+}

--- a/cryptography/Cargo.toml
+++ b/cryptography/Cargo.toml
@@ -13,11 +13,11 @@ edition = "2018"
 
 [dependencies]
 aead = { version = "0.3", optional = true, path = "../aead" }
-block-cipher = { version = "0.7", optional = true, path = "../block-cipher" }
+block-cipher = { version = "0.8", optional = true, path = "../block-cipher" }
 digest = { version = "0.9", optional = true, path = "../digest" }
 mac = { version = "0.8", package = "crypto-mac", optional = true, path = "../crypto-mac" }
 signature = { version = "1.1.0", optional = true, default-features = false, path = "../signature" }
-stream-cipher = { version = "0.5", optional = true, path = "../stream-cipher" }
+stream-cipher = { version = "0.6", optional = true, path = "../stream-cipher" }
 universal-hash = { version = "0.4", optional = true, path = "../universal-hash" }
 
 [package.metadata.docs.rs]

--- a/stream-cipher/Cargo.toml
+++ b/stream-cipher/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "stream-cipher"
 description = "Stream cipher traits"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
@@ -16,7 +16,7 @@ generic-array = "0.14"
 blobby = { version = "0.2", optional = true }
 
 [dependencies.block-cipher]
-version = "0.7"
+version = "0.8"
 optional = true
 path = "../block-cipher"
 

--- a/stream-cipher/Cargo.toml
+++ b/stream-cipher/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["cryptography", "no-std"]
 
 [dependencies]
 generic-array = "0.14"
-blobby = { version = "0.2", optional = true }
+blobby = { version = "0.3", optional = true }
 
 [dependencies.block-cipher]
 version = "0.8"

--- a/stream-cipher/src/dev.rs
+++ b/stream-cipher/src/dev.rs
@@ -54,7 +54,7 @@ macro_rules! new_seek_test {
 
             let data = include_bytes!(concat!("data/", $test_name, ".blb"));
             for (i, row) in Blob4Iterator::new(data).unwrap().enumerate() {
-                let [key, iv ,pt, ct] = row.unwrap();
+                let [key, iv, pt, ct] = row.unwrap();
 
                 let mut mode = <$cipher>::new_var(key, iv).unwrap();
                 let pl = pt.len();

--- a/stream-cipher/src/lib.rs
+++ b/stream-cipher/src/lib.rs
@@ -125,6 +125,18 @@ impl<C: SyncStreamCipher> StreamCipher for C {
     }
 }
 
+impl<C: SyncStreamCipher> SyncStreamCipher for &mut C {
+    #[inline]
+    fn apply_keystream(&mut self, data: &mut [u8]) {
+        C::apply_keystream(self, data);
+    }
+
+    #[inline]
+    fn try_apply_keystream(&mut self, data: &mut [u8]) -> Result<(), LoopError> {
+        C::try_apply_keystream(self, data)
+    }
+}
+
 /// Trait for initializing a stream cipher from a block cipher
 #[cfg(feature = "block-cipher")]
 #[cfg_attr(docsrs, doc(cfg(feature = "block-cipher")))]


### PR DESCRIPTION
Closes RustCrypto/MACs#47

IIUC strictly speaking these changes are not backwards compatible, since downstream crates may define their own trait implementations for references. I wonder if we can overlook it and release these changes under patch releases.

Unfortunately it's not possible to write `impl<Alg: BlockCipherMut> BlockCipherMut for &mut Alg { .. }`, since it potentially conflicts with `impl<Alg: BlockCipher> BlockCipherMut for Alg { .. }`. Same goes for `StreamCipher`, which conflicts with the `SyncStreamCipher` impl. I think it's impossible to solve this problem without negative trait bounds, which are not even on horizon. Specialization may help, but I failed to make it work.