### PR TITLE
elliptic-curve: rename `ScalarBytes` => `ElementBytes`

### DIFF
--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -102,4 +102,4 @@ pub trait Generate {
 }
 
 /// Byte array containing a serialized scalar value (i.e. an integer)
-pub type ScalarBytes<C> = GenericArray<u8, <C as Curve>::ElementSize>;
+pub type ElementBytes<C> = GenericArray<u8, <C as Curve>::ElementSize>;

--- a/elliptic-curve/src/secret_key.rs
+++ b/elliptic-curve/src/secret_key.rs
@@ -1,13 +1,13 @@
 //! Secret keys for elliptic curves (i.e. private scalars)
 //!
-//! The [`SecretKey`] type wraps the [`ScalarBytes`] byte array type with
-//! a wrapper designed to prevent unintentional exposure of the scalar
-//! value (e.g. via `Debug` or other logging).
+//! The [`SecretKey`] type is a wrapper around a secret scalar value which is
+//! designed to prevent unintentional exposure (e.g. via `Debug` or other
+//! logging).
 //!
 //! When the `zeroize` feature of this crate is enabled, it also handles
 //! zeroing it out of memory securely on drop.
 
-use crate::{error::Error, Curve, ScalarBytes};
+use crate::{error::Error, Curve, ElementBytes};
 use core::{
     convert::{TryFrom, TryInto},
     fmt::{self, Debug},
@@ -29,12 +29,12 @@ use {
 #[derive(Clone)]
 pub struct SecretKey<C: Curve> {
     /// Private scalar value
-    scalar: ScalarBytes<C>,
+    scalar: ElementBytes<C>,
 }
 
 impl<C: Curve> SecretKey<C> {
     /// Create a new secret key from a serialized scalar value
-    pub fn new(bytes: ScalarBytes<C>) -> Self {
+    pub fn new(bytes: ElementBytes<C>) -> Self {
         Self { scalar: bytes }
     }
 
@@ -43,8 +43,8 @@ impl<C: Curve> SecretKey<C> {
         bytes.as_ref().try_into()
     }
 
-    /// Expose the secret [`ScalarBytes`] value this [`SecretKey`] wraps
-    pub fn secret_scalar(&self) -> &ScalarBytes<C> {
+    /// Expose the byte serialization of the value this [`SecretKey`] wraps
+    pub fn as_bytes(&self) -> &ElementBytes<C> {
         &self.scalar
     }
 }
@@ -74,7 +74,7 @@ impl<C: Curve> Debug for SecretKey<C> {
 impl<C> Generate for SecretKey<C>
 where
     C: Curve + Arithmetic,
-    C::Scalar: Generate + Into<ScalarBytes<C>>,
+    C::Scalar: Generate + Into<ElementBytes<C>>,
 {
     /// Generate a new [`SecretKey`]
     fn generate(rng: impl CryptoRng + RngCore) -> Self {

--- a/elliptic-curve/src/weierstrass/point.rs
+++ b/elliptic-curve/src/weierstrass/point.rs
@@ -7,7 +7,7 @@
 //! <https://www.secg.org/sec1-v2.pdf>
 
 use super::Curve;
-use crate::ScalarBytes;
+use crate::ElementBytes;
 use core::ops::Add;
 use generic_array::{
     typenum::{Unsigned, U1},
@@ -47,7 +47,7 @@ where
     CompressedPointSize<C>: ArrayLength<u8>,
 {
     /// Compress and serialize an elliptic curve point from its affine coordinates
-    pub fn from_affine_coords(x: &ScalarBytes<C>, y: &ScalarBytes<C>) -> Self {
+    pub fn from_affine_coords(x: &ElementBytes<C>, y: &ElementBytes<C>) -> Self {
         // Is the y-coordinate odd in the SEC-1 sense: `self mod 2 == 1`?
         let is_y_odd = y.as_ref().last().expect("last byte") & 1 == 1;
         let mut bytes = GenericArray::default();
@@ -137,7 +137,7 @@ where
     UncompressedPointSize<C>: ArrayLength<u8>,
 {
     /// Serialize an elliptic curve point from its affine coordinates
-    pub fn from_affine_coords(x: &ScalarBytes<C>, y: &ScalarBytes<C>) -> Self {
+    pub fn from_affine_coords(x: &ElementBytes<C>, y: &ElementBytes<C>) -> Self {
         let scalar_size = C::ElementSize::to_usize();
         let mut bytes = GenericArray::default();
         bytes[0] = 0x04;
@@ -173,12 +173,12 @@ where
     }
 
     /// Get the x-coordinate of this curve point
-    pub(crate) fn x(&self) -> &ScalarBytes<C> {
+    pub(crate) fn x(&self) -> &ElementBytes<C> {
         GenericArray::from_slice(&self.bytes[1..(C::ElementSize::to_usize() + 1)])
     }
 
     /// Get the y-coordinate of this curve point
-    pub(crate) fn y(&self) -> &ScalarBytes<C> {
+    pub(crate) fn y(&self) -> &ElementBytes<C> {
         GenericArray::from_slice(&self.bytes[(C::ElementSize::to_usize() + 1)..])
     }
 }


### PR DESCRIPTION
This type alias is being used for things that aren't elements of the scalar field, like serialized affine coordinates.

This commit renames it into something more general which applies to these cases. It's also more consistent with the `Curve::ElementSize` associated type name.