### PR TITLE
elliptic-curve: ensure C::AffinePoint Mul<Output=Self::AffinePoint>

### DIFF
--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -100,7 +100,9 @@ pub trait Arithmetic: Curve {
         + Into<ElementBytes<Self>>;
 
     /// Affine point type for a given curve
-    type AffinePoint: ConditionallySelectable + Mul<scalar::NonZeroScalar<Self>> + point::Generator;
+    type AffinePoint: ConditionallySelectable
+        + Mul<scalar::NonZeroScalar<Self>, Output = Self::AffinePoint>
+        + point::Generator;
 }
 
 /// Try to decode the given bytes into a curve element


### PR DESCRIPTION
Ensures that the output of a scalar multiplication with an affine point is also an affine point.