### PR TITLE
cryptography v0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,7 +94,7 @@ dependencies = [
 
 [[package]]
 name = "cryptography"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "aead",
  "block-cipher 0.8.0",

--- a/cryptography/CHANGELOG.md
+++ b/cryptography/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.3.0 (2020-08-10)
+### Added
+- `elliptic-curve` feature ([#213])
+
+### Changed
+- Bump `crypto-mac` to v0.9 ([#217])
+
+[#213]: https://github.com/RustCrypto/traits/pull/213
+[#217]: https://github.com/RustCrypto/traits/pull/217
+
 ## 0.2.0 (2020-07-03)
 ### Changed
 - Bump `stream-cipher` to v0.5 ([#209])

--- a/cryptography/Cargo.toml
+++ b/cryptography/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cryptography"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["The RustCrypto Project Developers"]
 license = "Apache-2.0 OR MIT"
 description = "Facade crate for the RustCrypto project's traits"


### PR DESCRIPTION
### Added
- `elliptic-curve` feature ([#213])

### Changed
- Bump `crypto-mac` to v0.9 ([#217])

[#213]: https://github.com/RustCrypto/traits/pull/213
[#217]: https://github.com/RustCrypto/traits/pull/217