### PR TITLE
elliptic-curve: derive Clone on SecretKey

### DIFF
--- a/elliptic-curve/src/secret_key.rs
+++ b/elliptic-curve/src/secret_key.rs
@@ -26,6 +26,7 @@ use {
 /// This type wraps a serialized scalar value, helping to prevent accidental
 /// exposure and securely erasing the value from memory when dropped
 /// (when the `zeroize` feature of this crate is enabled).
+#[derive(Clone)]
 pub struct SecretKey<C: Curve> {
     /// Private scalar value
     scalar: ScalarBytes<C>,


### PR DESCRIPTION
SecretKey is auto-zeroizing. While cloning it isn't ideal, we have a strategy for automatically cleaning up afterward.

Cloning SecretKey came up in practice in the `k256` crate (PR forthcoming).