### PR TITLE
elliptic-curve: bump version to v0.5.0-pre

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,7 +109,7 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.4.0"
+version = "0.5.0-pre"
 dependencies = [
  "generic-array 0.14.3",
  "rand_core",

--- a/cryptography/Cargo.toml
+++ b/cryptography/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 aead = { version = "0.3", optional = true, path = "../aead" }
 block-cipher = { version = "0.8", optional = true, path = "../block-cipher" }
 digest = { version = "0.9", optional = true, path = "../digest" }
-elliptic-curve = { version = "0.4", optional = true, path = "../elliptic-curve" }
+elliptic-curve = { version = "= 0.5.0-pre", optional = true, path = "../elliptic-curve" }
 mac = { version = "0.8", package = "crypto-mac", optional = true, path = "../crypto-mac" }
 signature = { version = "1.1.0", optional = true, default-features = false, path = "../signature" }
 stream-cipher = { version = "0.6", optional = true, path = "../stream-cipher" }

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -5,7 +5,7 @@ General purpose Elliptic Curve Cryptography (ECC) support, including types
 and traits for representing various elliptic curve forms, scalars, points,
 and public/secret keys composed thereof.
 """
-version       = "0.4.0" # Also update html_root_url in lib.rs when bumping this
+version       = "0.5.0-pre" # Also update html_root_url in lib.rs when bumping this
 authors       = ["RustCrypto Developers"]
 license       = "Apache-2.0 OR MIT"
 documentation = "https://docs.rs/elliptic-curve"


### PR DESCRIPTION
This commit isn't intended to be a release, but just bumps the version number in Cargo.toml to a `-pre` to distinguish it from the currently released v0.4.0.

Several backwards incompatible / semver breaking changes have been introduced since the release.