### PR TITLE
elliptic-curve: add weierstrass::PublicKey::compress

### DIFF
--- a/elliptic-curve/src/weierstrass/point.rs
+++ b/elliptic-curve/src/weierstrass/point.rs
@@ -171,6 +171,16 @@ where
     pub fn into_bytes(self) -> GenericArray<u8, UncompressedPointSize<C>> {
         self.bytes
     }
+
+    /// Get the x-coordinate of this curve point
+    pub(crate) fn x(&self) -> &ScalarBytes<C> {
+        GenericArray::from_slice(&self.bytes[1..(C::ElementSize::to_usize() + 1)])
+    }
+
+    /// Get the y-coordinate of this curve point
+    pub(crate) fn y(&self) -> &ScalarBytes<C> {
+        GenericArray::from_slice(&self.bytes[(C::ElementSize::to_usize() + 1)..])
+    }
 }
 
 impl<C: Curve> AsRef<[u8]> for UncompressedPoint<C>

--- a/elliptic-curve/src/weierstrass/public_key.rs
+++ b/elliptic-curve/src/weierstrass/public_key.rs
@@ -99,6 +99,15 @@ where
         PublicKey::Uncompressed(UncompressedPoint::from_bytes(tagged_bytes).unwrap())
     }
 
+    /// Compress this [`PublicKey`].
+    ///
+    /// If the key is already compressed, this is a no-op.
+    pub fn compress(&mut self) {
+        if let PublicKey::Uncompressed(point) = self {
+            *self = CompressedPoint::from_affine_coords(point.x(), point.y()).into();
+        }
+    }
+
     /// Obtain public key as a byte array reference
     #[inline]
     pub fn as_bytes(&self) -> &[u8] {


### PR DESCRIPTION
Generic point compression support for SEC-1 encoded public keys