### PR TITLE
Rename C::ElementSize => FieldSize

### DIFF
--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -71,7 +71,7 @@ use subtle::{ConditionallySelectable, ConstantTimeEq, CtOption};
 use rand_core::{CryptoRng, RngCore};
 
 /// Byte array containing a serialized scalar value (i.e. an integer)
-pub type ElementBytes<C> = GenericArray<u8, <C as Curve>::ElementSize>;
+pub type ElementBytes<C> = GenericArray<u8, <C as Curve>::FieldSize>;
 
 /// Elliptic curve.
 ///
@@ -82,11 +82,12 @@ pub type ElementBytes<C> = GenericArray<u8, <C as Curve>::ElementSize>;
 /// be impl'd by these ZSTs, facilitating types which are generic over elliptic
 /// curves (e.g. [`SecretKey`]).
 pub trait Curve: Clone + Debug + Default + Eq + Ord + Send + Sync {
-    /// Number of bytes required to serialize elements of field elements
-    /// associated with this curve, e.g. elements of the base/scalar fields.
+    /// Size of this curve's field in *bytes*, i.e. the number of bytes needed
+    /// to serialize a field element.
     ///
-    /// This is used for computing the sizes for types related to this curve.
-    type ElementSize: ArrayLength<u8> + Add + Eq + Ord + Unsigned;
+    /// This is used for computing the sizes of field element types related to
+    /// this curve and other types composed from them (e.g. signatures).
+    type FieldSize: ArrayLength<u8> + Add + Eq + Ord + Unsigned;
 }
 
 /// Elliptic curve with curve arithmetic support
@@ -95,7 +96,7 @@ pub trait Arithmetic: Curve {
     type Scalar: ConditionallySelectable
         + ConstantTimeEq
         + Default
-        + FromBytes<Size = Self::ElementSize>
+        + FromBytes<Size = Self::FieldSize>
         + Into<ElementBytes<Self>>;
 
     /// Affine point type for a given curve
@@ -121,7 +122,7 @@ pub trait FromDigest<C: Curve> {
     /// Instantiate this type from a [`Digest`] instance
     fn from_digest<D>(digest: D) -> Self
     where
-        D: Digest<OutputSize = C::ElementSize>;
+        D: Digest<OutputSize = C::FieldSize>;
 }
 
 /// Randomly generate a value.

--- a/elliptic-curve/src/scalar.rs
+++ b/elliptic-curve/src/scalar.rs
@@ -80,7 +80,7 @@ impl<C> FromBytes for NonZeroScalar<C>
 where
     C: Curve + Arithmetic,
 {
-    type Size = C::ElementSize;
+    type Size = C::FieldSize;
 
     fn from_bytes(bytes: &ElementBytes<C>) -> CtOption<Self> {
         C::Scalar::from_bytes(bytes).and_then(Self::new)

--- a/elliptic-curve/src/sec1.rs
+++ b/elliptic-curve/src/sec1.rs
@@ -30,7 +30,7 @@ use zeroize::Zeroize;
 /// Size of a compressed point for the given elliptic curve when encoded
 /// using the SEC1 `Elliptic-Curve-Point-to-Octet-String` algorithm
 /// (including leading `0x02` or `0x03` tag byte).
-pub type CompressedPointSize<C> = <<C as crate::Curve>::ElementSize as Add<U1>>::Output;
+pub type CompressedPointSize<C> = <<C as crate::Curve>::FieldSize as Add<U1>>::Output;
 
 /// Size of an uncompressed point for the given elliptic curve when encoded
 /// using the SEC1 `Elliptic-Curve-Point-to-Octet-String` algorithm
@@ -38,7 +38,7 @@ pub type CompressedPointSize<C> = <<C as crate::Curve>::ElementSize as Add<U1>>:
 pub type UncompressedPointSize<C> = <UntaggedPointSize<C> as Add<U1>>::Output;
 
 /// Size of an untagged point for given elliptic curve.
-pub type UntaggedPointSize<C> = <<C as crate::Curve>::ElementSize as Add>::Output;
+pub type UntaggedPointSize<C> = <<C as crate::Curve>::FieldSize as Add>::Output;
 
 /// SEC1 encoded curve point.
 ///
@@ -75,7 +75,7 @@ where
         let tag = input.first().cloned().ok_or(Error).and_then(Tag::from_u8)?;
 
         // Validate length
-        let expected_len = tag.message_len(C::ElementSize::to_usize());
+        let expected_len = tag.message_len(C::FieldSize::to_usize());
 
         if input.len() != expected_len {
             return Err(Error);
@@ -90,7 +90,7 @@ where
     /// encoded as the concatenated `x || y` coordinates with no leading SEC1
     /// tag byte (which would otherwise be `0x04` for an uncompressed point).
     pub fn from_untagged_bytes(bytes: &GenericArray<u8, UntaggedPointSize<C>>) -> Self {
-        let (x, y) = bytes.split_at(C::ElementSize::to_usize());
+        let (x, y) = bytes.split_at(C::FieldSize::to_usize());
         Self::from_affine_coords(x.into(), y.into(), false)
     }
 
@@ -106,7 +106,7 @@ where
         let mut bytes = GenericArray::default();
         bytes[0] = tag.into();
 
-        let element_size = C::ElementSize::to_usize();
+        let element_size = C::FieldSize::to_usize();
         bytes[1..(element_size + 1)].copy_from_slice(x);
 
         if !compress {
@@ -137,7 +137,7 @@ where
 
     /// Get the length of the encoded point in bytes
     pub fn len(&self) -> usize {
-        self.tag().message_len(C::ElementSize::to_usize())
+        self.tag().message_len(C::FieldSize::to_usize())
     }
 
     /// Get byte slice containing the serialized [`EncodedPoint`].
@@ -217,7 +217,7 @@ where
     /// Get the coordinates for this [`EncodedPoint`] as a pair
     #[inline]
     fn coordinates(&self) -> (&ElementBytes<C>, Option<&ElementBytes<C>>) {
-        let (x, y) = self.bytes[1..].split_at(C::ElementSize::to_usize());
+        let (x, y) = self.bytes[1..].split_at(C::FieldSize::to_usize());
 
         if self.is_compressed() {
             (x.into(), None)
@@ -377,7 +377,7 @@ mod tests {
     struct ExampleCurve;
 
     impl Curve for ExampleCurve {
-        type ElementSize = U32;
+        type FieldSize = U32;
     }
 
     impl weierstrass::Curve for ExampleCurve {

--- a/elliptic-curve/src/secret_key.rs
+++ b/elliptic-curve/src/secret_key.rs
@@ -52,7 +52,7 @@ impl<C: Curve> TryFrom<&[u8]> for SecretKey<C> {
     type Error = Error;
 
     fn try_from(slice: &[u8]) -> Result<Self, Error> {
-        if slice.len() == C::ElementSize::to_usize() {
+        if slice.len() == C::FieldSize::to_usize() {
             Ok(SecretKey {
                 scalar: GenericArray::clone_from_slice(slice),
             })


### PR DESCRIPTION
This is hopefully a more apt description of this particular size.