### PR TITLE
Revert "build(deps): bump bitvec from 0.18.3 to 0.19.0 (#301)"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,17 +32,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bitvec"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36d8f44cf786f61f341ff3d14c600c47326642326c59d1f65a53f8318885c4b9"
-dependencies = [
- "funty",
- "radium",
- "wyz",
-]
-
-[[package]]
 name = "blobby"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -149,7 +138,7 @@ dependencies = [
 name = "elliptic-curve"
 version = "0.6.0"
 dependencies = [
- "bitvec 0.19.0",
+ "bitvec",
  "const-oid",
  "digest 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ff",
@@ -167,7 +156,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01646e077d4ebda82b73f1bca002ea1e91561a77df2431a9e79729bcc31950ef"
 dependencies = [
- "bitvec 0.18.3",
+ "bitvec",
  "rand_core",
  "subtle",
 ]

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["cryptography", "no-std"]
 keywords   = ["crypto", "ecc", "elliptic", "weierstrass"]
 
 [dependencies]
-bitvec = { version = "0.19", optional = true, default-features = false }
+bitvec = { version = "0.18", optional = true, default-features = false }
 digest = { version = "0.9", optional = true }
 ff = { version = "0.8", optional = true, default-features = false }
 group = { version = "0.8", optional = true, default-features = false }


### PR DESCRIPTION
This reverts commit b541170e97553891833a4359ea1c27576e0a2b4d.

This needs to be upgraded in coordination with the `ff` and `group` crates, so this reverts it back to what the current releases of those crates are presently using.