### PR TITLE
elliptic-curve v0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,7 +136,7 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "bitvec",
  "const-oid",

--- a/cryptography/Cargo.toml
+++ b/cryptography/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 aead = { version = "0.3", optional = true, path = "../aead" }
 block-cipher = { version = "0.8", optional = true, path = "../block-cipher" }
 digest = { version = "0.9", optional = true, path = "../digest" }
-elliptic-curve = { version = "= 0.5", optional = true, path = "../elliptic-curve" }
+elliptic-curve = { version = "0.6", optional = true, path = "../elliptic-curve" }
 mac = { version = "0.9", package = "crypto-mac", optional = true, path = "../crypto-mac" }
 signature = { version = "1.1.0", optional = true, default-features = false, path = "../signature" }
 stream-cipher = { version = "0.7", optional = true, path = "../stream-cipher" }

--- a/elliptic-curve/CHANGELOG.md
+++ b/elliptic-curve/CHANGELOG.md
@@ -4,6 +4,61 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.6.0 (2020-09-11)
+### Added
+- `arithmetic` feature ([#293])
+- Generic curve/field arithmetic using the `ff` and `group` crates
+  ([#287], [#291], [#292])
+- `sec1::Coordinates` ([#286])
+- `weierstrass::point::Compression` trait ([#283], [#300])
+- Arithmetic helper functions ([#281])
+- `digest` feature and `FromDigest` trait ([#279])
+- impl `Deref` for `NonZeroScalar` ([#278])
+- Conditionally impl `Invert` for `NonZeroScalar` ([#277])
+- `NonZeroScalar::to_bytes` ([#276])
+- `EncodedPoint::decompress` ([#275])
+- `sec1::Tag` ([#270])
+- `weierstrass::point::Decompress` trait ([#266])
+- `alloc` feature + `EncodedPoint::to_bytes()` ([#265])
+
+### Changed
+- Renamed `Arithmetic` trait to `point::ProjectiveArithmetic` ([#300])
+- Replaced `Arithmetic::Scalar` and `Arithmetic::AffinePoint`
+  with `Scalar<C>` and `AffinePoint<C>` ([#300])
+- Made `SecretKey<C>` inner type generic ([#297])
+- Renamed `ElementBytes<C>` to `FieldBytes<C>` ([#296])
+- MSRV 1.44 ([#292])
+- Minimum `subtle` version now v2.3 ([#290])
+- Renamed `Curve::ElementSize` to `::FieldSize` ([#282])
+- Refactor `PublicKey` into `sec1::EncodedPoint` ([#264])
+
+### Removed
+- `FromBytes` trait ([#300])
+- `Generate` trait ([#295])
+
+[#300]: https://github.com/RustCrypto/traits/pull/300
+[#297]: https://github.com/RustCrypto/traits/pull/297
+[#296]: https://github.com/RustCrypto/traits/pull/296
+[#295]: https://github.com/RustCrypto/traits/pull/295
+[#293]: https://github.com/RustCrypto/traits/pull/293
+[#292]: https://github.com/RustCrypto/traits/pull/292
+[#291]: https://github.com/RustCrypto/traits/pull/291
+[#290]: https://github.com/RustCrypto/traits/pull/290
+[#287]: https://github.com/RustCrypto/traits/pull/293
+[#286]: https://github.com/RustCrypto/traits/pull/286
+[#283]: https://github.com/RustCrypto/traits/pull/283
+[#282]: https://github.com/RustCrypto/traits/pull/282
+[#281]: https://github.com/RustCrypto/traits/pull/281
+[#279]: https://github.com/RustCrypto/traits/pull/279
+[#278]: https://github.com/RustCrypto/traits/pull/278
+[#277]: https://github.com/RustCrypto/traits/pull/277
+[#276]: https://github.com/RustCrypto/traits/pull/276
+[#275]: https://github.com/RustCrypto/traits/pull/275
+[#270]: https://github.com/RustCrypto/traits/pull/270
+[#266]: https://github.com/RustCrypto/traits/pull/266
+[#265]: https://github.com/RustCrypto/traits/pull/265
+[#264]: https://github.com/RustCrypto/traits/pull/264
+
 ## 0.5.0 (2020-08-10)
 ### Added
 - `Arithmetic` trait ([#219])

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -5,7 +5,7 @@ General purpose Elliptic Curve Cryptography (ECC) support, including types
 and traits for representing various elliptic curve forms, scalars, points,
 and public/secret keys composed thereof.
 """
-version    = "0.5.0" # Also update html_root_url in lib.rs when bumping this
+version    = "0.6.0" # Also update html_root_url in lib.rs when bumping this
 authors    = ["RustCrypto Developers"]
 license    = "Apache-2.0 OR MIT"
 repository = "https://github.com/RustCrypto/traits/tree/master/elliptic-curve"

--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -16,7 +16,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/elliptic-curve/0.5.0"
+    html_root_url = "https://docs.rs/elliptic-curve/0.6.0"
 )]
 
 #[cfg(feature = "alloc")]


### PR DESCRIPTION
### Added
- `arithmetic` feature ([#293])
- Generic curve/field arithmetic using the `ff` and `group` crates ([#287], [#291], [#292])
- `sec1::Coordinates` ([#286])
- `weierstrass::point::Compression` trait ([#283], [#300])
- Arithmetic helper functions ([#281])
- `digest` feature and `FromDigest` trait ([#279])
- impl `Deref` for `NonZeroScalar` ([#278])
- Conditionally impl `Invert` for `NonZeroScalar` ([#277])
- `NonZeroScalar::to_bytes` ([#276])
- `EncodedPoint::decompress` ([#275])
- `sec1::Tag` ([#270])
- `weierstrass::point::Decompress` trait ([#266])
- `alloc` feature + `EncodedPoint::to_bytes()` ([#265])

### Changed
- Renamed `Arithmetic` trait to `point::ProjectiveArithmetic` ([#300])
- Replaced `Arithmetic::Scalar` and `Arithmetic::AffinePoint` with `Scalar<C>` and `AffinePoint<C>` ([#300])
- Made `SecretKey<C>` inner type generic ([#297])
- Renamed `ElementBytes<C>` to `FieldBytes<C>` ([#296])
- MSRV 1.44 ([#292])
- Minimum `subtle` version now v2.3 ([#290])
- Renamed `Curve::ElementSize` to `::FieldSize` ([#282])
- Refactor `PublicKey` into `sec1::EncodedPoint` ([#264])

### Removed
- `FromBytes` trait ([#300])
- `Generate` trait ([#295])

[#300]: https://github.com/RustCrypto/traits/pull/300
[#297]: https://github.com/RustCrypto/traits/pull/297
[#296]: https://github.com/RustCrypto/traits/pull/296
[#295]: https://github.com/RustCrypto/traits/pull/295
[#293]: https://github.com/RustCrypto/traits/pull/293
[#292]: https://github.com/RustCrypto/traits/pull/292
[#291]: https://github.com/RustCrypto/traits/pull/291
[#290]: https://github.com/RustCrypto/traits/pull/290
[#287]: https://github.com/RustCrypto/traits/pull/293
[#286]: https://github.com/RustCrypto/traits/pull/286
[#283]: https://github.com/RustCrypto/traits/pull/283
[#282]: https://github.com/RustCrypto/traits/pull/282
[#281]: https://github.com/RustCrypto/traits/pull/281
[#279]: https://github.com/RustCrypto/traits/pull/279
[#278]: https://github.com/RustCrypto/traits/pull/278
[#277]: https://github.com/RustCrypto/traits/pull/277
[#276]: https://github.com/RustCrypto/traits/pull/276
[#275]: https://github.com/RustCrypto/traits/pull/275
[#270]: https://github.com/RustCrypto/traits/pull/270
[#266]: https://github.com/RustCrypto/traits/pull/266
[#265]: https://github.com/RustCrypto/traits/pull/265
[#264]: https://github.com/RustCrypto/traits/pull/264