### PR TITLE
elliptic-curve: add `Arithmetic` trait

### DIFF
--- a/elliptic-curve/src/weierstrass/curve.rs
+++ b/elliptic-curve/src/weierstrass/curve.rs
@@ -16,5 +16,14 @@ pub trait Curve: Clone + Debug + Default + Eq + Ord + Send + Sync {
     type ScalarSize: ArrayLength<u8> + Add + Add<U1> + Eq + Ord + Unsigned;
 }
 
+/// Curve arithmetic support
+pub trait Arithmetic: Curve {
+    /// Scalar type for a given curve
+    type Scalar;
+
+    /// Affine point type for a given curve
+    type AffinePoint;
+}
+
 /// Alias for [`SecretKey`] type for a given Weierstrass curve
 pub type SecretKey<C> = crate::secret_key::SecretKey<<C as Curve>::ScalarSize>;


### PR DESCRIPTION
Several potentially useful traits (including the ECDSA ones) need access to these types, so it's helpful to have a single trait that defines them as associated types.

Some additional bounds would really be helpful, but we can add those as they come up in practice.