### PR TITLE
elliptic-curve: add back FromPublicKey trait

### DIFF
--- a/elliptic-curve/src/weierstrass/public_key.rs
+++ b/elliptic-curve/src/weierstrass/public_key.rs
@@ -16,6 +16,7 @@ use generic_array::{
     typenum::{Unsigned, U1},
     ArrayLength, GenericArray,
 };
+use subtle::CtOption;
 
 /// Size of an untagged point for given elliptic curve.
 pub type UntaggedPointSize<C> = <<C as crate::Curve>::ElementSize as Add>::Output;
@@ -205,4 +206,22 @@ where
     fn from(point: UncompressedPoint<C>) -> Self {
         PublicKey::Uncompressed(point)
     }
+}
+
+/// Trait for deserializing a value from a public key.
+///
+/// This is intended for use with the `AffinePoint` type for a given elliptic curve.
+pub trait FromPublicKey<C: Curve>: Sized
+where
+    C::ElementSize: Add<U1>,
+    <C::ElementSize as Add>::Output: Add<U1>,
+    CompressedPointSize<C>: ArrayLength<u8>,
+    UncompressedPointSize<C>: ArrayLength<u8>,
+{
+    /// Deserialize this value from a [`PublicKey`]
+    ///
+    /// # Returns
+    ///
+    /// `None` if the public key is not on the curve.
+    fn from_public_key(public_key: &PublicKey<C>) -> CtOption<Self>;
 }


### PR DESCRIPTION
It seems this was a bit too hastily removed in #247. It's worth keeping around for now as it handles the variable sizes of SEC-1 keys.