### PR TITLE
signature v1.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -236,7 +236,7 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "digest 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex-literal",

--- a/signature/CHANGELOG.md
+++ b/signature/CHANGELOG.md
@@ -4,11 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 1.2.0 (2020-07-29)
+## 1.2.1 (2020-07-29)
 ### Removed
 - RNG generic parameter `R` from `RandomizedSigner` ([#231])
 
 [#231]: https://github.com/RustCrypto/traits/pull/231
+
+## 1.2.0 (2020-07-29) [YANKED]
+- Note: this release was published without the intended changes
 
 ## 1.1.0 (2020-06-09)
 ### Changed

--- a/signature/Cargo.toml
+++ b/signature/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name          = "signature"
 description   = "Traits for cryptographic signature algorithms (e.g. ECDSA, Ed25519)"
-version       = "1.2.0" # Also update html_root_url in lib.rs when bumping this
+version       = "1.2.1" # Also update html_root_url in lib.rs when bumping this
 authors       = ["RustCrypto Developers"]
 license       = "Apache-2.0 OR MIT"
 documentation = "https://docs.rs/signature"

--- a/signature/src/lib.rs
+++ b/signature/src/lib.rs
@@ -155,7 +155,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/ferris_signer.png",
-    html_root_url = "https://docs.rs/signature/1.2.0"
+    html_root_url = "https://docs.rs/signature/1.2.1"
 )]
 #![forbid(unsafe_code)]
 #![warn(


### PR DESCRIPTION
#232 did not properly include the changes from #231. Looks like Squash + Merge incorporated them, but I published off the branch (which I tend to do in case the branch contains something that would be rejected by the crates.io API).

This republishes it with the changes correctly included, after which I'll yank v1.2.0.