### PR TITLE
stream-cipher: add SyncStreamCipherSeek::try_seek method

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -280,7 +280,7 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "stream-cipher"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "blobby 0.3.0",
  "block-cipher 0.8.0",

--- a/cryptography/Cargo.toml
+++ b/cryptography/Cargo.toml
@@ -18,7 +18,7 @@ digest = { version = "0.9", optional = true, path = "../digest" }
 elliptic-curve = { version = "= 0.5", optional = true, path = "../elliptic-curve" }
 mac = { version = "0.9", package = "crypto-mac", optional = true, path = "../crypto-mac" }
 signature = { version = "1.1.0", optional = true, default-features = false, path = "../signature" }
-stream-cipher = { version = "0.6", optional = true, path = "../stream-cipher" }
+stream-cipher = { version = "0.7", optional = true, path = "../stream-cipher" }
 universal-hash = { version = "0.4", optional = true, path = "../universal-hash" }
 
 [package.metadata.docs.rs]

--- a/stream-cipher/CHANGELOG.md
+++ b/stream-cipher/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Rework of the `SyncStreamCipherSeek` trait, make methods generic over
 numeric types, add fallable `try_seek` and `try_current_pos` methods ([#260])
+- Rework macro for generating seek tests, re-export `blobby` at top-level,
+remove the `dev` module from public API ([#260])
 
 [#260]: https://github.com/RustCrypto/traits/pull/260
 

--- a/stream-cipher/CHANGELOG.md
+++ b/stream-cipher/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.7.0 (2020-08-25)
+### Changed
+- Rework of the `SyncStreamCipherSeek` trait, make methods generic over
+numeric types, add fallable `try_seek` and `try_current_pos` methods ([#260])
+
+[#260]: https://github.com/RustCrypto/traits/pull/260
+
 ## 0.6.0 (2020-07-10)
 ### Changed
 - Add blanket implementation for `&mut SyncCtreamCipher` ([#210])

--- a/stream-cipher/Cargo.toml
+++ b/stream-cipher/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "stream-cipher"
 description = "Stream cipher traits"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/stream-cipher/src/dev.rs
+++ b/stream-cipher/src/dev.rs
@@ -77,6 +77,19 @@ macro_rules! new_seek_test {
                     }
                 }
             }
+
+            const MAX_CHUNK: usize = 128;
+
+            let mut buf = [0u8; MAX_CHUNK];
+            let mut mode = <$cipher>::new(&Default::default(), &Default::default());
+            for n in 0..MAX_CHUNK {
+                assert_eq!(mode.current_pos::<usize>(), 0);
+                for m in 1..=MAX_CHUNK {
+                    mode.apply_keystream(&mut buf[..n]);
+                    assert_eq!(mode.current_pos::<usize>(), n*m);
+                }
+                mode.seek(0);
+            }
         }
     };
 }

--- a/stream-cipher/src/dev.rs
+++ b/stream-cipher/src/dev.rs
@@ -1,7 +1,5 @@
 //! Development-related functionality
 
-pub use blobby;
-
 /// Test core functionality of synchronous stream cipher
 #[macro_export]
 #[cfg_attr(docsrs, doc(cfg(feature = "dev")))]
@@ -9,7 +7,7 @@ macro_rules! new_sync_test {
     ($name:ident, $cipher:ty, $test_name:expr) => {
         #[test]
         fn $name() {
-            use stream_cipher::dev::blobby::Blob4Iterator;
+            use stream_cipher::blobby::Blob4Iterator;
             use stream_cipher::generic_array::GenericArray;
             use stream_cipher::{NewStreamCipher, SyncStreamCipher};
 
@@ -99,7 +97,7 @@ macro_rules! new_async_test {
     ($name:ident, $test_name:expr, $cipher:ty) => {
         #[test]
         fn $name() {
-            use stream_cipher::dev::blobby::Blob4Iterator;
+            use stream_cipher::blobby::Blob4Iterator;
             use stream_cipher::generic_array::GenericArray;
             use stream_cipher::{NewStreamCipher, StreamCipher};
 

--- a/stream-cipher/src/dev.rs
+++ b/stream-cipher/src/dev.rs
@@ -61,8 +61,10 @@ macro_rules! new_seek_test {
                 let n = if pl > MAX_SEEK { MAX_SEEK } else { pl };
                 for seek_n in 0..n {
                     let mut pt = pt[seek_n..].to_vec();
-                    mode.seek(seek_n as u64);
+                    mode.seek(seek_n);
+                    assert_eq!(mode.current_pos::<usize>(), seek_n);
                     mode.apply_keystream(&mut pt);
+                    assert_eq!(mode.current_pos::<usize>(), ct.len());
                     if pt != &ct[seek_n..] {
                         panic!(
                             "Failed seek test №{}, seek pos: {}\n\

--- a/stream-cipher/src/errors.rs
+++ b/stream-cipher/src/errors.rs
@@ -1,6 +1,6 @@
 use core::fmt;
 
-/// Error which notifies that stream cipher has reached the end of a keystream.
+/// The error type returned when stream cipher has reached the end of a keystream.
 #[derive(Copy, Clone, Debug)]
 pub struct LoopError;
 
@@ -13,7 +13,7 @@ impl fmt::Display for LoopError {
 #[cfg(feature = "std")]
 impl std::error::Error for LoopError {}
 
-/// Error which notifies that key or/and nonce used in stream cipher
+/// The error type returned when key and/or nonce used in stream cipher
 /// initialization had an invalid length.
 #[derive(Copy, Clone, Debug)]
 pub struct InvalidKeyNonceLength;
@@ -26,3 +26,17 @@ impl fmt::Display for InvalidKeyNonceLength {
 
 #[cfg(feature = "std")]
 impl std::error::Error for InvalidKeyNonceLength {}
+
+/// The error type returned when a cipher position can not be represented
+/// by the requested type.
+#[derive(Copy, Clone, Debug)]
+pub struct OverflowError;
+
+impl From<OverflowError> for LoopError {
+    fn from(_v: OverflowError) -> LoopError {
+        LoopError
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for OverflowError {}

--- a/stream-cipher/src/errors.rs
+++ b/stream-cipher/src/errors.rs
@@ -32,8 +32,14 @@ impl std::error::Error for InvalidKeyNonceLength {}
 #[derive(Copy, Clone, Debug)]
 pub struct OverflowError;
 
+impl fmt::Display for OverflowError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        f.write_str("Overflow Error")
+    }
+}
+
 impl From<OverflowError> for LoopError {
-    fn from(_v: OverflowError) -> LoopError {
+    fn from(_: OverflowError) -> LoopError {
         LoopError
     }
 }

--- a/stream-cipher/src/lib.rs
+++ b/stream-cipher/src/lib.rs
@@ -255,6 +255,4 @@ macro_rules! impl_seek_num {
     };
 }
 
-// note: the trait is implemented for i32 to allow expressions
-// like `cipher.seek(10)`
 impl_seek_num! { u8 i8 u16 i16 u32 i32 u64 i64 u128 i128 }

--- a/stream-cipher/src/lib.rs
+++ b/stream-cipher/src/lib.rs
@@ -95,11 +95,11 @@ pub trait SyncStreamCipher {
     fn try_apply_keystream(&mut self, data: &mut [u8]) -> Result<(), LoopError>;
 }
 
-/// Trait for additionall functionality available for seekable stream ciphers.
+/// Trait for seekable stream ciphers.
 ///
-/// Methods of this trait are generic over the following numeric types: `u8`,
-/// `u16`, `u32`, `u64`, and `u128`. This is done via a "sealed" `SeekNum`
-/// trait. By default methods
+/// Methods of this trait are generic over the [`NumSeek`] trait, which is
+/// implemented for the following numeric types: `u8`, `u16`, `u32`, `u64`,
+/// and `u128`. By default methods will use `u64`.
 pub trait SyncStreamCipherSeek<T: SeekNum = u64> {
     /// Try to get current keystream position
     ///

--- a/stream-cipher/src/lib.rs
+++ b/stream-cipher/src/lib.rs
@@ -22,12 +22,13 @@ pub mod dev;
 
 mod errors;
 
-pub use crate::errors::{InvalidKeyNonceLength, LoopError};
+pub use errors::{InvalidKeyNonceLength, LoopError, OverflowError};
 pub use generic_array::{self, typenum::consts};
 
 #[cfg(feature = "block-cipher")]
 pub use block_cipher;
 
+use core::convert::{TryFrom, TryInto};
 use generic_array::typenum::Unsigned;
 use generic_array::{ArrayLength, GenericArray};
 
@@ -94,24 +95,38 @@ pub trait SyncStreamCipher {
     fn try_apply_keystream(&mut self, data: &mut [u8]) -> Result<(), LoopError>;
 }
 
-/// Synchronous stream cipher seeking trait.
-pub trait SyncStreamCipherSeek {
-    /// Return current position of a keystream in bytes from the beginning.
-    fn get_current_pos(&self) -> u64;
+/// Trait for additionall functionality available for seekable stream ciphers.
+///
+/// Methods of this trait are generic over the following numeric types: `u8`,
+/// `u16`, `u32`, `u64`, and `u128`. This is done via a "sealed" `SeekNum`
+/// trait. By default methods
+pub trait SyncStreamCipherSeek<T: SeekNum = u64> {
+    /// Try to get current keystream position
+    ///
+    /// Returns [`LoopError`] if position can not be represented by type `T`
+    fn try_get_pos(&self) -> Result<T, OverflowError>;
 
-    /// Seek keystream to the given `pos` in bytes.
+    /// Try to seek to the given position
+    ///
+    /// Returns [`LoopError`] if provided position value is bigger than
+    /// keystream leangth
+    fn try_seek(&mut self, pos: T) -> Result<(), LoopError>;
+
+    /// Get current keystream position
     ///
     /// # Panics
-    /// If provided position is outside of the cipher keystream.
-    fn seek(&mut self, pos: u64) {
-        self.try_seek(pos).unwrap()
+    /// If position can not be represented by type `T`
+    fn get_pos(&self) -> T {
+        self.try_get_pos().unwrap()
     }
 
-    /// Try to seek keystream to the given `pos` in bytes.
+    /// Seek to the given position
     ///
-    /// It will return `Err(LoopError)` if provided position is outside of
-    /// the cipher keystream.
-    fn try_seek(&mut self, pos: u64) -> Result<(), LoopError>;
+    /// # Panics
+    /// If provided position value is bigger than keystream leangth
+    fn seek(&mut self, pos: T) {
+        self.try_seek(pos).unwrap()
+    }
 }
 
 /// Stream cipher core trait which covers both synchronous and asynchronous
@@ -161,7 +176,6 @@ pub trait FromBlockCipher {
     type NonceSize: ArrayLength<u8>;
 
     /// Instantiate a stream cipher from a block cipher
-    // TODO(tarcieri): add associated type for NonceSize?
     fn from_block_cipher(
         cipher: Self::BlockCipher,
         nonce: &GenericArray<u8, Self::NonceSize>,
@@ -196,3 +210,53 @@ where
         }
     }
 }
+
+/// Trait implemented for numeric types which can be used with the
+/// [`SyncStreamCipherSeek`] trait.
+///
+/// This trait is implemented for the following primitive numeric types:
+/// `u8`, `u16`, `u32`, `u64`, and `u128`. It is not intended to be implemented
+/// in third-party crates.
+pub trait SeekNum:
+    Sized
+    + TryInto<u8>
+    + TryFrom<u8>
+    + TryInto<u16>
+    + TryFrom<u16>
+    + TryInto<u32>
+    + TryFrom<u32>
+    + TryInto<u64>
+    + TryFrom<u64>
+    + TryInto<u128>
+    + TryFrom<u128>
+{
+    /// Try to get position for block number `block`, byte position inside
+    /// block `byte`, and block size `bs`.
+    fn from_block_byte<T: SeekNum>(block: T, byte: u8, bs: u8) -> Result<Self, OverflowError>;
+
+    /// Try to get block number and bytes position for given block size `bs`.
+    fn to_block_byte<T: SeekNum>(self, bs: u8) -> Result<(T, u8), OverflowError>;
+}
+
+macro_rules! impl_seek_num {
+    {$($t:ty )*} => {
+        $(
+            impl SeekNum for $t {
+                fn from_block_byte<T: TryInto<Self>>(block: T, byte: u8, bs: u8) -> Result<Self, OverflowError> {
+                    debug_assert!(byte < bs);
+                    let block = block.try_into().map_err(|_| OverflowError)?;
+                    let pos = block.checked_mul(bs as Self).ok_or(OverflowError)? + (byte as Self);
+                    Ok(pos)
+                }
+
+                fn to_block_byte<T: TryFrom<Self>>(self, bs: u8) -> Result<(T, u8), OverflowError> {
+                    let byte = (self as u8) % bs;
+                    let block = T::try_from(self/(bs as Self)).map_err(|_| OverflowError)?;
+                    Ok((block, byte))
+                }
+            }
+        )*
+    };
+}
+
+impl_seek_num! { u8 u16 u32 u64 u128 }

--- a/stream-cipher/src/lib.rs
+++ b/stream-cipher/src/lib.rs
@@ -17,8 +17,7 @@
 extern crate std;
 
 #[cfg(feature = "dev")]
-#[cfg_attr(docsrs, doc(cfg(feature = "dev")))]
-pub mod dev;
+mod dev;
 
 mod errors;
 
@@ -27,6 +26,9 @@ pub use generic_array::{self, typenum::consts};
 
 #[cfg(feature = "block-cipher")]
 pub use block_cipher;
+
+#[cfg(feature = "dev")]
+pub use blobby;
 
 use core::convert::{TryFrom, TryInto};
 use generic_array::typenum::Unsigned;
@@ -97,7 +99,7 @@ pub trait SyncStreamCipher {
 
 /// Trait for seekable stream ciphers.
 ///
-/// Methods of this trait are generic over the [`NumSeek`] trait, which is
+/// Methods of this trait are generic over the [`SeekNum`] trait, which is
 /// implemented for primitive numeric types, i.e.: `i/u8`, `i/u16`, `i/u32`,
 /// `i/u64`, `i/u128`, and `i/usize`.
 pub trait SyncStreamCipherSeek {

--- a/stream-cipher/src/lib.rs
+++ b/stream-cipher/src/lib.rs
@@ -98,8 +98,8 @@ pub trait SyncStreamCipher {
 /// Trait for seekable stream ciphers.
 ///
 /// Methods of this trait are generic over the [`NumSeek`] trait, which is
-/// implemented for the following numeric types: `u8`, `u16`, `u32`, `i32`,
-/// `u64`, and `u128`.
+/// implemented for primitive numeric types, i.e.: `i/u8`, `i/u16`, `i/u32`,
+/// `i/u64`, and `i/u128`.
 pub trait SyncStreamCipherSeek {
     /// Try to get current keystream position
     ///
@@ -214,23 +214,17 @@ where
 /// Trait implemented for numeric types which can be used with the
 /// [`SyncStreamCipherSeek`] trait.
 ///
-/// This trait is implemented for the following primitive numeric types:
-/// `u8`, `u16`, `u32`, `i32`, `u64`, and `u128`. It is not intended to
-/// be implemented in third-party crates.
+/// This trait is implemented for primitive numeric types, i.e. `i/u8`,
+/// `i/u16`, `i/u32`, `i/u64`, and `i/u128`. It is not intended to be
+/// implemented in third-party crates.
+#[rustfmt::skip]
 pub trait SeekNum:
     Sized
-    + TryInto<u8>
-    + TryFrom<u8>
-    + TryInto<u16>
-    + TryFrom<u16>
-    + TryInto<u32>
-    + TryFrom<u32>
-    + TryInto<i32>
-    + TryFrom<i32>
-    + TryInto<u64>
-    + TryFrom<u64>
-    + TryInto<u128>
-    + TryFrom<u128>
+    + TryInto<u8> + TryFrom<u8> + TryInto<i8> + TryFrom<i8>
+    + TryInto<u16> + TryFrom<u16> + TryInto<i16> + TryFrom<i16>
+    + TryInto<u32> + TryFrom<u32> + TryInto<i32> + TryFrom<i32>
+    + TryInto<u64> + TryFrom<u64> + TryInto<i64> + TryFrom<i64>
+    + TryInto<u128> + TryFrom<u128> + TryInto<i128> + TryFrom<i128>
 {
     /// Try to get position for block number `block`, byte position inside
     /// block `byte`, and block size `bs`.
@@ -263,4 +257,4 @@ macro_rules! impl_seek_num {
 
 // note: the trait is implemented for i32 to allow expressions
 // like `cipher.seek(10)`
-impl_seek_num! { i32 u8 u16 u32 u64 u128 }
+impl_seek_num! { u8 i8 u16 i16 u32 i32 u64 i64 u128 i128 }

--- a/stream-cipher/src/lib.rs
+++ b/stream-cipher/src/lib.rs
@@ -104,7 +104,7 @@ pub trait SyncStreamCipherSeek {
     /// Try to get current keystream position
     ///
     /// Returns [`LoopError`] if position can not be represented by type `T`
-    fn try_get_pos<T: SeekNum>(&self) -> Result<T, OverflowError>;
+    fn try_current_pos<T: SeekNum>(&self) -> Result<T, OverflowError>;
 
     /// Try to seek to the given position
     ///
@@ -117,7 +117,7 @@ pub trait SyncStreamCipherSeek {
     /// # Panics
     /// If position can not be represented by type `T`
     fn get_pos<T: SeekNum>(&self) -> T {
-        self.try_get_pos().unwrap()
+        self.try_current_pos().unwrap()
     }
 
     /// Seek to the given position

--- a/stream-cipher/src/lib.rs
+++ b/stream-cipher/src/lib.rs
@@ -256,4 +256,4 @@ macro_rules! impl_seek_num {
     };
 }
 
-impl_seek_num! { u8 i8 u16 i16 u32 i32 u64 i64 u128 i128 }
+impl_seek_num! { u8 i8 u16 i16 u32 i32 u64 i64 u128 i128 isize usize }

--- a/stream-cipher/src/lib.rs
+++ b/stream-cipher/src/lib.rs
@@ -97,10 +97,21 @@ pub trait SyncStreamCipher {
 /// Synchronous stream cipher seeking trait.
 pub trait SyncStreamCipherSeek {
     /// Return current position of a keystream in bytes from the beginning.
-    fn current_pos(&self) -> u64;
+    fn get_current_pos(&self) -> u64;
 
     /// Seek keystream to the given `pos` in bytes.
-    fn seek(&mut self, pos: u64);
+    ///
+    /// # Panics
+    /// If provided position is outside of the cipher keystream.
+    fn seek(&mut self, pos: u64) {
+        self.try_seek(pos).unwrap()
+    }
+
+    /// Try to seek keystream to the given `pos` in bytes.
+    ///
+    /// It will return `Err(LoopError)` if provided position is outside of
+    /// the cipher keystream.
+    fn try_seek(&mut self, pos: u64) -> Result<(), LoopError>;
 }
 
 /// Stream cipher core trait which covers both synchronous and asynchronous

--- a/stream-cipher/src/lib.rs
+++ b/stream-cipher/src/lib.rs
@@ -99,7 +99,7 @@ pub trait SyncStreamCipher {
 ///
 /// Methods of this trait are generic over the [`NumSeek`] trait, which is
 /// implemented for primitive numeric types, i.e.: `i/u8`, `i/u16`, `i/u32`,
-/// `i/u64`, and `i/u128`.
+/// `i/u64`, `i/u128`, and `i/usize`.
 pub trait SyncStreamCipherSeek {
     /// Try to get current keystream position
     ///
@@ -215,8 +215,8 @@ where
 /// [`SyncStreamCipherSeek`] trait.
 ///
 /// This trait is implemented for primitive numeric types, i.e. `i/u8`,
-/// `i/u16`, `i/u32`, `i/u64`, and `i/u128`. It is not intended to be
-/// implemented in third-party crates.
+/// `i/u16`, `i/u32`, `i/u64`, `i/u128`, and `i/usize`. It is not intended
+/// to be implemented in third-party crates.
 #[rustfmt::skip]
 pub trait SeekNum:
     Sized
@@ -225,6 +225,7 @@ pub trait SeekNum:
     + TryInto<u32> + TryFrom<u32> + TryInto<i32> + TryFrom<i32>
     + TryInto<u64> + TryFrom<u64> + TryInto<i64> + TryFrom<i64>
     + TryInto<u128> + TryFrom<u128> + TryInto<i128> + TryFrom<i128>
+    + TryInto<usize> + TryFrom<usize> + TryInto<isize> + TryFrom<isize>
 {
     /// Try to get position for block number `block`, byte position inside
     /// block `byte`, and block size `bs`.

--- a/stream-cipher/src/lib.rs
+++ b/stream-cipher/src/lib.rs
@@ -116,7 +116,7 @@ pub trait SyncStreamCipherSeek {
     ///
     /// # Panics
     /// If position can not be represented by type `T`
-    fn get_pos<T: SeekNum>(&self) -> T {
+    fn current_pos<T: SeekNum>(&self) -> T {
         self.try_current_pos().unwrap()
     }
 


### PR DESCRIPTION
Closes: RustCrypto/stream-ciphers#9

Unfortunately I forgot about this issue during the work on `stream-cipher` v0.6.

I wonder if it'll be worth to go even further and introduce something like this:
```rust
pub trait SyncStreamCipherSeek<T: num_traits::Unsigned = u64> {
    fn get_pos(&self) -> T {
        self.try_get_pos().unwrap()
    }
    fn try_get_pos(&self) -> Result<T, OverflowError>;
    fn seek(&mut self, pos: T) {
        self.try_seek(pos).unwrap()
    }
    fn try_seek(&mut self, pos: T) -> Result<(), LoopError>;
}
```

cc @kazcw