### PR TITLE
elliptic-curve: add `alloc` feature + EncodedPoint::to_bytes()

### DIFF
--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -26,10 +26,11 @@ hex-literal = "0.2"
 
 [features]
 default = ["rand"]
+alloc = []
 ecdh = ["rand", "weierstrass", "zeroize"]
 rand = ["rand_core"]
 weierstrass = []
-std = []
+std = ["alloc"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/elliptic-curve/src/ecdh.rs
+++ b/elliptic-curve/src/ecdh.rs
@@ -7,8 +7,8 @@
 //! # Usage
 //!
 //! Have each participant generate an [`EphemeralSecret`] value, compute the
-//! [`EncodedPoint`] for that value, exchange public keys, then each participant
-//! uses their [`EphemeralSecret`] and the other participant's [`EncodedPoint`]
+//! [`PublicKey'] for that value, exchange public keys, then each participant
+//! uses their [`EphemeralSecret`] and the other participant's [`PublicKey`]
 //! to compute a [`SharedSecret`] value.
 //!
 //! # ⚠️ SECURITY WARNING ⚠️

--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -19,6 +19,9 @@
     html_root_url = "https://docs.rs/elliptic-curve/0.5.0"
 )]
 
+#[cfg(feature = "alloc")]
+extern crate alloc;
+
 #[cfg(feature = "std")]
 extern crate std;
 

--- a/elliptic-curve/src/sec1.rs
+++ b/elliptic-curve/src/sec1.rs
@@ -17,6 +17,9 @@ use generic_array::{
 };
 use subtle::CtOption;
 
+#[cfg(feature = "alloc")]
+use alloc::boxed::Box;
+
 #[cfg(feature = "zeroize")]
 use zeroize::Zeroize;
 
@@ -120,9 +123,15 @@ where
     }
 
     /// Get byte slice containing the serialized [`EncodedPoint`].
-    #[inline]
     pub fn as_bytes(&self) -> &[u8] {
         &self.bytes[..self.len()]
+    }
+
+    /// Get boxed byte slice containing the serialized [`EncodedPoint`]
+    #[cfg(feature = "alloc")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+    pub fn to_bytes(&self) -> Box<[u8]> {
+        self.as_bytes().to_vec().into_boxed_slice()
     }
 
     /// Compress this [`EncodedPoint`], returning a new [`EncodedPoint`].
@@ -447,5 +456,12 @@ mod tests {
         let uncompressed_point = EncodedPoint::from_bytes(&UNCOMPRESSED_BYTES[..]).unwrap();
         let compressed_point = uncompressed_point.compress();
         assert_eq!(compressed_point.as_bytes(), &COMPRESSED_BYTES[..]);
+    }
+
+    #[cfg(feature = "alloc")]
+    #[test]
+    fn to_bytes() {
+        let uncompressed_point = EncodedPoint::from_bytes(&UNCOMPRESSED_BYTES[..]).unwrap();
+        assert_eq!(&*uncompressed_point.to_bytes(), &UNCOMPRESSED_BYTES[..]);
     }
 }


### PR DESCRIPTION
Support serializing an `EncodedPoint` as a heap-allocated byte slice.