### PR TITLE
elliptic-curve: don't conditionally define `EncodedPoint::x`

### DIFF
--- a/.github/workflows/elliptic-curve.yml
+++ b/.github/workflows/elliptic-curve.yml
@@ -51,5 +51,6 @@ jobs:
         toolchain: ${{ matrix.rust }}
     - run: cargo check --all-features
     - run: cargo test --no-default-features
+    - run: cargo test --no-default-features --features weierstrass
     - run: cargo test
     - run: cargo test --all-features

--- a/elliptic-curve/src/sec1.rs
+++ b/elliptic-curve/src/sec1.rs
@@ -152,7 +152,6 @@ where
     }
 
     /// Get the x-coordinate for this [`EncodedPoint`]
-    #[cfg(feature = "ecdh")]
     pub(crate) fn x(&self) -> &ElementBytes<C> {
         self.coordinates().0
     }


### PR DESCRIPTION
This was causing compile errors when only the `weierstrass` feature was enabled.