### PR TITLE
elliptic-curve: remove `Generate` trait

### DIFF
--- a/elliptic-curve/src/ecdh.rs
+++ b/elliptic-curve/src/ecdh.rs
@@ -27,7 +27,7 @@ use crate::{
     scalar::NonZeroScalar,
     sec1::{self, FromEncodedPoint, UncompressedPointSize, UntaggedPointSize},
     weierstrass::Curve,
-    Arithmetic, ElementBytes, Error, Generate,
+    Arithmetic, ElementBytes, Error,
 };
 use core::ops::{Add, Mul};
 use rand_core::{CryptoRng, RngCore};
@@ -45,7 +45,7 @@ pub type PublicKey<C> = sec1::EncodedPoint<C>;
 pub struct EphemeralSecret<C>
 where
     C: Curve + Arithmetic,
-    C::Scalar: Generate + Zeroize,
+    C::Scalar: Zeroize,
 {
     scalar: NonZeroScalar<C>,
 }
@@ -53,15 +53,15 @@ where
 impl<C> EphemeralSecret<C>
 where
     C: Curve + Arithmetic,
-    C::Scalar: Clone + Generate + Zeroize,
+    C::Scalar: Clone + Zeroize,
     C::AffinePoint: FromEncodedPoint<C> + Mul<NonZeroScalar<C>, Output = C::AffinePoint> + Zeroize,
     PublicKey<C>: From<C::AffinePoint>,
     UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
     UncompressedPointSize<C>: ArrayLength<u8>,
 {
-    /// Generate a new [`EphemeralSecret`].
-    pub fn generate(rng: impl CryptoRng + RngCore) -> Self {
-        let scalar = NonZeroScalar::generate(rng);
+    /// Generate a cryptographically random [`EphemeralSecret`].
+    pub fn random(rng: impl CryptoRng + RngCore) -> Self {
+        let scalar = NonZeroScalar::random(rng);
         Self { scalar }
     }
 
@@ -89,7 +89,7 @@ where
 impl<C> From<&EphemeralSecret<C>> for PublicKey<C>
 where
     C: Curve + Arithmetic,
-    C::Scalar: Clone + Generate + Zeroize,
+    C::Scalar: Clone + Zeroize,
     C::AffinePoint: FromEncodedPoint<C> + Mul<NonZeroScalar<C>, Output = C::AffinePoint> + Zeroize,
     PublicKey<C>: From<C::AffinePoint>,
     UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
@@ -103,7 +103,7 @@ where
 impl<C> Zeroize for EphemeralSecret<C>
 where
     C: Curve + Arithmetic,
-    C::Scalar: Generate + Zeroize,
+    C::Scalar: Zeroize,
 {
     fn zeroize(&mut self) {
         self.scalar.zeroize()
@@ -113,7 +113,7 @@ where
 impl<C> Drop for EphemeralSecret<C>
 where
     C: Curve + Arithmetic,
-    C::Scalar: Generate + Zeroize,
+    C::Scalar: Zeroize,
 {
     fn drop(&mut self) {
         self.zeroize();

--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -66,7 +66,6 @@ pub use zeroize;
 
 use core::{fmt::Debug, ops::Add};
 use generic_array::{typenum::Unsigned, ArrayLength, GenericArray};
-use rand_core::{CryptoRng, RngCore};
 use subtle::{ConditionallySelectable, CtOption};
 
 #[cfg(feature = "arithmetic")]
@@ -122,14 +121,6 @@ pub trait FromBytes: ConditionallySelectable + Sized {
 
     /// Try to decode this object from bytes
     fn from_bytes(bytes: &GenericArray<u8, Self::Size>) -> CtOption<Self>;
-}
-
-/// Randomly generate a value.
-///
-/// Primarily intended for use with scalar types for a particular curve.
-pub trait Generate {
-    /// Generate a random element of this type using the provided [`CryptoRng`]
-    fn generate(rng: impl CryptoRng + RngCore) -> Self;
 }
 
 /// Instantiate this type from the output of a digest.

--- a/elliptic-curve/src/ops.rs
+++ b/elliptic-curve/src/ops.rs
@@ -1,6 +1,6 @@
 //! Traits for arithmetic operations on elliptic curve field elements
 
-pub use core::ops::{Add, Mul};
+pub use core::ops::{Add, AddAssign, Mul, Neg, Sub, SubAssign};
 
 use subtle::CtOption;
 
@@ -11,4 +11,13 @@ pub trait Invert {
 
     /// Invert a field element.
     fn invert(&self) -> CtOption<Self::Output>;
+}
+
+#[cfg(feature = "arithmetic")]
+impl<F: ff::Field> Invert for F {
+    type Output = F;
+
+    fn invert(&self) -> CtOption<F> {
+        ff::Field::invert(self)
+    }
 }

--- a/elliptic-curve/src/secret_key.rs
+++ b/elliptic-curve/src/secret_key.rs
@@ -15,7 +15,7 @@ use core::{
 use generic_array::{typenum::Unsigned, GenericArray};
 
 #[cfg(feature = "arithmetic")]
-use crate::{scalar::NonZeroScalar, Arithmetic, Generate};
+use crate::{scalar::NonZeroScalar, Arithmetic};
 #[cfg(feature = "arithmetic")]
 use rand_core::{CryptoRng, RngCore};
 
@@ -31,6 +31,18 @@ pub struct SecretKey<C: Curve> {
 }
 
 impl<C: Curve> SecretKey<C> {
+    /// Generate a random [`SecretKey`]
+    #[cfg(feature = "arithmetic")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
+    pub fn random(rng: impl CryptoRng + RngCore) -> Self
+    where
+        C: Arithmetic,
+    {
+        Self {
+            scalar: NonZeroScalar::<C>::random(rng).into(),
+        }
+    }
+
     /// Create a new secret key from a serialized scalar value
     pub fn new(bytes: ElementBytes<C>) -> Self {
         Self { scalar: bytes }
@@ -64,20 +76,6 @@ impl<C: Curve> TryFrom<&[u8]> for SecretKey<C> {
 impl<C: Curve> Debug for SecretKey<C> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "SecretKey<{:?}>{{ ... }}", C::default())
-    }
-}
-
-#[cfg(feature = "arithmetic")]
-impl<C> Generate for SecretKey<C>
-where
-    C: Curve + Arithmetic,
-    C::Scalar: Generate + Into<ElementBytes<C>>,
-{
-    /// Generate a new [`SecretKey`]
-    fn generate(rng: impl CryptoRng + RngCore) -> Self {
-        Self {
-            scalar: NonZeroScalar::<C>::generate(rng).into(),
-        }
     }
 }
 


### PR DESCRIPTION
The functionality it previously provided as a trait is now available via methods like `Field::random` and `Group::random`.

The other places where it was being used have been converted to inherent methods on concrete types, which is easier to use because there's no need to import a trait.