### PR TITLE
elliptic-curve: add `digest` feature and FromDigest trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,6 +128,7 @@ name = "elliptic-curve"
 version = "0.5.0"
 dependencies = [
  "const-oid",
+ "digest 0.9.0",
  "generic-array 0.14.4",
  "hex-literal",
  "rand_core",

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -15,6 +15,7 @@ categories = ["cryptography", "no-std"]
 keywords   = ["crypto", "ecc", "elliptic", "weierstrass"]
 
 [dependencies]
+digest = { version = "0.9", optional = true, path = "../digest" }
 generic-array = { version = "0.14", default-features = false }
 oid = { package = "const-oid", version = "0.1", optional = true }
 rand_core = { version = "0.5", optional = true, default-features = false }

--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -47,6 +47,9 @@ pub use self::{error::Error, secret_key::SecretKey};
 pub use generic_array::{self, typenum::consts};
 pub use subtle;
 
+#[cfg(feature = "digest")]
+pub use digest::{self, Digest};
+
 #[cfg(feature = "oid")]
 pub use oid;
 
@@ -105,6 +108,19 @@ pub trait FromBytes: ConditionallySelectable + Sized {
 
     /// Try to decode this object from bytes
     fn from_bytes(bytes: &GenericArray<u8, Self::Size>) -> CtOption<Self>;
+}
+
+/// Instantiate this type from the output of a digest.
+///
+/// This can be used for implementing hash-to-scalar (e.g. as in ECDSA) or
+/// hash-to-curve algorithms.
+#[cfg(feature = "digest")]
+#[cfg_attr(docsrs, doc(cfg(feature = "digest")))]
+pub trait FromDigest<C: Curve> {
+    /// Instantiate this type from a [`Digest`] instance
+    fn from_digest<D>(digest: D) -> Self
+    where
+        D: Digest<OutputSize = C::ElementSize>;
 }
 
 /// Randomly generate a value.


### PR DESCRIPTION
This is needed in a generic implementation of RFC 6979, but is also potentially useful for things like hash-to-curve.