### PR TITLE
elliptic-curve: replace FixedBaseScalarMul with ops::MulBase

### DIFF
--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -30,10 +30,7 @@ pub mod secret_key;
 #[cfg_attr(docsrs, doc(cfg(feature = "weierstrass")))]
 pub mod weierstrass;
 
-pub use self::{
-    error::Error,
-    secret_key::{FromSecretKey, SecretKey},
-};
+pub use self::{error::Error, secret_key::SecretKey};
 pub use generic_array::{self, typenum::consts};
 pub use subtle;
 
@@ -42,6 +39,7 @@ pub use rand_core;
 
 use core::{fmt::Debug, ops::Add};
 use generic_array::{typenum::Unsigned, ArrayLength, GenericArray};
+use subtle::ConditionallySelectable;
 
 #[cfg(feature = "rand_core")]
 use rand_core::{CryptoRng, RngCore};
@@ -65,10 +63,13 @@ pub trait Curve: Clone + Debug + Default + Eq + Ord + Send + Sync {
 /// Elliptic curve with curve arithmetic support
 pub trait Arithmetic: Curve {
     /// Scalar type for a given curve
-    type Scalar: FromSecretKey<Self>;
+    type Scalar: ConditionallySelectable
+        + Default
+        + secret_key::FromSecretKey<Self>
+        + ops::MulBase<Output = Self::AffinePoint>;
 
     /// Affine point type for a given curve
-    type AffinePoint;
+    type AffinePoint: ConditionallySelectable;
 }
 
 /// Randomly generate a value.

--- a/elliptic-curve/src/ops.rs
+++ b/elliptic-curve/src/ops.rs
@@ -10,3 +10,12 @@ pub trait Invert {
     /// Invert a field element.
     fn invert(&self) -> CtOption<Self::Output>;
 }
+
+/// Fixed-base scalar multiplication
+pub trait MulBase {
+    /// Affine point type
+    type Output;
+
+    /// Multiply this value by the generator point for the elliptic curve
+    fn mul_base(&self) -> CtOption<Self::Output>;
+}

--- a/elliptic-curve/src/weierstrass.rs
+++ b/elliptic-curve/src/weierstrass.rs
@@ -8,16 +8,5 @@ pub use self::{
     public_key::{FromPublicKey, PublicKey},
 };
 
-use crate::{Arithmetic, ScalarBytes};
-use subtle::CtOption;
-
 /// Marker trait for elliptic curves in short Weierstrass form
 pub trait Curve: super::Curve {}
-
-/// Fixed-base scalar multiplication
-pub trait FixedBaseScalarMul: Curve + Arithmetic {
-    /// Multiply the given scalar by the generator point for this elliptic
-    /// curve.
-    // TODO(tarcieri): use `Self::Scalar` for the `scalar` param
-    fn mul_base(scalar: &ScalarBytes<Self>) -> CtOption<Self::AffinePoint>;
-}


### PR DESCRIPTION
`FixedBaseScalarMul` was a hack around the lack of an associated `Scalar` type on a curve and generic way of converting a `SecretKey` to a `Scalar`.

We have both of those things, so this commit replaces it with an `ops::MulBase` trait intended to be impl'd on `Scalar` types.

Further, it bounds the `Arithmetic::Scalar` associated type on this, which allows it to be used for generic `SecretKey` -> `PublicKey` conversions.

It also means the `Arithmetic` trait now has a(n implicit) way of representing the generator point, making it genuinely useful for generic arithmetic operations. This would also be useful for e.g. a generic implementation of Diffie-Hellman.