### PR TITLE
elliptic-curve: vendor core `group` traits; add `ff` dependency

### DIFF
--- a/.github/workflows/elliptic-curve.yml
+++ b/.github/workflows/elliptic-curve.yml
@@ -51,6 +51,5 @@ jobs:
         toolchain: ${{ matrix.rust }}
     - run: cargo check --all-features
     - run: cargo test --no-default-features
-    - run: cargo test --no-default-features --features weierstrass
     - run: cargo test
     - run: cargo test --all-features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -129,11 +129,23 @@ version = "0.5.0"
 dependencies = [
  "const-oid",
  "digest 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ff",
  "generic-array 0.14.4",
  "hex-literal",
  "rand_core",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "ff"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01d11efdc125f2647dde5a0f5f88010a5b0f89b700f86052afa1d148c4696047"
+dependencies = [
+ "byteorder",
+ "rand_core",
+ "subtle",
 ]
 
 [[package]]

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -16,9 +16,10 @@ keywords   = ["crypto", "ecc", "elliptic", "weierstrass"]
 
 [dependencies]
 digest = { version = "0.9", optional = true }
+ff = { version = "0.7", default-features = false }
 generic-array = { version = "0.14", default-features = false }
 oid = { package = "const-oid", version = "0.1", optional = true }
-rand_core = { version = "0.5", optional = true, default-features = false }
+rand_core = { version = "0.5", default-features = false }
 subtle = { version = "2.2", default-features = false }
 zeroize = { version = "1", optional = true,  default-features = false }
 
@@ -26,11 +27,9 @@ zeroize = { version = "1", optional = true,  default-features = false }
 hex-literal = "0.2"
 
 [features]
-default = ["rand"]
+default = []
 alloc = []
-ecdh = ["rand", "weierstrass", "zeroize"]
-rand = ["rand_core"]
-weierstrass = []
+ecdh = ["zeroize"]
 std = ["alloc"]
 
 [package.metadata.docs.rs]

--- a/elliptic-curve/src/group.rs
+++ b/elliptic-curve/src/group.rs
@@ -1,0 +1,114 @@
+//! Algebraic group traits vendored from the `group` crate
+
+// Copyrights in the "group" library are retained by their contributors. No
+// copyright assignment is required to contribute to the "group" library.
+//
+// The "group" library is licensed under either of
+//
+// * Apache License, Version 2.0, (see ./LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0)
+// * MIT license (see ./LICENSE-MIT or http://opensource.org/licenses/MIT)
+//
+// at your option.
+//
+// Unless you explicitly state otherwise, any contribution intentionally
+// submitted for inclusion in the work by you, as defined in the Apache-2.0
+// license, shall be dual licensed as above, without any additional terms or
+// conditions.
+
+// TODO(tarcieri): switch to the upstream crate. Blocked on `no_std` support:
+// <https://github.com/zkcrypto/group/pull/9>
+
+use core::fmt;
+use core::iter::Sum;
+use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
+use ff::PrimeField;
+use rand_core::{CryptoRng, RngCore};
+use subtle::Choice;
+
+/// A helper trait for types with a group operation.
+pub trait GroupOps<Rhs = Self, Output = Self>:
+    Add<Rhs, Output = Output> + Sub<Rhs, Output = Output> + AddAssign<Rhs> + SubAssign<Rhs>
+{
+}
+
+impl<T, Rhs, Output> GroupOps<Rhs, Output> for T where
+    T: Add<Rhs, Output = Output> + Sub<Rhs, Output = Output> + AddAssign<Rhs> + SubAssign<Rhs>
+{
+}
+
+/// A helper trait for references with a group operation.
+pub trait GroupOpsOwned<Rhs = Self, Output = Self>: for<'r> GroupOps<&'r Rhs, Output> {}
+impl<T, Rhs, Output> GroupOpsOwned<Rhs, Output> for T where T: for<'r> GroupOps<&'r Rhs, Output> {}
+
+/// A helper trait for types implementing group scalar multiplication.
+pub trait ScalarMul<Rhs, Output = Self>: Mul<Rhs, Output = Output> + MulAssign<Rhs> {}
+
+impl<T, Rhs, Output> ScalarMul<Rhs, Output> for T where T: Mul<Rhs, Output = Output> + MulAssign<Rhs>
+{}
+
+/// A helper trait for references implementing group scalar multiplication.
+pub trait ScalarMulOwned<Rhs, Output = Self>: for<'r> ScalarMul<&'r Rhs, Output> {}
+impl<T, Rhs, Output> ScalarMulOwned<Rhs, Output> for T where T: for<'r> ScalarMul<&'r Rhs, Output> {}
+
+/// This trait represents an element of a cryptographic group.
+pub trait Group:
+    Clone
+    + Copy
+    + fmt::Debug
+    + fmt::Display
+    + Eq
+    + Sized
+    + Send
+    + Sync
+    + 'static
+    + Sum
+    + for<'a> Sum<&'a Self>
+    + Neg<Output = Self>
+    + GroupOps
+    + GroupOpsOwned
+    + ScalarMul<<Self as Group>::Scalar>
+    + ScalarMulOwned<<Self as Group>::Scalar>
+{
+    /// Scalars modulo the order of this group's scalar field.
+    type Scalar: PrimeField;
+
+    /// Returns an element chosen uniformly at random from the non-identity elements of
+    /// this group.
+    ///
+    /// This function is non-deterministic, and samples from the user-provided RNG.
+    fn random(rng: impl CryptoRng + RngCore) -> Self;
+
+    /// Returns the additive identity, also known as the "neutral element".
+    fn identity() -> Self;
+
+    /// Returns a fixed generator of the prime-order subgroup.
+    fn generator() -> Self;
+
+    /// Determines if this point is the identity.
+    fn is_identity(&self) -> Choice;
+
+    /// Doubles this element.
+    #[must_use]
+    fn double(&self) -> Self;
+}
+
+/// Efficient representation of an elliptic curve point guaranteed.
+pub trait Curve:
+    Group + GroupOps<<Self as Curve>::AffineRepr> + GroupOpsOwned<<Self as Curve>::AffineRepr>
+{
+    /// The affine representation for this elliptic curve.
+    type AffineRepr;
+
+    /// Converts a batch of projective elements into affine elements. This function will
+    /// panic if `p.len() != q.len()`.
+    fn batch_normalize(p: &[Self], q: &mut [Self::AffineRepr]) {
+        assert_eq!(p.len(), q.len());
+
+        for (p, q) in p.iter().zip(q.iter_mut()) {
+            *q = p.to_affine();
+        }
+    }
+
+    /// Converts this element into its affine representation.
+    fn to_affine(&self) -> Self::AffineRepr;
+}

--- a/elliptic-curve/src/scalar.rs
+++ b/elliptic-curve/src/scalar.rs
@@ -1,14 +1,12 @@
 //! Scalar types
 
-use crate::{ops::Invert, Arithmetic, Curve, ElementBytes, FromBytes};
+use crate::{
+    ops::Invert,
+    rand_core::{CryptoRng, RngCore},
+    Arithmetic, Curve, ElementBytes, FromBytes, Generate,
+};
 use core::ops::Deref;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
-
-#[cfg(feature = "rand")]
-use crate::{
-    rand_core::{CryptoRng, RngCore},
-    Generate,
-};
 
 #[cfg(feature = "zeroize")]
 use zeroize::Zeroize;
@@ -109,7 +107,6 @@ where
     }
 }
 
-#[cfg(feature = "rand")]
 impl<C> Generate for NonZeroScalar<C>
 where
     C: Curve + Arithmetic,

--- a/elliptic-curve/src/secret_key.rs
+++ b/elliptic-curve/src/secret_key.rs
@@ -8,17 +8,13 @@
 //! zeroing it out of memory securely on drop.
 
 use crate::{error::Error, Curve, ElementBytes};
+use crate::{Arithmetic, Generate};
 use core::{
     convert::{TryFrom, TryInto},
     fmt::{self, Debug},
 };
 use generic_array::{typenum::Unsigned, GenericArray};
-
-#[cfg(feature = "rand")]
-use {
-    crate::{Arithmetic, Generate},
-    rand_core::{CryptoRng, RngCore},
-};
+use rand_core::{CryptoRng, RngCore};
 
 /// Elliptic curve secret keys.
 ///
@@ -68,8 +64,6 @@ impl<C: Curve> Debug for SecretKey<C> {
     }
 }
 
-#[cfg(feature = "rand")]
-#[cfg_attr(docsrs, doc(cfg(feature = "rand")))]
 impl<C> Generate for SecretKey<C>
 where
     C: Curve + Arithmetic,


### PR DESCRIPTION
Vendors the core set of group traits from the `group` crate:

https://github.com/zkcrypto/group

Using the upstream crate is presently blocked on `no_std` support:

https://github.com/zkcrypto/group/pull/9

However, aside from a suggested change to the RNG API (zkcrypto/group#10) the traits used in this PR are verbatim from the upstream crate, so migrating to it should be easy.

This PR also removes the `rand` and `weierstrass` features from the `elliptic-curve` crate, making `rand_core` a hard requirement, since it seems at least `rand_core` will probably be a hard requirement for `group`, and requiring an RNG as a hard dependency makes sense.

cc @str4d @ebfull