### PR TITLE
elliptic-curve: add `arithmetic` feature

### DIFF
--- a/.github/workflows/elliptic-curve.yml
+++ b/.github/workflows/elliptic-curve.yml
@@ -36,6 +36,7 @@ jobs:
           target: ${{ matrix.target }}
           override: true
       - run: cargo build --no-default-features --release --target ${{ matrix.target }}
+      - run: cargo build --no-default-features --release --target ${{ matrix.target }} --features arithmetic
   test:
     runs-on: ubuntu-latest
     strategy:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,6 +138,7 @@ dependencies = [
 name = "elliptic-curve"
 version = "0.5.0"
 dependencies = [
+ "bitvec",
  "const-oid",
  "digest 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ff",

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -15,9 +15,10 @@ categories = ["cryptography", "no-std"]
 keywords   = ["crypto", "ecc", "elliptic", "weierstrass"]
 
 [dependencies]
+bitvec = { version = "0.18", optional = true, default-features = false }
 digest = { version = "0.9", optional = true }
-ff = { version = "0.8", default-features = false }
-group = { version = "0.8", default-features = false }
+ff = { version = "0.8", optional = true, default-features = false }
+group = { version = "0.8", optional = true, default-features = false }
 generic-array = { version = "0.14", default-features = false }
 oid = { package = "const-oid", version = "0.1", optional = true }
 rand_core = { version = "0.5", default-features = false }
@@ -28,9 +29,10 @@ zeroize = { version = "1", optional = true,  default-features = false }
 hex-literal = "0.2"
 
 [features]
-default = []
+default = ["arithmetic"]
 alloc = []
-ecdh = ["zeroize"]
+arithmetic = ["bitvec", "ff", "group"]
+ecdh = ["arithmetic", "zeroize"]
 std = ["alloc"]
 
 [package.metadata.docs.rs]

--- a/elliptic-curve/src/ops.rs
+++ b/elliptic-curve/src/ops.rs
@@ -1,5 +1,7 @@
 //! Traits for arithmetic operations on elliptic curve field elements
 
+pub use core::ops::{Add, Mul};
+
 use subtle::CtOption;
 
 /// Perform an inversion on a field element (i.e. base field element or scalar)

--- a/elliptic-curve/src/sec1.rs
+++ b/elliptic-curve/src/sec1.rs
@@ -5,24 +5,25 @@
 //!
 //! <https://www.secg.org/sec1-v2.pdf>
 
-use crate::{
-    point::Generator,
-    scalar::NonZeroScalar,
-    weierstrass::{point::Decompress, Curve},
-    Arithmetic, ElementBytes, Error, FromBytes, SecretKey,
-};
+use crate::{weierstrass::Curve, ElementBytes, Error};
 use core::{
     fmt::{self, Debug},
-    ops::{Add, Mul},
+    ops::Add,
 };
 use generic_array::{
     typenum::{Unsigned, U1},
     ArrayLength, GenericArray,
 };
-use subtle::{Choice, CtOption};
+use subtle::CtOption;
 
 #[cfg(feature = "alloc")]
 use alloc::boxed::Box;
+
+#[cfg(feature = "arithmetic")]
+use crate::{
+    ops::Mul, point::Generator, scalar::NonZeroScalar, subtle::Choice,
+    weierstrass::point::Decompress, Arithmetic, FromBytes, SecretKey,
+};
 
 #[cfg(feature = "zeroize")]
 use zeroize::Zeroize;
@@ -124,6 +125,8 @@ where
     /// [`SecretKey`].
     ///
     /// The `compress` flag requests point compression.
+    #[cfg(feature = "arithmetic")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
     pub fn from_secret_key(secret_key: &SecretKey<C>, compress: bool) -> Result<Self, Error>
     where
         C: Arithmetic,
@@ -170,6 +173,8 @@ where
     }
 
     /// Decompress this [`EncodedPoint`], returning a new [`EncodedPoint`].
+    #[cfg(feature = "arithmetic")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
     pub fn decompress(&self) -> CtOption<Self>
     where
         C: Arithmetic,

--- a/elliptic-curve/src/secret_key.rs
+++ b/elliptic-curve/src/secret_key.rs
@@ -8,12 +8,15 @@
 //! zeroing it out of memory securely on drop.
 
 use crate::{error::Error, Curve, ElementBytes};
-use crate::{Arithmetic, Generate};
 use core::{
     convert::{TryFrom, TryInto},
     fmt::{self, Debug},
 };
 use generic_array::{typenum::Unsigned, GenericArray};
+
+#[cfg(feature = "arithmetic")]
+use crate::{scalar::NonZeroScalar, Arithmetic, Generate};
+#[cfg(feature = "arithmetic")]
 use rand_core::{CryptoRng, RngCore};
 
 /// Elliptic curve secret keys.
@@ -64,6 +67,7 @@ impl<C: Curve> Debug for SecretKey<C> {
     }
 }
 
+#[cfg(feature = "arithmetic")]
 impl<C> Generate for SecretKey<C>
 where
     C: Curve + Arithmetic,
@@ -72,7 +76,7 @@ where
     /// Generate a new [`SecretKey`]
     fn generate(rng: impl CryptoRng + RngCore) -> Self {
         Self {
-            scalar: C::Scalar::generate(rng).into(),
+            scalar: NonZeroScalar::<C>::generate(rng).into(),
         }
     }
 }


### PR DESCRIPTION
This crate now has a large(r) number of dependencies via the `ff` and `group` crates (notably the recently introduced `bitvec` and its transitive dependencies).

This commit adds an `arithmetic` feature and gates related functionality under it, along with the `ff` and `group` crate dependencies.

This ensures these dependencies (and their transitive dependencies) can be excluded when the `arithmetic` features of elliptic curve implementations are non-existent or an associated feature disabled.