### PR TITLE
elliptic-curve: bump minimum subtle version to 2.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -315,15 +315,15 @@ dependencies = [
 
 [[package]]
 name = "subtle"
-version = "2.2.3"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "502d53007c02d7605a05df1c1a73ee436952781653da5d0bf57ad608f66932c1"
+checksum = "343f3f510c2915908f155e94f17220b19ccfacf2a64a2a5d8004f2c3e311e7fd"
 
 [[package]]
 name = "syn"
-version = "1.0.39"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891d8d6567fe7c7f8835a3a98af4208f3846fba258c1bc3c31d6e506239f11f9"
+checksum = "963f7d3cc59b59b9325165add223142bbf1df27655d07789f109896d353d8350"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -21,7 +21,7 @@ group = { version = "0.7", default-features = false }
 generic-array = { version = "0.14", default-features = false }
 oid = { package = "const-oid", version = "0.1", optional = true }
 rand_core = { version = "0.5", default-features = false }
-subtle = { version = "2.2", default-features = false }
+subtle = { version = "2.3", default-features = false }
 zeroize = { version = "1", optional = true,  default-features = false }
 
 [dev-dependencies]


### PR DESCRIPTION
This version has the following extremely useful impls:

- `From<CtOption> for Option`
- `ConstantTimeEq` for `Choice`

There is a bunch of code in `RustCrypto/elliptic-curve` that can be cleaned up/simplified assuming these are available.