### PR TITLE
async-signature: initial crate

### DIFF
--- a/.github/workflows/async-signature.yml
+++ b/.github/workflows/async-signature.yml
@@ -1,0 +1,35 @@
+name: async-signature
+
+on:
+  pull_request:
+    paths:
+      - "signature/**"
+      - "Cargo.*"
+  push:
+    branches: master
+
+defaults:
+  run:
+    working-directory: signature/async
+
+env:
+  CARGO_INCREMENTAL: 0
+  RUSTFLAGS: "-Dwarnings"
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - 1.41.0 # MSRV
+          - stable
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: ${{ matrix.rust }}
+    - run: cargo check --all-features
+    - run: cargo test --release
+    - run: cargo test --all-features --release

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,6 +21,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-signature"
+version = "0.0.0"
+dependencies = [
+ "async-trait",
+ "signature",
+]
+
+[[package]]
+name = "async-trait"
+version = "0.1.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b246867b8b3b6ae56035f1eb1ed557c1d8eae97f0d53696138a50fa0e3a3b8c0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "bitvec"
 version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "digest",
     "elliptic-curve",
     "signature",
+    "signature/async",
     "stream-cipher",
     "universal-hash",
 ]

--- a/README.md
+++ b/README.md
@@ -4,16 +4,17 @@ Collection of traits which describe functionality of cryptographic primitives.
 
 ## Crates
 
-| Crate name         | Algorithm                     | Crates.io | Docs  | Build Status |
-|--------------------|-------------------------------|-----------|-------|--------------|
-| [`aead`]           | [Authenticated encryption]    | [![crates.io](https://img.shields.io/crates/v/aead.svg)](https://crates.io/crates/aead) | [![Documentation](https://docs.rs/aead/badge.svg)](https://docs.rs/aead) | ![build](https://github.com/RustCrypto/traits/workflows/aead/badge.svg?branch=master&event=push) |
-| [`block‑cipher`]   | [Block cipher]                | [![crates.io](https://img.shields.io/crates/v/block-cipher.svg)](https://crates.io/crates/block-cipher) | [![Documentation](https://docs.rs/block-cipher/badge.svg)](https://docs.rs/block-cipher) | ![build](https://github.com/RustCrypto/traits/workflows/block-cipher/badge.svg?branch=master&event=push) |
-| [`crypto‑mac`]     | [Message authentication code] | [![crates.io](https://img.shields.io/crates/v/crypto-mac.svg)](https://crates.io/crates/crypto-mac) | [![Documentation](https://docs.rs/crypto-mac/badge.svg)](https://docs.rs/crypto-mac) | ![build](https://github.com/RustCrypto/traits/workflows/crypto-mac/badge.svg?branch=master&event=push) |
-| [`digest`]         | [Cryptographic hash function] | [![crates.io](https://img.shields.io/crates/v/digest.svg)](https://crates.io/crates/digest) | [![Documentation](https://docs.rs/digest/badge.svg)](https://docs.rs/digest) | ![build](https://github.com/RustCrypto/traits/workflows/digest/badge.svg?branch=master&event=push) |
-| [`elliptic-curve`] | [Elliptic curve cryptography] | [![crates.io](https://img.shields.io/crates/v/elliptic-curve.svg)](https://crates.io/crates/elliptic-curve) | [![Documentation](https://docs.rs/elliptic-curve/badge.svg)](https://docs.rs/elliptic-curve) | ![build](https://github.com/RustCrypto/traits/workflows/elliptic-curve/badge.svg?branch=master&event=push) |
-| [`signature`]      | [Digital signature]           | [![crates.io](https://img.shields.io/crates/v/signature.svg)](https://crates.io/crates/signature) | [![Documentation](https://docs.rs/signature/badge.svg)](https://docs.rs/signature) | ![build](https://github.com/RustCrypto/traits/workflows/signature/badge.svg?branch=master&event=push) |
-| [`stream‑cipher`]  | [Stream cipher]               | [![crates.io](https://img.shields.io/crates/v/stream-cipher.svg)](https://crates.io/crates/stream-cipher) | [![Documentation](https://docs.rs/stream-cipher/badge.svg)](https://docs.rs/stream-cipher) | ![build](https://github.com/RustCrypto/traits/workflows/stream-cipher/badge.svg?branch=master&event=push) |
-| [`universal‑hash`] | [Universal hash function]     | [![crates.io](https://img.shields.io/crates/v/universal-hash.svg)](https://crates.io/crates/universal-hash) | [![Documentation](https://docs.rs/universal-hash/badge.svg)](https://docs.rs/universal-hash) | ![build](https://github.com/RustCrypto/traits/workflows/universal-hash/badge.svg?branch=master&event=push) |
+| Crate name          | Algorithm                     | Crates.io | Docs  | Build Status |
+|---------------------|-------------------------------|-----------|-------|--------------|
+| [`aead`]            | [Authenticated encryption]    | [![crates.io](https://img.shields.io/crates/v/aead.svg)](https://crates.io/crates/aead) | [![Documentation](https://docs.rs/aead/badge.svg)](https://docs.rs/aead) | ![build](https://github.com/RustCrypto/traits/workflows/aead/badge.svg?branch=master&event=push) |
+| [`async-signature`] | [Digital signature]           | [![crates.io](https://img.shields.io/crates/v/async-signature.svg)](https://crates.io/crates/async-signature) | [![Documentation](https://docs.rs/async-signature/badge.svg)](https://docs.rs/async-signature) | ![build](https://github.com/RustCrypto/traits/workflows/async-signature/badge.svg?branch=master&event=push) |
+| [`block‑cipher`]    | [Block cipher]                | [![crates.io](https://img.shields.io/crates/v/block-cipher.svg)](https://crates.io/crates/block-cipher) | [![Documentation](https://docs.rs/block-cipher/badge.svg)](https://docs.rs/block-cipher) | ![build](https://github.com/RustCrypto/traits/workflows/block-cipher/badge.svg?branch=master&event=push) |
+| [`crypto‑mac`]      | [Message authentication code] | [![crates.io](https://img.shields.io/crates/v/crypto-mac.svg)](https://crates.io/crates/crypto-mac) | [![Documentation](https://docs.rs/crypto-mac/badge.svg)](https://docs.rs/crypto-mac) | ![build](https://github.com/RustCrypto/traits/workflows/crypto-mac/badge.svg?branch=master&event=push) |
+| [`digest`]          | [Cryptographic hash function] | [![crates.io](https://img.shields.io/crates/v/digest.svg)](https://crates.io/crates/digest) | [![Documentation](https://docs.rs/digest/badge.svg)](https://docs.rs/digest) | ![build](https://github.com/RustCrypto/traits/workflows/digest/badge.svg?branch=master&event=push) |
+| [`elliptic-curve`]  | [Elliptic curve cryptography] | [![crates.io](https://img.shields.io/crates/v/elliptic-curve.svg)](https://crates.io/crates/elliptic-curve) | [![Documentation](https://docs.rs/elliptic-curve/badge.svg)](https://docs.rs/elliptic-curve) | ![build](https://github.com/RustCrypto/traits/workflows/elliptic-curve/badge.svg?branch=master&event=push) |
+| [`signature`]       | [Digital signature]           | [![crates.io](https://img.shields.io/crates/v/signature.svg)](https://crates.io/crates/signature) | [![Documentation](https://docs.rs/signature/badge.svg)](https://docs.rs/signature) | ![build](https://github.com/RustCrypto/traits/workflows/signature/badge.svg?branch=master&event=push) |
+| [`stream‑cipher`]   | [Stream cipher]               | [![crates.io](https://img.shields.io/crates/v/stream-cipher.svg)](https://crates.io/crates/stream-cipher) | [![Documentation](https://docs.rs/stream-cipher/badge.svg)](https://docs.rs/stream-cipher) | ![build](https://github.com/RustCrypto/traits/workflows/stream-cipher/badge.svg?branch=master&event=push) |
+| [`universal‑hash`]  | [Universal hash function]     | [![crates.io](https://img.shields.io/crates/v/universal-hash.svg)](https://crates.io/crates/universal-hash) | [![Documentation](https://docs.rs/universal-hash/badge.svg)](https://docs.rs/universal-hash) | ![build](https://github.com/RustCrypto/traits/workflows/universal-hash/badge.svg?branch=master&event=push) |
 
 ### Additional crates
 
@@ -50,6 +51,7 @@ dual licensed as above, without any additional terms or conditions.
 [//]: # (crates)
 
 [`aead`]: https://github.com/RustCrypto/traits/tree/master/aead
+[`async-signature`]: https://github.com/RustCrypto/traits/tree/master/signature/async
 [`block‑cipher`]: https://github.com/RustCrypto/traits/tree/master/block-cipher
 [`crypto‑mac`]: https://github.com/RustCrypto/traits/tree/master/crypto-mac
 [`cryptography`]: https://github.com/RustCrypto/traits/tree/master/cryptography

--- a/signature/async/CHANGELOG.md
+++ b/signature/async/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/signature/async/Cargo.toml
+++ b/signature/async/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name          = "async-signature"
+description   = "Traits for cryptographic signature algorithms (e.g. ECDSA, Ed25519)"
+version       = "0.0.0" # Also update html_root_url in lib.rs when bumping this
+authors       = ["RustCrypto Developers"]
+license       = "Apache-2.0 OR MIT"
+documentation = "https://docs.rs/async-signature"
+repository    = "https://github.com/RustCrypto/traits/tree/master/signature/async"
+readme        = "README.md"
+edition       = "2018"
+keywords      = ["crypto", "ecdsa", "ed25519", "signature", "signing"]
+categories    = ["cryptography", "no-std"]
+
+[dependencies]
+async-trait = "0.1"
+signature = { version = "1.2.0", path = ".." }
+
+[features]
+digest = ["signature/digest-preview"]
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/signature/async/README.md
+++ b/signature/async/README.md
@@ -1,0 +1,40 @@
+# RustCrypto: `async-signature`
+
+[![crate][crate-image]][crate-link]
+[![Docs][docs-image]][docs-link]
+![Apache2/MIT licensed][license-image]
+![Rust Version][rustc-image]
+[![Build Status][build-image]][build-link]
+
+## Minimum Supported Rust Version
+
+Rust **1.41** or higher.
+
+Minimum supported Rust version can be changed in the future, but it will be
+done with a minor version bump.
+
+## License
+
+Licensed under either of
+
+ * [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0)
+ * [MIT license](http://opensource.org/licenses/MIT)
+
+at your option.
+
+### Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally submitted
+for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
+dual licensed as above, without any additional terms or conditions.
+
+[//]: # (badges)
+
+[crate-image]: https://img.shields.io/crates/v/async-signature.svg
+[crate-link]: https://crates.io/crates/async-signature
+[docs-image]: https://docs.rs/async-signature/badge.svg
+[docs-link]: https://docs.rs/async-signature/
+[license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.41+-blue.svg
+[build-image]: https://github.com/RustCrypto/traits/workflows/async-signature/badge.svg?branch=master&event=push
+[build-link]: https://github.com/RustCrypto/traits/actions?query=workflow:async-signature

--- a/signature/async/src/lib.rs
+++ b/signature/async/src/lib.rs
@@ -1,0 +1,93 @@
+//! RustCrypto: `async-signature` crate.
+//!
+//! This is an experimental crate containing `async` versions of select traits
+//! from the [`signature`] crate, namely [`AsyncSigner`] and when the `digest`
+//! feature is enabled, [`AsyncDigestSigner`].
+//!
+//! Traits are implemented using [`async-trait`], which rewrites the traits to
+//! use `Box`-ed futures.
+//!
+//! The longer-term goal is to move these traits into the [`signature`] crate
+//! itself, however before doing so we'd like to remove the [`async-trait`]
+//! dependency in order to enable use in `no_std` environments. This crate
+//! is a stopgap until that happens.
+//!
+//! For more information, see:
+//! <https://github.com/RustCrypto/traits/issues/304>
+//!
+//! [`async-trait`]: https://docs.rs/async-trait
+
+#![cfg_attr(docsrs, feature(doc_cfg))]
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
+    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
+    html_root_url = "https://docs.rs/async-signature/0.0.0"
+)]
+#![forbid(unsafe_code)]
+#![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
+
+pub use signature::{self, Error, Signature};
+
+#[cfg(feature = "digest")]
+pub use signature::digest::{self, Digest};
+
+use async_trait::async_trait;
+
+/// Asynchronously sign the provided message bytestring using `Self`
+/// (e.g. client for a Cloud KMS or HSM), returning a digital signature.
+///
+/// This trait is an async equivalent of the [`signature::Signer`] trait.
+#[async_trait]
+pub trait AsyncSigner<S>
+where
+    Self: Send + Sync,
+    S: Signature + Send + 'static,
+{
+    /// Attempt to sign the given message, returning a digital signature on
+    /// success, or an error if something went wrong.
+    ///
+    /// The main intended use case for signing errors is when communicating
+    /// with external signers, e.g. cloud KMS, HSMs, or other hardware tokens.
+    async fn sign_async(&self, msg: &[u8]) -> Result<S, Error>;
+}
+
+#[async_trait]
+impl<S, T> AsyncSigner<S> for T
+where
+    S: Signature + Send + 'static,
+    T: signature::Signer<S> + Send + Sync,
+{
+    async fn sign_async(&self, msg: &[u8]) -> Result<S, Error> {
+        self.try_sign(msg)
+    }
+}
+
+/// Asynchronously sign the given prehashed message [`Digest`] using `Self`.
+///
+/// This trait is an async equivalent of the [`signature::DigestSigner`] trait.
+#[cfg(feature = "digest")]
+#[cfg_attr(docsrs, doc(cfg(feature = "digest")))]
+#[async_trait]
+pub trait AsyncDigestSigner<D, S>
+where
+    Self: Send + Sync,
+    D: Digest + Send + 'static,
+    S: Signature + 'static,
+{
+    /// Attempt to sign the given prehashed message [`Digest`], returning a
+    /// digital signature on success, or an error if something went wrong.
+    async fn sign_digest_async(&self, digest: D) -> Result<S, Error>;
+}
+
+#[cfg(feature = "digest")]
+#[async_trait]
+impl<D, S, T> AsyncDigestSigner<D, S> for T
+where
+    D: Digest + Send + 'static,
+    S: Signature + Send + 'static,
+    T: signature::DigestSigner<D, S> + Send + Sync,
+{
+    async fn sign_digest_async(&self, digest: D) -> Result<S, Error> {
+        self.try_sign_digest(digest)
+    }
+}

--- a/signature/src/lib.rs
+++ b/signature/src/lib.rs
@@ -147,8 +147,12 @@
 //!   systems which rely on a cryptographically secure random number generator
 //!   for security.
 //!
+//! NOTE: the [`async-signature`] crate contains experimental `async` support
+//! for [`Signer`] and [`DigestSigner`].
+//!
+//! [`async-signature`]: https://docs.rs/async-signature
+//! [`digest`]: https://docs.rs/digest/
 //! [`Digest`]: https://docs.rs/digest/latest/digest/trait.Digest.html
-//! [`digest`]: https://docs.rs/digest/latest/digest/
 //! [Fiat-Shamir heuristic]: https://en.wikipedia.org/wiki/Fiat%E2%80%93Shamir_heuristic
 
 #![no_std]
@@ -159,12 +163,7 @@
     html_root_url = "https://docs.rs/signature/1.2.2"
 )]
 #![forbid(unsafe_code)]
-#![warn(
-    missing_docs,
-    rust_2018_idioms,
-    unused_qualifications,
-    intra_doc_link_resolution_failure
-)]
+#![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
 
 #[cfg(feature = "std")]
 extern crate std;

--- a/signature/src/signer.rs
+++ b/signature/src/signer.rs
@@ -50,7 +50,7 @@ where
     D: Digest,
     S: Signature,
 {
-    /// Sign the given prehashed message `Digest`, returning a signature.
+    /// Sign the given prehashed message [`Digest`], returning a signature.
     ///
     /// Panics in the event of a signing error.
     fn sign_digest(&self, digest: D) -> S {
@@ -58,7 +58,7 @@ where
             .expect("signature operation failed")
     }
 
-    /// Attempt to sign the given prehashed message `Digest`, returning a
+    /// Attempt to sign the given prehashed message [`Digest`], returning a
     /// digital signature on success, or an error if something went wrong.
     fn try_sign_digest(&self, digest: D) -> Result<S, Error>;
 }

--- a/signature/src/verifier.rs
+++ b/signature/src/verifier.rs
@@ -41,6 +41,6 @@ where
     D: Digest,
     S: Signature,
 {
-    /// Verify the signature against the given `Digest` output.
+    /// Verify the signature against the given [`Digest`] output.
     fn verify_digest(&self, digest: D, signature: &S) -> Result<(), Error>;
 }


### PR DESCRIPTION
Adds an `async-signature` crate with `AsyncSigner` and `AsyncDigestSigner` traits, based on the `async-trait` crate.

Though we'd discussed not using an `async-trait`-based approach (#304), there are some immediate needs for these traits for `std` users, namely providing a common `async` API to things like Cloud KMS services and NetHSMs.

I think we can still pursue nightly-only versions of these traits in the `signature` crate itself (ones which will work in `no_std` environments).

In the meantime, these traits are self-contained within their own, relatively small crate to unblock making some initial progress with things like Cloud KMS abstractions.