### PR TITLE
elliptic-curve: rename FieldBits to ScalarBits

### DIFF
--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -70,16 +70,9 @@ use rand_core::{CryptoRng, RngCore};
 use subtle::{ConditionallySelectable, CtOption};
 
 #[cfg(feature = "arithmetic")]
-use bitvec::{array::BitArray, order::Lsb0};
-#[cfg(feature = "arithmetic")]
 use core::ops::Mul;
 #[cfg(feature = "arithmetic")]
 use subtle::ConstantTimeEq;
-
-/// Bit representation of a scalar field element of a given curve.
-#[cfg(feature = "arithmetic")]
-#[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
-pub type FieldBits<C> = BitArray<Lsb0, <<C as Arithmetic>::Scalar as ff::PrimeField>::ReprBits>;
 
 /// Byte representation of a base/scalar field element of a given curve.
 pub type ElementBytes<C> = GenericArray<u8, <C as Curve>::FieldSize>;

--- a/elliptic-curve/src/scalar.rs
+++ b/elliptic-curve/src/scalar.rs
@@ -5,11 +5,15 @@ use crate::{
     rand_core::{CryptoRng, RngCore},
     Arithmetic, Curve, ElementBytes, FromBytes, Generate,
 };
+use bitvec::{array::BitArray, order::Lsb0};
 use core::ops::Deref;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 
 #[cfg(feature = "zeroize")]
 use zeroize::Zeroize;
+
+/// Bit representation of a scalar field element of a given curve.
+pub type ScalarBits<C> = BitArray<Lsb0, <<C as Arithmetic>::Scalar as ff::PrimeField>::ReprBits>;
 
 /// Non-zero scalar type.
 ///


### PR DESCRIPTION
This is a property of the scalar field specifically and importantly retains layout/properties of the internal scalar field representation.