### PR TITLE
crypto-mac: re-export block-cipher

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,7 +84,7 @@ checksum = "8aebca1129a03dc6dc2b127edd729435bbc4a37e1d5f4d7513165089ceb02634"
 
 [[package]]
 name = "crypto-mac"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "blobby 0.3.0",
  "block-cipher 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/crypto-mac/CHANGELOG.md
+++ b/crypto-mac/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.9.1 (2020-08-12)
+### Added
+- Re-export the `block-cipher` crate ([#257])
+
+[#257]: https://github.com/RustCrypto/traits/pull/257
+
 ## 0.9.0 (2020-08-10)
 ### Added
 - `FromBlockCipher` trait and blanket implementation of the `NewMac` trait

--- a/crypto-mac/Cargo.toml
+++ b/crypto-mac/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "crypto-mac"
 description = "Trait for Message Authentication Code (MAC) algorithms"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/crypto-mac/src/lib.rs
+++ b/crypto-mac/src/lib.rs
@@ -13,6 +13,8 @@
 extern crate std;
 
 #[cfg(feature = "block-cipher")]
+pub use block_cipher;
+#[cfg(feature = "block-cipher")]
 use block_cipher::{BlockCipher, NewBlockCipher};
 
 #[cfg(feature = "dev")]


### PR DESCRIPTION
This will allow us to remove explicit dependency on `block-cipher` from `cmac`, `daa` and `pmac` crates, thus making version synchronization a bit easier.