### PR TITLE
elliptic-curve: refactor ProjectiveArithmetic trait

### DIFF
--- a/elliptic-curve/src/point.rs
+++ b/elliptic-curve/src/point.rs
@@ -1,13 +1,22 @@
-//! Traits for elliptic curve points
+//! Elliptic curve points.
 
-/// Point compression settings
-pub trait Compression {
-    /// Should point compression be applied by default?
-    const COMPRESS_POINTS: bool;
+use crate::{Curve, FieldBytes, Scalar};
+
+/// Elliptic curve with projective arithmetic implementation.
+pub trait ProjectiveArithmetic: Curve
+where
+    FieldBytes<Self>: From<Scalar<Self>> + for<'r> From<&'r Scalar<Self>>,
+    Scalar<Self>: ff::PrimeField<Repr = FieldBytes<Self>>,
+{
+    /// Elliptic curve point in projective coordinates.
+    type ProjectivePoint: group::Curve;
 }
 
-/// Obtain the generator point.
-pub trait Generator {
-    /// Get the generator point for this elliptic curve
-    fn generator() -> Self;
-}
+/// Affine point type for a given curve with a [`ProjectiveArithmetic`]
+/// implementation.
+pub type AffinePoint<C> =
+    <<C as ProjectiveArithmetic>::ProjectivePoint as group::Curve>::AffineRepr;
+
+/// Projective point type for a given curve with a [`ProjectiveArithmetic`]
+/// implementation.
+pub type ProjectivePoint<C> = <C as ProjectiveArithmetic>::ProjectivePoint;

--- a/elliptic-curve/src/weierstrass/point.rs
+++ b/elliptic-curve/src/weierstrass/point.rs
@@ -4,6 +4,12 @@ use super::Curve;
 use crate::FieldBytes;
 use subtle::{Choice, CtOption};
 
+/// Point compression settings
+pub trait Compression {
+    /// Should point compression be applied by default?
+    const COMPRESS_POINTS: bool;
+}
+
 /// Attempt to decompress an elliptic curve point from its x-coordinate and
 /// a boolean flag indicating whether or not the y-coordinate is odd.
 pub trait Decompress<C: Curve>: Sized {


### PR DESCRIPTION
Renames the `Arithmetic` trait to `ProjectiveArithmetic` and changes it to have only a single associated type: `ProjectivePoint`.

Adds `AffinePoint<C>` and `Scalar<C>` type aliases which are able to look up the corresponding associated type chain (along with `ProjectivePoint<C>` for consistency, although this is available as `<C as ProjectiveArithmetic>::ProjectivePoint`).