### PR TITLE
elliptic-curve: rename ElementBytes => FieldBytes

### DIFF
--- a/elliptic-curve/src/ecdh.rs
+++ b/elliptic-curve/src/ecdh.rs
@@ -27,7 +27,7 @@ use crate::{
     scalar::NonZeroScalar,
     sec1::{self, FromEncodedPoint, UncompressedPointSize, UntaggedPointSize},
     weierstrass::Curve,
-    Arithmetic, ElementBytes, Error,
+    Arithmetic, Error, FieldBytes,
 };
 use core::ops::{Add, Mul};
 use rand_core::{CryptoRng, RngCore};
@@ -135,7 +135,7 @@ where
 /// Function (KDF) or cryptographic hash function to produce a symmetric key.
 pub struct SharedSecret<C: Curve + Arithmetic> {
     /// Computed secret value
-    secret_bytes: ElementBytes<C>,
+    secret_bytes: FieldBytes<C>,
 }
 
 impl<C> SharedSecret<C>
@@ -158,7 +158,7 @@ where
     /// should not be used directly as a symmetric encryption key, but instead
     /// as input to a KDF (or failing that, a hash function) used to produce
     /// a symmetric key.
-    pub fn as_bytes(&self) -> &ElementBytes<C> {
+    pub fn as_bytes(&self) -> &FieldBytes<C> {
         &self.secret_bytes
     }
 }

--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -74,7 +74,7 @@ use core::ops::Mul;
 use subtle::ConstantTimeEq;
 
 /// Byte representation of a base/scalar field element of a given curve.
-pub type ElementBytes<C> = GenericArray<u8, <C as Curve>::FieldSize>;
+pub type FieldBytes<C> = GenericArray<u8, <C as Curve>::FieldSize>;
 
 /// Elliptic curve.
 ///
@@ -102,7 +102,7 @@ pub trait Arithmetic: Curve {
         + ConstantTimeEq
         + Default
         + FromBytes<Size = Self::FieldSize>
-        + Into<ElementBytes<Self>>;
+        + Into<FieldBytes<Self>>;
 
     /// Elliptic curve point in affine coordinates.
     type AffinePoint: ConditionallySelectable

--- a/elliptic-curve/src/scalar.rs
+++ b/elliptic-curve/src/scalar.rs
@@ -3,7 +3,7 @@
 use crate::{
     ops::Invert,
     rand_core::{CryptoRng, RngCore},
-    Arithmetic, Curve, ElementBytes, FromBytes,
+    Arithmetic, Curve, FieldBytes, FromBytes,
 };
 use bitvec::{array::BitArray, order::Lsb0};
 use core::ops::Deref;
@@ -54,7 +54,7 @@ where
     }
 
     /// Serialize this [`NonZeroScalar`] as a byte array
-    pub fn to_bytes(&self) -> ElementBytes<C> {
+    pub fn to_bytes(&self) -> FieldBytes<C> {
         self.scalar.into()
     }
 }
@@ -97,16 +97,16 @@ where
 {
     type Size = C::FieldSize;
 
-    fn from_bytes(bytes: &ElementBytes<C>) -> CtOption<Self> {
+    fn from_bytes(bytes: &FieldBytes<C>) -> CtOption<Self> {
         C::Scalar::from_bytes(bytes).and_then(Self::new)
     }
 }
 
-impl<C> From<NonZeroScalar<C>> for ElementBytes<C>
+impl<C> From<NonZeroScalar<C>> for FieldBytes<C>
 where
     C: Curve + Arithmetic,
 {
-    fn from(scalar: NonZeroScalar<C>) -> ElementBytes<C> {
+    fn from(scalar: NonZeroScalar<C>) -> FieldBytes<C> {
         scalar.to_bytes()
     }
 }

--- a/elliptic-curve/src/sec1.rs
+++ b/elliptic-curve/src/sec1.rs
@@ -5,7 +5,7 @@
 //!
 //! <https://www.secg.org/sec1-v2.pdf>
 
-use crate::{weierstrass::Curve, ElementBytes, Error};
+use crate::{weierstrass::Curve, Error, FieldBytes};
 use core::{
     fmt::{self, Debug},
     ops::Add,
@@ -97,11 +97,7 @@ where
 
     /// Encode an elliptic curve point from big endian serialized coordinates
     /// (with optional point compression)
-    pub fn from_affine_coordinates(
-        x: &ElementBytes<C>,
-        y: &ElementBytes<C>,
-        compress: bool,
-    ) -> Self {
+    pub fn from_affine_coordinates(x: &FieldBytes<C>, y: &FieldBytes<C>, compress: bool) -> Self {
         let tag = if compress {
             Tag::compress_y(y.as_slice())
         } else {
@@ -230,7 +226,7 @@ where
     }
 
     /// Get the x-coordinate for this [`EncodedPoint`]
-    pub fn x(&self) -> &ElementBytes<C> {
+    pub fn x(&self) -> &FieldBytes<C> {
         match self.coordinates() {
             Coordinates::Compressed { x, .. } => x,
             Coordinates::Uncompressed { x, .. } => x,
@@ -240,7 +236,7 @@ where
     /// Get the y-coordinate for this [`EncodedPoint`].
     ///
     /// Returns `None` if this point is compressed.
-    pub fn y(&self) -> Option<&ElementBytes<C>> {
+    pub fn y(&self) -> Option<&FieldBytes<C>> {
         match self.coordinates() {
             Coordinates::Compressed { .. } => None,
             Coordinates::Uncompressed { y, .. } => Some(y),
@@ -299,7 +295,7 @@ pub enum Coordinates<'a, C: Curve> {
     /// Compressed curve point
     Compressed {
         /// x-coordinate
-        x: &'a ElementBytes<C>,
+        x: &'a FieldBytes<C>,
 
         /// Is the y-coordinate odd?
         y_is_odd: bool,
@@ -308,10 +304,10 @@ pub enum Coordinates<'a, C: Curve> {
     /// Uncompressed curve point
     Uncompressed {
         /// x-coordinate
-        x: &'a ElementBytes<C>,
+        x: &'a FieldBytes<C>,
 
         /// y-coordinate
-        y: &'a ElementBytes<C>,
+        y: &'a FieldBytes<C>,
     },
 }
 

--- a/elliptic-curve/src/secret_key.rs
+++ b/elliptic-curve/src/secret_key.rs
@@ -7,7 +7,7 @@
 //! When the `zeroize` feature of this crate is enabled, it also handles
 //! zeroing it out of memory securely on drop.
 
-use crate::{error::Error, Curve, ElementBytes};
+use crate::{error::Error, Curve, FieldBytes};
 use core::{
     convert::{TryFrom, TryInto},
     fmt::{self, Debug},
@@ -27,7 +27,7 @@ use rand_core::{CryptoRng, RngCore};
 #[derive(Clone)]
 pub struct SecretKey<C: Curve> {
     /// Private scalar value
-    scalar: ElementBytes<C>,
+    scalar: FieldBytes<C>,
 }
 
 impl<C: Curve> SecretKey<C> {
@@ -44,7 +44,7 @@ impl<C: Curve> SecretKey<C> {
     }
 
     /// Create a new secret key from a serialized scalar value
-    pub fn new(bytes: ElementBytes<C>) -> Self {
+    pub fn new(bytes: FieldBytes<C>) -> Self {
         Self { scalar: bytes }
     }
 
@@ -54,7 +54,7 @@ impl<C: Curve> SecretKey<C> {
     }
 
     /// Expose the byte serialization of the value this [`SecretKey`] wraps
-    pub fn as_bytes(&self) -> &ElementBytes<C> {
+    pub fn as_bytes(&self) -> &FieldBytes<C> {
         &self.scalar
     }
 }

--- a/elliptic-curve/src/weierstrass/point.rs
+++ b/elliptic-curve/src/weierstrass/point.rs
@@ -1,12 +1,12 @@
 //! Traits for Weierstrass elliptic curve points
 
 use super::Curve;
-use crate::ElementBytes;
+use crate::FieldBytes;
 use subtle::{Choice, CtOption};
 
 /// Attempt to decompress an elliptic curve point from its x-coordinate and
 /// a boolean flag indicating whether or not the y-coordinate is odd.
 pub trait Decompress<C: Curve>: Sized {
     /// Attempt to decompress an elliptic curve point
-    fn decompress(x: &ElementBytes<C>, y_is_odd: Choice) -> CtOption<Self>;
+    fn decompress(x: &FieldBytes<C>, y_is_odd: Choice) -> CtOption<Self>;
 }


### PR DESCRIPTION
Makes it clearer this refers to a field element.

Alternative to #288.