### PR TITLE
elliptic-curve: impl FromBytes on NonZeroScalar

### DIFF
--- a/elliptic-curve/src/ecdh.rs
+++ b/elliptic-curve/src/ecdh.rs
@@ -61,16 +61,15 @@ where
 {
     /// Generate a new [`EphemeralSecret`].
     pub fn generate(rng: impl CryptoRng + RngCore) -> Self {
-        Self {
-            scalar: NonZeroScalar::generate(rng),
-        }
+        let scalar = NonZeroScalar::generate(rng);
+        Self { scalar }
     }
 
     /// Get the public key associated with this ephemeral secret.
     ///
     /// The `compress` flag enables point compression.
     pub fn public_key(&self) -> PublicKey<C> {
-        PublicKey::from(C::AffinePoint::generator() * self.scalar.clone())
+        PublicKey::from(C::AffinePoint::generator() * self.scalar)
     }
 
     /// Compute a Diffie-Hellman shared secret from an ephemeral secret and the
@@ -79,7 +78,7 @@ where
         let affine_point = C::AffinePoint::from_encoded_point(public_key);
 
         if affine_point.is_some().into() {
-            let shared_secret = affine_point.unwrap() * self.scalar.clone();
+            let shared_secret = affine_point.unwrap() * self.scalar;
             Ok(SharedSecret::new(shared_secret.into()))
         } else {
             Err(Error)

--- a/elliptic-curve/src/scalar.rs
+++ b/elliptic-curve/src/scalar.rs
@@ -1,7 +1,7 @@
 //! Scalar types
 
-use crate::{Arithmetic, Curve, FromBytes};
-use subtle::{ConstantTimeEq, CtOption};
+use crate::{Arithmetic, Curve, ElementBytes, FromBytes};
+use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 
 #[cfg(feature = "rand")]
 use crate::{
@@ -44,6 +44,29 @@ where
 {
     fn as_ref(&self) -> &C::Scalar {
         &self.scalar
+    }
+}
+
+impl<C> ConditionallySelectable for NonZeroScalar<C>
+where
+    C: Curve + Arithmetic,
+{
+    fn conditional_select(a: &Self, b: &Self, choice: Choice) -> Self {
+        let scalar = C::Scalar::conditional_select(&a.scalar, &b.scalar, choice);
+        Self { scalar }
+    }
+}
+
+impl<C> Copy for NonZeroScalar<C> where C: Curve + Arithmetic {}
+
+impl<C> FromBytes for NonZeroScalar<C>
+where
+    C: Curve + Arithmetic,
+{
+    type Size = C::ElementSize;
+
+    fn from_bytes(bytes: &ElementBytes<C>) -> CtOption<Self> {
+        C::Scalar::from_bytes(bytes).and_then(Self::new)
     }
 }
 


### PR DESCRIPTION
Provides a more direct path from serialized bytes to a NonZeroScalar.