### PR TITLE
elliptic-curve: add `Invert` trait

### DIFF
--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -22,6 +22,7 @@
 extern crate std;
 
 pub mod error;
+pub mod ops;
 pub mod secret_key;
 
 // TODO(tarcieri): other curve forms

--- a/elliptic-curve/src/ops.rs
+++ b/elliptic-curve/src/ops.rs
@@ -1,0 +1,12 @@
+//! Traits for arithmetic operations on elliptic curve field elements
+
+use subtle::CtOption;
+
+/// Perform an inversion on a field element (i.e. base field element or scalar)
+pub trait Invert {
+    /// Field element type
+    type Output;
+
+    /// Invert a field element.
+    fn invert(&self) -> CtOption<Self::Output>;
+}


### PR DESCRIPTION
Add a trait for performing scalar/field inversions.

The main motivation for this is to allow for things like `BlindedScalar` type which use random blinding for either efficiency reasons (to allow a vartime inversion) and/or as a side-channel defense.