### PR TITLE
elliptic-curve: derive `Clone` on `SecretBytes`

### DIFF
--- a/elliptic-curve/src/secret_key.rs
+++ b/elliptic-curve/src/secret_key.rs
@@ -168,6 +168,7 @@ where
 /// Newtype wrapper for [`FieldBytes`] which impls [`Zeroize`].
 ///
 /// This allows it to fulfill the [`Zeroize`] bound on [`SecretValue::Secret`].
+#[derive(Clone)]
 pub struct SecretBytes<C: Curve>(FieldBytes<C>);
 
 impl<C: Curve> From<FieldBytes<C>> for SecretBytes<C> {


### PR DESCRIPTION
This is needed by the `elliptic_curve::SecretKey::to_bytes` method.