### PR TITLE
elliptic-curve: change MulBase trait to be impl'd on point types

### DIFF
--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -66,13 +66,10 @@ pub trait Curve: Clone + Debug + Default + Eq + Ord + Send + Sync {
 /// Elliptic curve with curve arithmetic support
 pub trait Arithmetic: Curve {
     /// Scalar type for a given curve
-    type Scalar: ConditionallySelectable
-        + Default
-        + secret_key::FromSecretKey<Self>
-        + ops::MulBase<Output = Self::AffinePoint>;
+    type Scalar: ConditionallySelectable + Default + secret_key::FromSecretKey<Self>;
 
     /// Affine point type for a given curve
-    type AffinePoint: ConditionallySelectable;
+    type AffinePoint: ConditionallySelectable + ops::MulBase<Scalar = Self::Scalar>;
 }
 
 /// Randomly generate a value.

--- a/elliptic-curve/src/ops.rs
+++ b/elliptic-curve/src/ops.rs
@@ -11,11 +11,13 @@ pub trait Invert {
     fn invert(&self) -> CtOption<Self::Output>;
 }
 
-/// Fixed-base scalar multiplication
-pub trait MulBase {
-    /// Affine point type
-    type Output;
+/// Fixed-base scalar multiplication.
+///
+/// This trait is intended to be implemented on a point type.
+pub trait MulBase: Sized {
+    /// Scalar type
+    type Scalar;
 
-    /// Multiply this value by the generator point for the elliptic curve
-    fn mul_base(&self) -> CtOption<Self::Output>;
+    /// Multiply scalar by the generator point for the elliptic curve
+    fn mul_base(scalar: &Self::Scalar) -> CtOption<Self>;
 }

--- a/elliptic-curve/src/weierstrass/public_key.rs
+++ b/elliptic-curve/src/weierstrass/public_key.rs
@@ -118,7 +118,8 @@ where
     ///
     /// The `compress` flag requests point compression.
     pub fn from_secret_key(secret_key: &SecretKey<C>, compress: bool) -> Result<Self, Error> {
-        let ct_option = C::Scalar::from_secret_key(&secret_key).and_then(|s| s.mul_base());
+        let ct_option =
+            C::Scalar::from_secret_key(&secret_key).and_then(|s| C::AffinePoint::mul_base(&s));
 
         if ct_option.is_none().into() {
             return Err(Error);


### PR DESCRIPTION
This makes the `MulBase` trait a static method for point types, which takes an associated scalar type as an associated parameter.

This allows multiple impls on both `AffinePoint` and `ProjectivePoint`.