### PR TITLE
elliptic-curve: simplify `FixedBaseScalarMul` trait

### DIFF
--- a/elliptic-curve/src/weierstrass.rs
+++ b/elliptic-curve/src/weierstrass.rs
@@ -8,28 +8,16 @@ pub use self::{
     public_key::PublicKey,
 };
 
-use crate::{consts::U1, ScalarBytes};
-use core::ops::Add;
-use generic_array::ArrayLength;
-use subtle::{ConditionallySelectable, CtOption};
+use crate::{Arithmetic, ScalarBytes};
+use subtle::CtOption;
 
 /// Marker trait for elliptic curves in short Weierstrass form
 pub trait Curve: super::Curve {}
 
 /// Fixed-base scalar multiplication
-pub trait FixedBaseScalarMul: Curve
-where
-    Self::ElementSize: Add<U1>,
-    <Self::ElementSize as Add>::Output: Add<U1>,
-    CompressedPoint<Self>: From<Self::AffinePoint>,
-    UncompressedPoint<Self>: From<Self::AffinePoint>,
-    CompressedPointSize<Self>: ArrayLength<u8>,
-    UncompressedPointSize<Self>: ArrayLength<u8>,
-{
-    /// Affine point type for this elliptic curve
-    type AffinePoint: ConditionallySelectable;
-
+pub trait FixedBaseScalarMul: Curve + Arithmetic {
     /// Multiply the given scalar by the generator point for this elliptic
     /// curve.
+    // TODO(tarcieri): use `Self::Scalar` for the `scalar` param
     fn mul_base(scalar: &ScalarBytes<Self>) -> CtOption<Self::AffinePoint>;
 }

--- a/elliptic-curve/src/weierstrass/public_key.rs
+++ b/elliptic-curve/src/weierstrass/public_key.rs
@@ -5,7 +5,7 @@ use super::{
     point::{CompressedPoint, CompressedPointSize, UncompressedPoint, UncompressedPointSize},
     Curve, FixedBaseScalarMul,
 };
-use crate::SecretKey;
+use crate::{Error, SecretKey};
 use core::fmt::{self, Debug};
 use core::ops::Add;
 use generic_array::{
@@ -116,19 +116,19 @@ where
     /// Compute the [`PublicKey`] for the provided [`SecretKey`].
     ///
     /// The `compress` flag requests point compression.
-    pub fn from_secret_key(secret_key: &SecretKey<C>, compress: bool) -> Option<Self> {
+    pub fn from_secret_key(secret_key: &SecretKey<C>, compress: bool) -> Result<Self, Error> {
         let ct_option = C::mul_base(secret_key.secret_scalar());
 
         if ct_option.is_some().into() {
             let affine_point = ct_option.unwrap();
 
             if compress {
-                Some(PublicKey::Compressed(affine_point.into()))
+                Ok(PublicKey::Compressed(affine_point.into()))
             } else {
-                Some(PublicKey::Uncompressed(affine_point.into()))
+                Ok(PublicKey::Uncompressed(affine_point.into()))
             }
         } else {
-            None
+            Err(Error)
         }
     }
 }


### PR DESCRIPTION
Most of the previous bounds are now irrelevant, and it can now also leverage the `Arithmetic` trait for the `AffinePoint` definition.