### PR TITLE
elliptic-curve: simplify GenerateSecretKey signature

### DIFF
--- a/elliptic-curve/src/weierstrass.rs
+++ b/elliptic-curve/src/weierstrass.rs
@@ -42,5 +42,5 @@ where
 pub trait GenerateSecretKey: Curve {
     /// Generate a random [`SecretKey`] for this elliptic curve using the
     /// provided [`CryptoRng`]
-    fn generate_secret_key(rng: &mut (impl CryptoRng + RngCore)) -> SecretKey<Self::ScalarSize>;
+    fn generate_secret_key(rng: impl CryptoRng + RngCore) -> SecretKey<Self::ScalarSize>;
 }


### PR DESCRIPTION
Removes the reference requirement on the argument, since the `rand_core` traits are impl'd for reference types