### PR TITLE
elliptic-curve: add `ff` and `group` crate dependencies

### DIFF
--- a/.github/workflows/elliptic-curve.yml
+++ b/.github/workflows/elliptic-curve.yml
@@ -51,6 +51,5 @@ jobs:
         toolchain: ${{ matrix.rust }}
     - run: cargo check --all-features
     - run: cargo test --no-default-features
-    - run: cargo test --no-default-features --features weierstrass
     - run: cargo test
     - run: cargo test --all-features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -129,11 +129,24 @@ version = "0.5.0"
 dependencies = [
  "const-oid",
  "digest 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ff",
  "generic-array 0.14.4",
+ "group",
  "hex-literal",
  "rand_core",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "ff"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01d11efdc125f2647dde5a0f5f88010a5b0f89b700f86052afa1d148c4696047"
+dependencies = [
+ "byteorder",
+ "rand_core",
+ "subtle",
 ]
 
 [[package]]
@@ -162,6 +175,17 @@ checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "group"
+version = "0.7.0"
+source = "git+https://github.com/zkcrypto/group.git#2942324876cdbb5c94140ad39ae83da642c30374"
+dependencies = [
+ "byteorder",
+ "ff",
+ "rand_core",
+ "subtle",
 ]
 
 [[package]]
@@ -218,9 +242,9 @@ checksum = "99c605b9a0adc77b7211c6b1f722dcb613d68d66859a44f3d485a6da332b0598"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04f5f085b5d71e2188cb8271e5da0161ad52c3f227a661a3c135fdf28e258b12"
+checksum = "175c513d55719db99da20232b06cda8bab6b83ec2d04e3283edf0213c37c1a29"
 dependencies = [
  "unicode-xid",
 ]
@@ -297,9 +321,9 @@ checksum = "502d53007c02d7605a05df1c1a73ee436952781653da5d0bf57ad608f66932c1"
 
 [[package]]
 name = "syn"
-version = "1.0.38"
+version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e69abc24912995b3038597a7a593be5053eb0fb44f3cc5beec0deb421790c1f4"
+checksum = "891d8d6567fe7c7f8835a3a98af4208f3846fba258c1bc3c31d6e506239f11f9"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,6 @@ members = [
     "stream-cipher",
     "universal-hash",
 ]
+
+[patch.crates-io]
+group = { git = "https://github.com/zkcrypto/group.git" }

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -16,9 +16,11 @@ keywords   = ["crypto", "ecc", "elliptic", "weierstrass"]
 
 [dependencies]
 digest = { version = "0.9", optional = true }
+ff = { version = "0.7", default-features = false }
+group = { version = "0.7", default-features = false }
 generic-array = { version = "0.14", default-features = false }
 oid = { package = "const-oid", version = "0.1", optional = true }
-rand_core = { version = "0.5", optional = true, default-features = false }
+rand_core = { version = "0.5", default-features = false }
 subtle = { version = "2.2", default-features = false }
 zeroize = { version = "1", optional = true,  default-features = false }
 
@@ -26,11 +28,9 @@ zeroize = { version = "1", optional = true,  default-features = false }
 hex-literal = "0.2"
 
 [features]
-default = ["rand"]
+default = []
 alloc = []
-ecdh = ["rand", "weierstrass", "zeroize"]
-rand = ["rand_core"]
-weierstrass = []
+ecdh = ["zeroize"]
 std = ["alloc"]
 
 [package.metadata.docs.rs]

--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -29,23 +29,20 @@ pub mod error;
 pub mod ops;
 pub mod point;
 pub mod scalar;
+pub mod sec1;
 pub mod secret_key;
 pub mod util;
+pub mod weierstrass;
 
 #[cfg(feature = "ecdh")]
 #[cfg_attr(docsrs, doc(cfg(feature = "ecdh")))]
 pub mod ecdh;
 
-#[cfg(feature = "weierstrass")]
-#[cfg_attr(docsrs, doc(cfg(feature = "weierstrass")))]
-pub mod sec1;
-
-#[cfg(feature = "weierstrass")]
-#[cfg_attr(docsrs, doc(cfg(feature = "weierstrass")))]
-pub mod weierstrass;
-
 pub use self::{error::Error, secret_key::SecretKey};
+pub use ff;
 pub use generic_array::{self, typenum::consts};
+pub use group;
+pub use rand_core;
 pub use subtle;
 
 #[cfg(feature = "digest")]
@@ -53,9 +50,6 @@ pub use digest::{self, Digest};
 
 #[cfg(feature = "oid")]
 pub use oid;
-
-#[cfg(feature = "rand")]
-pub use rand_core;
 
 #[cfg(feature = "zeroize")]
 pub use zeroize;
@@ -65,10 +59,8 @@ use core::{
     ops::{Add, Mul},
 };
 use generic_array::{typenum::Unsigned, ArrayLength, GenericArray};
-use subtle::{ConditionallySelectable, ConstantTimeEq, CtOption};
-
-#[cfg(feature = "rand")]
 use rand_core::{CryptoRng, RngCore};
+use subtle::{ConditionallySelectable, ConstantTimeEq, CtOption};
 
 /// Byte array containing a serialized scalar value (i.e. an integer)
 pub type ElementBytes<C> = GenericArray<u8, <C as Curve>::FieldSize>;
@@ -114,6 +106,14 @@ pub trait FromBytes: ConditionallySelectable + Sized {
     fn from_bytes(bytes: &GenericArray<u8, Self::Size>) -> CtOption<Self>;
 }
 
+/// Randomly generate a value.
+///
+/// Primarily intended for use with scalar types for a particular curve.
+pub trait Generate {
+    /// Generate a random element of this type using the provided [`CryptoRng`]
+    fn generate(rng: impl CryptoRng + RngCore) -> Self;
+}
+
 /// Instantiate this type from the output of a digest.
 ///
 /// This can be used for implementing hash-to-scalar (e.g. as in ECDSA) or
@@ -125,16 +125,6 @@ pub trait FromDigest<C: Curve> {
     fn from_digest<D>(digest: D) -> Self
     where
         D: Digest<OutputSize = C::FieldSize>;
-}
-
-/// Randomly generate a value.
-///
-/// Primarily intended for use with scalar types for a particular curve.
-#[cfg(feature = "rand")]
-#[cfg_attr(docsrs, doc(cfg(feature = "rand")))]
-pub trait Generate {
-    /// Generate a random element of this type using the provided [`CryptoRng`]
-    fn generate(rng: impl CryptoRng + RngCore) -> Self;
 }
 
 /// Associate an object identifier (OID) with a curve

--- a/elliptic-curve/src/scalar.rs
+++ b/elliptic-curve/src/scalar.rs
@@ -1,14 +1,12 @@
 //! Scalar types
 
-use crate::{ops::Invert, Arithmetic, Curve, ElementBytes, FromBytes};
+use crate::{
+    ops::Invert,
+    rand_core::{CryptoRng, RngCore},
+    Arithmetic, Curve, ElementBytes, FromBytes, Generate,
+};
 use core::ops::Deref;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
-
-#[cfg(feature = "rand")]
-use crate::{
-    rand_core::{CryptoRng, RngCore},
-    Generate,
-};
 
 #[cfg(feature = "zeroize")]
 use zeroize::Zeroize;
@@ -109,7 +107,6 @@ where
     }
 }
 
-#[cfg(feature = "rand")]
 impl<C> Generate for NonZeroScalar<C>
 where
     C: Curve + Arithmetic,

--- a/elliptic-curve/src/secret_key.rs
+++ b/elliptic-curve/src/secret_key.rs
@@ -8,17 +8,13 @@
 //! zeroing it out of memory securely on drop.
 
 use crate::{error::Error, Curve, ElementBytes};
+use crate::{Arithmetic, Generate};
 use core::{
     convert::{TryFrom, TryInto},
     fmt::{self, Debug},
 };
 use generic_array::{typenum::Unsigned, GenericArray};
-
-#[cfg(feature = "rand")]
-use {
-    crate::{Arithmetic, Generate},
-    rand_core::{CryptoRng, RngCore},
-};
+use rand_core::{CryptoRng, RngCore};
 
 /// Elliptic curve secret keys.
 ///
@@ -68,8 +64,6 @@ impl<C: Curve> Debug for SecretKey<C> {
     }
 }
 
-#[cfg(feature = "rand")]
-#[cfg_attr(docsrs, doc(cfg(feature = "rand")))]
 impl<C> Generate for SecretKey<C>
 where
     C: Curve + Arithmetic,


### PR DESCRIPTION
Adds the `ff` and `group` crates as dependencies, with the goal of replacing some of the existing traits and trait relationships in `elliptic-curve` with ones from `ff`/`group`.

This PR also removes the `rand` and `weierstrass` features from the `elliptic-curve` crate, making `rand_core` a hard requirement, since it seems at least `rand_core` will probably be a hard requirement for `group`, and requiring an RNG as a hard dependency makes sense.