### PR TITLE
stream-cipher: remove NewBlockCipher bound on FromBlockCipher

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,7 +124,7 @@ dependencies = [
 
 [[package]]
 name = "cryptography"
-version = "0.4.1"
+version = "0.5.0-pre"
 dependencies = [
  "aead",
  "block-cipher 0.8.0",
@@ -349,7 +349,7 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "stream-cipher"
-version = "0.7.1"
+version = "0.8.0-pre"
 dependencies = [
  "blobby 0.3.0",
  "block-cipher 0.8.0",

--- a/cryptography/Cargo.toml
+++ b/cryptography/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cryptography"
-version = "0.4.1"
+version = "0.5.0-pre"
 authors = ["The RustCrypto Project Developers"]
 license = "Apache-2.0 OR MIT"
 description = "Facade crate for the RustCrypto project's traits"
@@ -18,7 +18,7 @@ digest = { version = "0.9", optional = true, path = "../digest" }
 elliptic-curve = { version = "0.6", optional = true, path = "../elliptic-curve" }
 mac = { version = "0.9", package = "crypto-mac", optional = true, path = "../crypto-mac" }
 signature = { version = "1.2.0", optional = true, default-features = false, path = "../signature" }
-stream-cipher = { version = "0.7", optional = true, path = "../stream-cipher" }
+stream-cipher = { version = "0.8.0-pre", optional = true, path = "../stream-cipher" }
 universal-hash = { version = "0.4", optional = true, path = "../universal-hash" }
 
 [features]

--- a/stream-cipher/Cargo.toml
+++ b/stream-cipher/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "stream-cipher"
 description = "Stream cipher traits"
-version = "0.7.1"
+version = "0.8.0-pre"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/stream-cipher/src/lib.rs
+++ b/stream-cipher/src/lib.rs
@@ -173,7 +173,7 @@ impl<C: SyncStreamCipher> SyncStreamCipher for &mut C {
 #[cfg_attr(docsrs, doc(cfg(feature = "block-cipher")))]
 pub trait FromBlockCipher {
     /// Block cipher
-    type BlockCipher: BlockCipher + NewBlockCipher;
+    type BlockCipher: BlockCipher;
     /// Nonce size in bytes
     type NonceSize: ArrayLength<u8>;
 
@@ -188,6 +188,7 @@ pub trait FromBlockCipher {
 impl<C> NewStreamCipher for C
 where
     C: FromBlockCipher,
+    C::BlockCipher: NewBlockCipher,
 {
     type KeySize = <<Self as FromBlockCipher>::BlockCipher as NewBlockCipher>::KeySize;
     type NonceSize = <Self as FromBlockCipher>::NonceSize;


### PR DESCRIPTION
Note: breaking change.

As far as I can tell this was an oversight: `FromBlockCipher` never needs to instantiate a new block cipher (isn't that the point?), making this bound needlessly limiting.

The rationale for it in the first place appears to be for the blanket impl of `NewStreamCipher` for `C: FromBlockCipher` which needs it, but we can add the bound to the blanket impl, rather than (needlessly) sticking it on the trait.