### PR TITLE
elliptic-curve: work around nightly-2020-10-06 breakage

### DIFF
--- a/elliptic-curve/src/ecdh.rs
+++ b/elliptic-curve/src/ecdh.rs
@@ -73,7 +73,8 @@ where
     ///
     /// The `compress` flag enables point compression.
     pub fn public_key(&self) -> PublicKey<C> {
-        (C::ProjectivePoint::generator() * &self.scalar)
+        #[allow(clippy::op_ref)]
+        (C::ProjectivePoint::generator() * &*self.scalar)
             .to_affine()
             .into()
     }


### PR DESCRIPTION
The `elliptic-curve` crate no longer builds on `nightly`.

Possible cause:

https://github.com/rust-lang/rust/issues/77638

Unfortunately this means rustdoc builds on https://docs.rs fail!

This commit works around the issue.