### PR TITLE
elliptic-curve: re-export `zeroize`

### DIFF
--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -37,6 +37,9 @@ pub use subtle;
 #[cfg(feature = "rand_core")]
 pub use rand_core;
 
+#[cfg(feature = "zeroize")]
+pub use zeroize;
+
 use core::{fmt::Debug, ops::Add};
 use generic_array::{typenum::Unsigned, ArrayLength, GenericArray};
 use subtle::ConditionallySelectable;


### PR DESCRIPTION
Useful for conditionally zeroizing long-lived secret `Scalar` values