### PR TITLE
signature: remove RNG generic parameter from RandomizedSigner

### DIFF
--- a/signature/src/signer.rs
+++ b/signature/src/signer.rs
@@ -66,13 +66,9 @@ where
 /// Sign the given message using the provided external randomness source.
 #[cfg(feature = "rand-preview")]
 #[cfg_attr(docsrs, doc(cfg(feature = "rand-preview")))]
-pub trait RandomizedSigner<R, S>
-where
-    R: CryptoRng + RngCore,
-    S: Signature,
-{
+pub trait RandomizedSigner<S: Signature> {
     /// Sign the given message and return a digital signature
-    fn sign_with_rng(&self, rng: &mut R, msg: &[u8]) -> S {
+    fn sign_with_rng(&self, rng: impl CryptoRng + RngCore, msg: &[u8]) -> S {
         self.try_sign_with_rng(rng, msg)
             .expect("signature operation failed")
     }
@@ -82,5 +78,5 @@ where
     ///
     /// The main intended use case for signing errors is when communicating
     /// with external signers, e.g. cloud KMS, HSMs, or other hardware tokens.
-    fn try_sign_with_rng(&self, rng: &mut R, msg: &[u8]) -> Result<S, Error>;
+    fn try_sign_with_rng(&self, rng: impl CryptoRng + RngCore, msg: &[u8]) -> Result<S, Error>;
 }


### PR DESCRIPTION
...replacing it with `impl CryptoRng + RngCore` parameter.

This is a SemVer breaking change, however per our policy around `*-preview` features, it will receive a minor version bump as these features are not part of the SemVer guarantees of this crate.

The rationale for this change is the exact RNG method doesn't matter, especially to the point it needs to be a generic parameter of the trait signature.