### PR TITLE
signature v1.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -236,7 +236,7 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "digest 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex-literal",

--- a/signature/CHANGELOG.md
+++ b/signature/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.2.0 (2020-07-29)
+### Removed
+- RNG generic parameter `R` from `RandomizedSigner` ([#231])
+
+[#231]: https://github.com/RustCrypto/traits/pull/231
+
 ## 1.1.0 (2020-06-09)
 ### Changed
 - Upgrade `digest` to v0.9; MSRV 1.41+ ([#186])

--- a/signature/Cargo.toml
+++ b/signature/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name          = "signature"
 description   = "Traits for cryptographic signature algorithms (e.g. ECDSA, Ed25519)"
-version       = "1.1.0" # Also update html_root_url in lib.rs when bumping this
+version       = "1.2.0" # Also update html_root_url in lib.rs when bumping this
 authors       = ["RustCrypto Developers"]
 license       = "Apache-2.0 OR MIT"
 documentation = "https://docs.rs/signature"

--- a/signature/src/lib.rs
+++ b/signature/src/lib.rs
@@ -5,7 +5,7 @@
 //!
 //! ## Minimum Supported Rust Version
 //!
-//! Rust **1.36** or higher.
+//! Rust **1.41** or higher.
 //!
 //! Minimum supported Rust version may be changed in the future, but such
 //! changes will be accompanied with a minor version bump.
@@ -155,7 +155,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/ferris_signer.png",
-    html_root_url = "https://docs.rs/signature/1.1.0"
+    html_root_url = "https://docs.rs/signature/1.2.0"
 )]
 #![forbid(unsafe_code)]
 #![warn(


### PR DESCRIPTION
### Removed
- RNG generic parameter `R` from `RandomizedSigner` ([#231])

[#231]: https://github.com/RustCrypto/traits/pull/231