### PR TITLE
elliptic-curve: NonZeroScalar + Generator (replaces MulBase)

### DIFF
--- a/elliptic-curve/src/ops.rs
+++ b/elliptic-curve/src/ops.rs
@@ -10,14 +10,3 @@ pub trait Invert {
     /// Invert a field element.
     fn invert(&self) -> CtOption<Self::Output>;
 }
-
-/// Fixed-base scalar multiplication.
-///
-/// This trait is intended to be implemented on a point type.
-pub trait MulBase: Sized {
-    /// Scalar type
-    type Scalar;
-
-    /// Multiply scalar by the generator point for the elliptic curve
-    fn mul_base(scalar: &Self::Scalar) -> CtOption<Self>;
-}

--- a/elliptic-curve/src/point.rs
+++ b/elliptic-curve/src/point.rs
@@ -1,0 +1,7 @@
+//! Traits for elliptic curve points
+
+/// Obtain the generator point.
+pub trait Generator {
+    /// Get the generator point for this elliptic curve
+    fn generator() -> Self;
+}

--- a/elliptic-curve/src/scalar.rs
+++ b/elliptic-curve/src/scalar.rs
@@ -1,0 +1,51 @@
+//! Scalar types
+
+use crate::{Arithmetic, Curve};
+use subtle::{ConstantTimeEq, CtOption};
+
+#[cfg(feature = "zeroize")]
+use zeroize::Zeroize;
+
+/// Non-zero scalar type.
+///
+/// This type ensures that its value is not zero, ala `core::num::NonZero*`.
+/// To do this, the generic `S` type must impl both `Default` and
+/// `ConstantTimeEq`, with the requirement that `S::default()` returns 0.
+///
+/// In the context of ECC, it's useful for ensuring that scalar multiplication
+/// cannot result in the point at infinity.
+pub struct NonZeroScalar<C: Curve + Arithmetic> {
+    scalar: C::Scalar,
+}
+
+impl<C> NonZeroScalar<C>
+where
+    C: Curve + Arithmetic,
+{
+    /// Create a [`NonZeroScalar`] from a scalar, performing a constant-time
+    /// check that it's non-zero.
+    pub fn new(scalar: C::Scalar) -> CtOption<Self> {
+        let is_zero = scalar.ct_eq(&C::Scalar::default());
+        CtOption::new(Self { scalar }, !is_zero)
+    }
+}
+
+impl<C> AsRef<C::Scalar> for NonZeroScalar<C>
+where
+    C: Curve + Arithmetic,
+{
+    fn as_ref(&self) -> &C::Scalar {
+        &self.scalar
+    }
+}
+
+#[cfg(feature = "zeroize")]
+impl<C> Zeroize for NonZeroScalar<C>
+where
+    C: Curve + Arithmetic,
+    C::Scalar: Zeroize,
+{
+    fn zeroize(&mut self) {
+        self.scalar.zeroize();
+    }
+}


### PR DESCRIPTION
Adds a `NonZeroScalar` type generic over curves along with a `Generator` trait which together with the `Mul` trait from `core` can replace the `MulBase` trait.

`NonZeroScalar` is able to use the bounds on `Arithmetic::Scalar` and therefore usable anywhere a `Scalar` otherwise would, but with the guarantee that multiplication by an `AffinePoint` will not result in the point at infinity, for which no `AffinePoint` representation is possible given current trait bounds/implementations.

cc @fjarri