### PR TITLE
elliptic-curve: remove dev-dependency on `hex`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,7 +112,6 @@ name = "elliptic-curve"
 version = "0.4.0"
 dependencies = [
  "generic-array 0.14.3",
- "hex",
  "rand_core",
  "subtle",
  "zeroize",
@@ -166,12 +165,6 @@ dependencies = [
  "hash32",
  "stable_deref_trait",
 ]
-
-[[package]]
-name = "hex"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "644f9158b2f133fd50f5fb3242878846d9eb792e445c893805ff0e3824006e35"
 
 [[package]]
 name = "hex-literal"

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -33,9 +33,6 @@ version = "1"
 optional = true
 default-features = false
 
-[dev-dependencies]
-hex = "0.4"
-
 [features]
 default = []
 weierstrass = []


### PR DESCRIPTION
It's not used in this crate