### PR TITLE
elliptic-curve: add FromPublicKey/FromSecretKey traits

### DIFF
--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -30,7 +30,10 @@ pub mod secret_key;
 #[cfg_attr(docsrs, doc(cfg(feature = "weierstrass")))]
 pub mod weierstrass;
 
-pub use self::{error::Error, secret_key::SecretKey};
+pub use self::{
+    error::Error,
+    secret_key::{FromSecretKey, SecretKey},
+};
 pub use generic_array::{self, typenum::consts};
 pub use subtle;
 
@@ -62,13 +65,13 @@ pub trait Curve: Clone + Debug + Default + Eq + Ord + Send + Sync {
 /// Elliptic curve with curve arithmetic support
 pub trait Arithmetic: Curve {
     /// Scalar type for a given curve
-    type Scalar;
+    type Scalar: FromSecretKey<Self>;
 
     /// Affine point type for a given curve
     type AffinePoint;
 }
 
-/// Trait for randomly generating a value.
+/// Randomly generate a value.
 ///
 /// Primarily intended for use with scalar types for a particular curve.
 #[cfg(feature = "rand_core")]

--- a/elliptic-curve/src/secret_key.rs
+++ b/elliptic-curve/src/secret_key.rs
@@ -13,6 +13,7 @@ use core::{
     fmt::{self, Debug},
 };
 use generic_array::{typenum::Unsigned, GenericArray};
+use subtle::CtOption;
 
 #[cfg(feature = "rand_core")]
 use {
@@ -88,4 +89,12 @@ impl<C: Curve> Drop for SecretKey<C> {
         use zeroize::Zeroize;
         self.scalar.zeroize();
     }
+}
+
+/// Trait for deserializing a value from a secret key.
+///
+/// This is intended for use with the `Scalar` type for a given elliptic curve.
+pub trait FromSecretKey<C: Curve>: Sized {
+    /// Deserialize this value from a [`SecretKey`]
+    fn from_secret_key(secret_key: &SecretKey<C>) -> CtOption<Self>;
 }

--- a/elliptic-curve/src/weierstrass.rs
+++ b/elliptic-curve/src/weierstrass.rs
@@ -5,7 +5,7 @@ pub mod public_key;
 
 pub use self::{
     point::{CompressedPoint, CompressedPointSize, UncompressedPoint, UncompressedPointSize},
-    public_key::PublicKey,
+    public_key::{FromPublicKey, PublicKey},
 };
 
 use crate::{Arithmetic, ScalarBytes};

--- a/elliptic-curve/src/weierstrass/public_key.rs
+++ b/elliptic-curve/src/weierstrass/public_key.rs
@@ -12,6 +12,7 @@ use generic_array::{
     typenum::{Unsigned, U1},
     ArrayLength, GenericArray,
 };
+use subtle::CtOption;
 
 /// Size of an untagged point for given elliptic curve.
 pub type UntaggedPointSize<C> = <<C as crate::Curve>::ElementSize as Add>::Output;
@@ -191,4 +192,22 @@ where
     fn from(point: UncompressedPoint<C>) -> Self {
         PublicKey::Uncompressed(point)
     }
+}
+
+/// Trait for deserializing a value from a public key.
+///
+/// This is intended for use with the `AffinePoint` type for a given elliptic curve.
+pub trait FromPublicKey<C: Curve>: Sized
+where
+    C::ElementSize: Add<U1>,
+    <C::ElementSize as Add>::Output: Add<U1>,
+    CompressedPointSize<C>: ArrayLength<u8>,
+    UncompressedPointSize<C>: ArrayLength<u8>,
+{
+    /// Deserialize this value from a [`PublicKey`]
+    ///
+    /// # Returns
+    ///
+    /// `None` if the public key is not on the curve.
+    fn from_public_key(public_key: &PublicKey<C>) -> CtOption<Self>;
 }


### PR DESCRIPTION
These traits allow converting:

- SecretKey => Scalar
- PublicKey => AffinePoint

...in a curve-agnostic way.