### PR TITLE
elliptic-curve v0.6.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,7 +136,7 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "bitvec",
  "const-oid",

--- a/elliptic-curve/CHANGELOG.md
+++ b/elliptic-curve/CHANGELOG.md
@@ -4,7 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.6.0 (2020-09-11)
+## 0.6.1 (2020-09-21)
+### Fixed
+- `sec1::EncodedPoint::decompress` ([#309])
+
+[#309]: https://github.com/RustCrypto/traits/pull/309
+
+## 0.6.0 (2020-09-11) [YANKED]
 ### Added
 - `arithmetic` feature ([#293])
 - Generic curve/field arithmetic using the `ff` and `group` crates

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -5,7 +5,7 @@ General purpose Elliptic Curve Cryptography (ECC) support, including types
 and traits for representing various elliptic curve forms, scalars, points,
 and public/secret keys composed thereof.
 """
-version    = "0.6.0" # Also update html_root_url in lib.rs when bumping this
+version    = "0.6.1" # Also update html_root_url in lib.rs when bumping this
 authors    = ["RustCrypto Developers"]
 license    = "Apache-2.0 OR MIT"
 repository = "https://github.com/RustCrypto/traits/tree/master/elliptic-curve"

--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -16,7 +16,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/elliptic-curve/0.6.0"
+    html_root_url = "https://docs.rs/elliptic-curve/0.6.1"
 )]
 
 #[cfg(feature = "alloc")]


### PR DESCRIPTION
### Fixed
- `sec1::EncodedPoint::decompress` ([#309])

[#309]: https://github.com/RustCrypto/traits/pull/309