### PR TITLE
elliptic-curve: remove `digest` crate path directive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,7 +128,7 @@ name = "elliptic-curve"
 version = "0.5.0"
 dependencies = [
  "const-oid",
- "digest 0.9.0",
+ "digest 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "generic-array 0.14.4",
  "hex-literal",
  "rand_core",

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["cryptography", "no-std"]
 keywords   = ["crypto", "ecc", "elliptic", "weierstrass"]
 
 [dependencies]
-digest = { version = "0.9", optional = true, path = "../digest" }
+digest = { version = "0.9", optional = true }
 generic-array = { version = "0.14", default-features = false }
 oid = { package = "const-oid", version = "0.1", optional = true }
 rand_core = { version = "0.5", optional = true, default-features = false }


### PR DESCRIPTION
This makes it incompatible with `signature` when fetched via git, which does not have such a declaration (and cannot, as it'd break the dev-dependency on `sha2`).