### PR TITLE
elliptic-curve: add Into<ElementBytes> bound to Arithmetic::Scalar

### DIFF
--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -80,7 +80,8 @@ pub trait Arithmetic: Curve {
     type Scalar: ConditionallySelectable
         + ConstantTimeEq
         + Default
-        + FromBytes<Size = Self::ElementSize>;
+        + FromBytes<Size = Self::ElementSize>
+        + Into<ElementBytes<Self>>;
 
     /// Affine point type for a given curve
     type AffinePoint: ConditionallySelectable + Mul<scalar::NonZeroScalar<Self>> + point::Generator;


### PR DESCRIPTION
Supports generic scalar serialization