### PR TITLE
elliptic-curve v0.6.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,7 +155,7 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "bitvec",
  "const-oid",

--- a/elliptic-curve/CHANGELOG.md
+++ b/elliptic-curve/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.6.6 (2020-10-08)
+### Added
+- Derive `Clone` on `SecretBytes` ([#330])
+
+[#300]: https://github.com/RustCrypto/traits/pull/300
+
 ## 0.6.5 (2020-10-08)
 ### Fixed
 - Work around `nightly-2020-10-06` breakage ([#328])

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -5,7 +5,7 @@ General purpose Elliptic Curve Cryptography (ECC) support, including types
 and traits for representing various elliptic curve forms, scalars, points,
 and public/secret keys composed thereof.
 """
-version    = "0.6.5" # Also update html_root_url in lib.rs when bumping this
+version    = "0.6.6" # Also update html_root_url in lib.rs when bumping this
 authors    = ["RustCrypto Developers"]
 license    = "Apache-2.0 OR MIT"
 repository = "https://github.com/RustCrypto/traits/tree/master/elliptic-curve"

--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -16,7 +16,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/elliptic-curve/0.6.5"
+    html_root_url = "https://docs.rs/elliptic-curve/0.6.6"
 )]
 
 #[cfg(feature = "alloc")]


### PR DESCRIPTION
### Added
- Derive `Clone` on `SecretBytes` ([#330])

[#300]: https://github.com/RustCrypto/traits/pull/300