### PR TITLE
cryptography: add `std` feature

### DIFF
--- a/.github/workflows/cryptography.yml
+++ b/.github/workflows/cryptography.yml
@@ -35,8 +35,9 @@ jobs:
           toolchain: ${{ matrix.rust }}
           target: ${{ matrix.target }}
           override: true
-      - run: cargo build --release --target ${{ matrix.target }}
-      - run: cargo build --all-features --release --target ${{ matrix.target }}
+      - run: cargo build --no-default-features --release --target ${{ matrix.target }}
+      - run: cargo build --no-default-features --release --target ${{ matrix.target }}
+               --features aead,block-cipher,mac,digest,elliptic-curve,signature,stream-cipher,universal-hash
   test:
     runs-on: ubuntu-latest
     strategy:

--- a/cryptography/Cargo.toml
+++ b/cryptography/Cargo.toml
@@ -21,5 +21,17 @@ signature = { version = "1.2.0", optional = true, default-features = false, path
 stream-cipher = { version = "0.7", optional = true, path = "../stream-cipher" }
 universal-hash = { version = "0.4", optional = true, path = "../universal-hash" }
 
+[features]
+std = [
+    "aead/std",
+    "block-cipher/std",
+    "digest/std",
+    "elliptic-curve/std",
+    "mac/std",
+    "signature/std",
+    "stream-cipher/std",
+    "universal-hash/std"
+]
+
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
Adds an off-by-default `std` feature which activates the `std` features of all of the other dependencies.

This is a somewhat lousy way of doing this, and I wish that there were a better approach, so much that I posted a Pre-Pre-RFC about it:

https://internals.rust-lang.org/t/pre-pre-rfc-weak-cargo-feature-activation/13141

Edit: seems there's an open issue about this already:

https://github.com/rust-lang/cargo/issues/3494

For now though, this is immediately useful to me.