### PR TITLE
Fix SeekNum::to_block_byte computation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -281,7 +281,7 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "stream-cipher"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "blobby 0.3.0",
  "block-cipher 0.8.0",

--- a/stream-cipher/CHANGELOG.md
+++ b/stream-cipher/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.7.1 (2020-08-25)
+### Fixed
+- Computation of `SeekNum::to_block_byte` for numbers which are not a power of 2 ([#261])
+
+[#261]: https://github.com/RustCrypto/traits/pull/261
+
 ## 0.7.0 (2020-08-25)
 ### Changed
 - Rework of the `SyncStreamCipherSeek` trait, make methods generic over

--- a/stream-cipher/CHANGELOG.md
+++ b/stream-cipher/CHANGELOG.md
@@ -7,9 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 0.7.1 (2020-08-25)
 ### Fixed
-- Computation of `SeekNum::to_block_byte` for numbers which are not a power of 2 ([#261])
+- Computation of `SeekNum::to_block_byte` for numbers which are not a power of 2 ([#268])
 
-[#261]: https://github.com/RustCrypto/traits/pull/261
+[#268]: https://github.com/RustCrypto/traits/pull/268
 
 ## 0.7.0 (2020-08-25)
 ### Changed

--- a/stream-cipher/Cargo.toml
+++ b/stream-cipher/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "stream-cipher"
 description = "Stream cipher traits"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/stream-cipher/src/lib.rs
+++ b/stream-cipher/src/lib.rs
@@ -249,9 +249,10 @@ macro_rules! impl_seek_num {
                 }
 
                 fn to_block_byte<T: TryFrom<Self>>(self, bs: u8) -> Result<(T, u8), OverflowError> {
-                    let byte = (self as u8) % bs;
-                    let block = T::try_from(self/(bs as Self)).map_err(|_| OverflowError)?;
-                    Ok((block, byte))
+                    let bs = bs as Self;
+                    let byte = self % bs;
+                    let block = T::try_from(self/bs).map_err(|_| OverflowError)?;
+                    Ok((block, byte as u8))
                 }
             }
         )*


### PR DESCRIPTION
The method was written in assumption that `bs` (block size) is power of two, but unfortunately I forgot that some modes in `gost-modes` have parameter `S`, which allows to change effective block size at will.