### PR TITLE
elliptic-curve: add weierstrass::point::Decompress trait

### DIFF
--- a/elliptic-curve/src/weierstrass.rs
+++ b/elliptic-curve/src/weierstrass.rs
@@ -1,5 +1,7 @@
 //! Elliptic curves in short Weierstrass form.
 
+pub mod point;
+
 /// Marker trait for elliptic curves in short Weierstrass form
 pub trait Curve: super::Curve {
     /// Should point compression be applied by default?

--- a/elliptic-curve/src/weierstrass/point.rs
+++ b/elliptic-curve/src/weierstrass/point.rs
@@ -1,0 +1,12 @@
+//! Traits for Weierstrass elliptic curve points
+
+use super::Curve;
+use crate::ElementBytes;
+use subtle::CtOption;
+
+/// Attempt to decompress an elliptic curve point from its x-coordinate and
+/// a boolean flag indicating whether or not the y-coordinate is odd.
+pub trait Decompress<C: Curve>: Sized {
+    /// Attempt to decompress an elliptic curve point
+    fn decompress(x: &ElementBytes<C>, y_is_odd: bool) -> CtOption<Self>;
+}


### PR DESCRIPTION
Adds a trait for decompressing Weierstrass points from a big endian encoded affine x-coordinate and a flag indicating whether or not the y-coordinate is odd.