### PR TITLE
elliptic-curve: extract point::Compression trait

### DIFF
--- a/elliptic-curve/src/point.rs
+++ b/elliptic-curve/src/point.rs
@@ -1,5 +1,11 @@
 //! Traits for elliptic curve points
 
+/// Point compression settings
+pub trait Compression {
+    /// Should point compression be applied by default?
+    const COMPRESS_POINTS: bool;
+}
+
 /// Obtain the generator point.
 pub trait Generator {
     /// Get the generator point for this elliptic curve

--- a/elliptic-curve/src/sec1.rs
+++ b/elliptic-curve/src/sec1.rs
@@ -380,9 +380,7 @@ mod tests {
         type FieldSize = U32;
     }
 
-    impl weierstrass::Curve for ExampleCurve {
-        const COMPRESS_POINTS: bool = false;
-    }
+    impl weierstrass::Curve for ExampleCurve {}
 
     type EncodedPoint = super::EncodedPoint<ExampleCurve>;
 

--- a/elliptic-curve/src/weierstrass.rs
+++ b/elliptic-curve/src/weierstrass.rs
@@ -3,7 +3,4 @@
 pub mod point;
 
 /// Marker trait for elliptic curves in short Weierstrass form
-pub trait Curve: super::Curve {
-    /// Should point compression be applied by default?
-    const COMPRESS_POINTS: bool;
-}
+pub trait Curve: super::Curve {}


### PR DESCRIPTION
Move point compression defaults onto their own trait