### PR TITLE
elliptic-curve v0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,7 +125,7 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.5.0-pre"
+version = "0.5.0"
 dependencies = [
  "const-oid",
  "generic-array 0.14.4",

--- a/cryptography/Cargo.toml
+++ b/cryptography/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 aead = { version = "0.3", optional = true, path = "../aead" }
 block-cipher = { version = "0.8", optional = true, path = "../block-cipher" }
 digest = { version = "0.9", optional = true, path = "../digest" }
-elliptic-curve = { version = "= 0.5.0-pre", optional = true, path = "../elliptic-curve" }
+elliptic-curve = { version = "= 0.5", optional = true, path = "../elliptic-curve" }
 mac = { version = "0.9", package = "crypto-mac", optional = true, path = "../crypto-mac" }
 signature = { version = "1.1.0", optional = true, default-features = false, path = "../signature" }
 stream-cipher = { version = "0.6", optional = true, path = "../stream-cipher" }

--- a/elliptic-curve/CHANGELOG.md
+++ b/elliptic-curve/CHANGELOG.md
@@ -4,33 +4,64 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.5.0 (2020-08-10)
+### Added
+- `Arithmetic` trait ([#219])
+- `Generate` trait ([#220], [#226])
+- Toplevel `Curve` trait ([#223])
+- `Invert` trait ([#228])
+- `FromPublicKey` trait ([#229], [#248])
+- Re-export `zeroize` ([#233])
+- OID support ([#240], [#245])
+- `NonZeroScalar` type ([#241])
+- `Generator` trait ([#241])
+- `weierstrass::PublicKey::compress` method ([#243])
+- Derive `Clone` on `SecretKey` ([#244])
+- Generic Elliptic Curve Diffie-Hellman support ([#251])
+
+### Changed
+- Moved repo to https://github.com/RustCrypto/traits ([#213])
+- Rename `ScalarBytes` to `ElementBytes` ([#246])
+- Rename `CompressedCurvePoint`/`UncompressedCurvePoint` to
+  `CompressedPoint`/`UncompressedPoint`
+
+[#213]: https://github.com/RustCrypto/traits/pull/213
+[#219]: https://github.com/RustCrypto/traits/pull/219
+[#220]: https://github.com/RustCrypto/traits/pull/220
+[#223]: https://github.com/RustCrypto/traits/pull/223
+[#226]: https://github.com/RustCrypto/traits/pull/226
+[#228]: https://github.com/RustCrypto/traits/pull/228
+[#229]: https://github.com/RustCrypto/traits/pull/229
+[#233]: https://github.com/RustCrypto/traits/pull/233
+[#240]: https://github.com/RustCrypto/traits/pull/240
+[#241]: https://github.com/RustCrypto/traits/pull/241
+[#243]: https://github.com/RustCrypto/traits/pull/243
+[#244]: https://github.com/RustCrypto/traits/pull/244
+[#245]: https://github.com/RustCrypto/traits/pull/245
+[#246]: https://github.com/RustCrypto/traits/pull/246
+[#248]: https://github.com/RustCrypto/traits/pull/248
+[#251]: https://github.com/RustCrypto/traits/pull/251
+
 ## 0.4.0 (2020-06-04)
 ### Changed
-- Bump `generic-array` dependency from v0.12 to v0.14 ([#38])
-
-[#38]: https://github.com/RustCrypto/elliptic-curves/pull/38
+- Bump `generic-array` dependency from v0.12 to v0.14
 
 ## 0.3.0 (2020-01-15)
 ### Added
-- `Scalar` struct type ([#5])
+- `Scalar` struct type
 
 ### Changed
 - Repository moved to <https://github.com/RustCrypto/elliptic-curves>
 
 ### Removed
-- Curve definitions/arithmetic extracted out into per-curve crates ([#5])
-
-[#5]: https://github.com/RustCrypto/elliptic-curves/pull/5
+- Curve definitions/arithmetic extracted out into per-curve crates
 
 ## 0.2.0 (2019-12-11)
 ### Added
-- `secp256r1` (P-256) point compression and decompression ([RustCrypto/signatures#63], [RustCrypto/signatures#64])
+- `secp256r1` (P-256) point compression and decompression
 
 ### Changed
-- Bump MSRV to 1.37 ([RustCrypto/signatures#63])
-
-[RustCrypto/signatures#63]: https://github.com/RustCrypto/signatures/pull/63
-[RustCrypto/signatures#64]: https://github.com/RustCrypto/signatures/pull/64
+- Bump MSRV to 1.37
 
 ## 0.1.0 (2019-12-06)
 - Initial release

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -5,21 +5,20 @@ General purpose Elliptic Curve Cryptography (ECC) support, including types
 and traits for representing various elliptic curve forms, scalars, points,
 and public/secret keys composed thereof.
 """
-version       = "0.5.0-pre" # Also update html_root_url in lib.rs when bumping this
-authors       = ["RustCrypto Developers"]
-license       = "Apache-2.0 OR MIT"
-documentation = "https://docs.rs/elliptic-curve"
-repository    = "https://github.com/RustCrypto/elliptic-curves/tree/master/elliptic-curve-crate"
-readme        = "README.md"
-edition       = "2018"
-categories    = ["cryptography", "no-std"]
-keywords      = ["crypto", "ecc", "elliptic", "weierstrass"]
+version    = "0.5.0" # Also update html_root_url in lib.rs when bumping this
+authors    = ["RustCrypto Developers"]
+license    = "Apache-2.0 OR MIT"
+repository = "https://github.com/RustCrypto/traits/tree/master/elliptic-curve"
+readme     = "README.md"
+edition    = "2018"
+categories = ["cryptography", "no-std"]
+keywords   = ["crypto", "ecc", "elliptic", "weierstrass"]
 
 [dependencies]
 generic-array = { version = "0.14", default-features = false }
 oid = { package = "const-oid", version = "0.1", optional = true }
 rand_core = { version = "0.5", optional = true, default-features = false }
-subtle = { version = "2.2.2", default-features = false }
+subtle = { version = "2.2", default-features = false }
 zeroize = { version = "1", optional = true,  default-features = false }
 
 [features]

--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -16,7 +16,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/elliptic-curve/0.4.0"
+    html_root_url = "https://docs.rs/elliptic-curve/0.5.0"
 )]
 
 #[cfg(feature = "std")]


### PR DESCRIPTION
### Added
- `Arithmetic` trait ([#219])
- `Generate` trait ([#220], [#226])
- Toplevel `Curve` trait ([#223])
- `Invert` trait ([#228])
- `FromPublicKey` trait ([#229], [#248])
- Re-export `zeroize` ([#233])
- OID support ([#240], [#245])
- `NonZeroScalar` type ([#241])
- `Generator` trait ([#241])
- `weierstrass::PublicKey::compress` method ([#243])
- Derive `Clone` on `SecretKey` ([#244])
- Generic Elliptic Curve Diffie-Hellman support ([#251])

### Changed
- Moved repo to https://github.com/RustCrypto/traits ([#213])
- Rename `ScalarBytes` to `ElementBytes` ([#246])
- Rename `CompressedCurvePoint`/`UncompressedCurvePoint` to `CompressedPoint`/`UncompressedPoint`

[#213]: https://github.com/RustCrypto/traits/pull/213
[#219]: https://github.com/RustCrypto/traits/pull/219
[#220]: https://github.com/RustCrypto/traits/pull/220
[#223]: https://github.com/RustCrypto/traits/pull/223
[#226]: https://github.com/RustCrypto/traits/pull/226
[#228]: https://github.com/RustCrypto/traits/pull/228
[#229]: https://github.com/RustCrypto/traits/pull/229
[#233]: https://github.com/RustCrypto/traits/pull/233
[#240]: https://github.com/RustCrypto/traits/pull/240
[#241]: https://github.com/RustCrypto/traits/pull/241
[#243]: https://github.com/RustCrypto/traits/pull/243
[#244]: https://github.com/RustCrypto/traits/pull/244
[#245]: https://github.com/RustCrypto/traits/pull/245
[#246]: https://github.com/RustCrypto/traits/pull/246
[#248]: https://github.com/RustCrypto/traits/pull/248
[#251]: https://github.com/RustCrypto/traits/pull/251