### PR TITLE
cryptography v0.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,7 +105,7 @@ dependencies = [
 
 [[package]]
 name = "cryptography"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "aead",
  "block-cipher 0.8.0",

--- a/cryptography/CHANGELOG.md
+++ b/cryptography/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.0 (2020-09-25)
+### Changed
+- Bump `signature` dependency to 1.2.0 ([#314])
+- Bump `elliptic-curve` dependency to 0.6 ([#302])
+- Bump `stream-cipher` dependency to 0.7 ([#260])
+
+[#314]: https://github.com/RustCrypto/traits/pull/314
+[#302]: https://github.com/RustCrypto/traits/pull/302
+[#260]: https://github.com/RustCrypto/traits/pull/260
+
 ## 0.3.0 (2020-08-10)
 ### Added
 - `elliptic-curve` feature ([#213])

--- a/cryptography/Cargo.toml
+++ b/cryptography/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cryptography"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["The RustCrypto Project Developers"]
 license = "Apache-2.0 OR MIT"
 description = "Facade crate for the RustCrypto project's traits"


### PR DESCRIPTION
### Changed
- Bump `signature` dependency to 1.2.0 ([#314])
- Bump `elliptic-curve` dependency to 0.6 ([#302])
- Bump `stream-cipher` dependency to 0.7 ([#260])

[#314]: https://github.com/RustCrypto/traits/pull/314
[#302]: https://github.com/RustCrypto/traits/pull/302
[#260]: https://github.com/RustCrypto/traits/pull/260