### PR TITLE
elliptic-curve: make weierstrass::point::Decode constant time

### DIFF
--- a/elliptic-curve/src/weierstrass/point.rs
+++ b/elliptic-curve/src/weierstrass/point.rs
@@ -2,11 +2,11 @@
 
 use super::Curve;
 use crate::ElementBytes;
-use subtle::CtOption;
+use subtle::{Choice, CtOption};
 
 /// Attempt to decompress an elliptic curve point from its x-coordinate and
 /// a boolean flag indicating whether or not the y-coordinate is odd.
 pub trait Decompress<C: Curve>: Sized {
     /// Attempt to decompress an elliptic curve point
-    fn decompress(x: &ElementBytes<C>, y_is_odd: bool) -> CtOption<Self>;
+    fn decompress(x: &ElementBytes<C>, y_is_odd: Choice) -> CtOption<Self>;
 }


### PR DESCRIPTION
Replaces boolean flag for y-coordinate even/odd with subtle::Choice