### PR TITLE
elliptic-curve: basic OID support

### DIFF
--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -22,6 +22,7 @@
 extern crate std;
 
 pub mod error;
+pub mod oid;
 pub mod ops;
 pub mod secret_key;
 
@@ -30,7 +31,7 @@ pub mod secret_key;
 #[cfg_attr(docsrs, doc(cfg(feature = "weierstrass")))]
 pub mod weierstrass;
 
-pub use self::{error::Error, secret_key::SecretKey};
+pub use self::{error::Error, oid::ObjectIdentifier, secret_key::SecretKey};
 pub use generic_array::{self, typenum::consts};
 pub use subtle;
 
@@ -70,6 +71,12 @@ pub trait Arithmetic: Curve {
 
     /// Affine point type for a given curve
     type AffinePoint: ConditionallySelectable + ops::MulBase<Scalar = Self::Scalar>;
+}
+
+/// Associate an object identifier (OID) with a curve
+pub trait Identifier: Curve {
+    /// Object Identifier (OID) for this curve
+    const OID: ObjectIdentifier;
 }
 
 /// Randomly generate a value.

--- a/elliptic-curve/src/oid.rs
+++ b/elliptic-curve/src/oid.rs
@@ -1,0 +1,48 @@
+//! Object identifiers (OIDs)
+
+use core::fmt;
+
+/// Object identifier (OID)
+pub struct ObjectIdentifier(&'static [u32]);
+
+impl ObjectIdentifier {
+    /// Create a new OID
+    pub const fn new(nodes: &'static [u32]) -> Self {
+        // TODO(tarcieri): validate nodes
+        Self(nodes)
+    }
+}
+
+impl AsRef<[u32]> for ObjectIdentifier {
+    fn as_ref(&self) -> &[u32] {
+        self.0
+    }
+}
+
+impl fmt::Display for ObjectIdentifier {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for (i, node) in self.0.iter().enumerate() {
+            write!(f, "{}", node)?;
+
+            if i < self.0.len() - 1 {
+                write!(f, ".")?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(all(test, std))]
+mod tests {
+    use super::ObjectIdentifier;
+    use std::string::ToString;
+
+    const EXAMPLE_OID: ObjectIdentifier = ObjectIdentifier::new(&[1, 2, 840, 10045, 3, 1, 7]);
+
+    #[test]
+    fn display_test() {
+        let oid = EXAMPLE_OID.to_string();
+        assert_eq!(oid, "1.2.840.10045.3.1.7");
+    }
+}


### PR DESCRIPTION
Adds a (very simple, const-and-no_std-friendly) `ObjectIdentifier` type and an `Identifier` trait for attaching an OID to a curve.

No validation of the nodes is presently performed (and since it's impl'd as a `const fn`, it'd require a MSRV bump to do so). Also requires the OID be specified as an array literal: no parsing is supported for either string or binary-encoded OIDs.

Only string serialization is supported for now (via `Display`). A `no_std`-friendly binary serializer will be somewhat tricky.