### PR TITLE
elliptic-curve: add `encoding` module

### DIFF
--- a/elliptic-curve/src/encoding.rs
+++ b/elliptic-curve/src/encoding.rs
@@ -1,0 +1,23 @@
+//! Traits for decoding/encoding elliptic curve elements (i.e. base and scalar
+//! field elements) as bytes.
+
+use generic_array::{ArrayLength, GenericArray};
+use subtle::{ConditionallySelectable, CtOption};
+
+/// Try to decode the given bytes into a curve element
+pub trait FromBytes: ConditionallySelectable + Sized {
+    /// Size of the serialized byte array
+    type Size: ArrayLength<u8>;
+
+    /// Try to decode this object from bytes
+    fn from_bytes(bytes: &GenericArray<u8, Self::Size>) -> CtOption<Self>;
+}
+
+/// Encode this curve element as bytes
+pub trait ToBytes {
+    /// Size of the serialized byte array
+    type Size: ArrayLength<u8>;
+
+    /// Encode this object to bytes
+    fn to_bytes(&self) -> GenericArray<u8, Self::Size>;
+}

--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -21,6 +21,7 @@
 #[cfg(feature = "std")]
 extern crate std;
 
+pub mod encoding;
 pub mod error;
 pub mod ops;
 pub mod point;
@@ -77,7 +78,7 @@ pub trait Arithmetic: Curve {
     type Scalar: ConditionallySelectable
         + ConstantTimeEq
         + Default
-        + secret_key::FromSecretKey<Self>;
+        + encoding::FromBytes<Size = Self::ElementSize>;
 
     /// Affine point type for a given curve
     type AffinePoint: ConditionallySelectable + Mul<scalar::NonZeroScalar<Self>> + point::Generator;

--- a/elliptic-curve/src/secret_key.rs
+++ b/elliptic-curve/src/secret_key.rs
@@ -13,7 +13,6 @@ use core::{
     fmt::{self, Debug},
 };
 use generic_array::{typenum::Unsigned, GenericArray};
-use subtle::CtOption;
 
 #[cfg(feature = "rand_core")]
 use {
@@ -90,12 +89,4 @@ impl<C: Curve> Drop for SecretKey<C> {
         use zeroize::Zeroize;
         self.scalar.zeroize();
     }
-}
-
-/// Trait for deserializing a value from a secret key.
-///
-/// This is intended for use with the `Scalar` type for a given elliptic curve.
-pub trait FromSecretKey<C: Curve>: Sized {
-    /// Deserialize this value from a [`SecretKey`]
-    fn from_secret_key(secret_key: &SecretKey<C>) -> CtOption<Self>;
 }

--- a/elliptic-curve/src/weierstrass.rs
+++ b/elliptic-curve/src/weierstrass.rs
@@ -5,7 +5,7 @@ pub mod public_key;
 
 pub use self::{
     point::{CompressedPoint, CompressedPointSize, UncompressedPoint, UncompressedPointSize},
-    public_key::{FromPublicKey, PublicKey},
+    public_key::PublicKey,
 };
 
 /// Marker trait for elliptic curves in short Weierstrass form


### PR DESCRIPTION
Replaces the previous `FromPublicKey` and `FromSecretKey` traits with a more general `FromBytes` and `ToBytes` traits.

These match the function signatures presently used in the existing crates, and are useful in cases where e.g. a scalar doesn't necessarily represent a secret (such as in ECDSA).