### PR TITLE
elliptic-curve: import arithmetic helper functions

### DIFF
--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -30,6 +30,7 @@ pub mod ops;
 pub mod point;
 pub mod scalar;
 pub mod secret_key;
+pub mod util;
 
 #[cfg(feature = "ecdh")]
 #[cfg_attr(docsrs, doc(cfg(feature = "ecdh")))]

--- a/elliptic-curve/src/util.rs
+++ b/elliptic-curve/src/util.rs
@@ -1,0 +1,55 @@
+//! Arithmetic helper functions designed for efficient LLVM lowering.
+//!
+//! These functions are intended for supporting arithmetic on field elements
+//! modeled as multiple "limbs" (e.g. carry chains).
+
+// TODO(tarcieri): enforce 64-bit versions are only available on 64-bit arches
+// i.e. add: #[cfg(target_pointer_width = "64")]
+
+/// Computes `a + b + carry`, returning the result along with the new carry.
+/// 32-bit version.
+#[inline(always)]
+pub const fn adc32(a: u32, b: u32, carry: u32) -> (u32, u32) {
+    let ret = (a as u64) + (b as u64) + (carry as u64);
+    (ret as u32, (ret >> 32) as u32)
+}
+
+/// Computes `a + b + carry`, returning the result along with the new carry.
+/// 64-bit version.
+#[inline(always)]
+pub const fn adc64(a: u64, b: u64, carry: u64) -> (u64, u64) {
+    let ret = (a as u128) + (b as u128) + (carry as u128);
+    (ret as u64, (ret >> 64) as u64)
+}
+
+/// Computes `a - (b + borrow)`, returning the result along with the new borrow.
+/// 32-bit version.
+#[inline(always)]
+pub const fn sbb32(a: u32, b: u32, borrow: u32) -> (u32, u32) {
+    let ret = (a as u64).wrapping_sub((b as u64) + ((borrow >> 31) as u64));
+    (ret as u32, (ret >> 32) as u32)
+}
+
+/// Computes `a - (b + borrow)`, returning the result along with the new borrow.
+/// 64-bit version.
+#[inline(always)]
+pub const fn sbb64(a: u64, b: u64, borrow: u64) -> (u64, u64) {
+    let ret = (a as u128).wrapping_sub((b as u128) + ((borrow >> 63) as u128));
+    (ret as u64, (ret >> 64) as u64)
+}
+
+/// Computes `a + (b * c) + carry`, returning the result along with the new carry.
+/// 32-bit version.
+#[inline(always)]
+pub const fn mac32(a: u32, b: u32, c: u32, carry: u32) -> (u32, u32) {
+    let ret = (a as u64) + ((b as u64) * (c as u64)) + (carry as u64);
+    (ret as u32, (ret >> 32) as u32)
+}
+
+/// Computes `a + (b * c) + carry`, returning the result along with the new carry.
+/// 64-bit version.
+#[inline(always)]
+pub const fn mac64(a: u64, b: u64, c: u64, carry: u64) -> (u64, u64) {
+    let ret = (a as u128) + ((b as u128) * (c as u128)) + (carry as u128);
+    (ret as u64, (ret >> 64) as u64)
+}


### PR DESCRIPTION
These are helper functions for performing arithmetic on field element "limbs", e.g. implementing carry chains.

The particular versions in this file come from the `k256`, which started as a fork of the `p256` crate, and notably provide 32-bit and 64-bit versions of the same functions.

These are potentially helpful to have in the `elliptic-curve` crate for several reasons, most notably for testing things which are generic across elliptic curves without having to provide a full curve arithmetic implementation.

Also having things in one place is nice, and potentially we can use these to provide a generic baseline implementation of certain types of curve arithmetic for curves that don't provide their own arithmetic.

cc @str4d who I had talked to about this at one point.