### PR TITLE
cipher v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,7 +85,7 @@ checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "cipher"
-version = "0.2.0-pre"
+version = "0.2.0"
 dependencies = [
  "blobby 0.3.0",
  "generic-array 0.14.4",

--- a/cipher/CHANGELOG.md
+++ b/cipher/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.0 (2020-10-15)
+### Changed
+- Unify `block-cipher` and `stream-cipher` into `cipher` ([#337])
+
+[#337]: https://github.com/RustCrypto/traits/pull/337
+
 ## 0.1.1 (2015-06-25)
 
 ## 0.1.0 (2015-06-24)

--- a/cipher/Cargo.toml
+++ b/cipher/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cipher"
 description = "Traits for describing block ciphers and stream ciphers"
-version = "0.2.0-pre"
+version = "0.2.0"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/crypto-mac/Cargo.toml
+++ b/crypto-mac/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["cryptography", "no-std"]
 
 [dependencies]
 generic-array = "0.14"
-cipher = { version = "=0.2.0-pre", optional = true, path = "../cipher" }
+cipher = { version = "0.2", optional = true, path = "../cipher" }
 subtle = { version = "2", default-features = false }
 blobby = { version = "0.3", optional = true }
 

--- a/cryptography/Cargo.toml
+++ b/cryptography/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 
 [dependencies]
 aead = { version = "0.3", optional = true, path = "../aead" }
-cipher = { version = "=0.2.0-pre", optional = true, path = "../cipher" }
+cipher = { version = "0.2", optional = true, path = "../cipher" }
 digest = { version = "0.9", optional = true, path = "../digest" }
 elliptic-curve = { version = "0.6", optional = true, path = "../elliptic-curve" }
 mac = { version = "=0.10.0-pre", package = "crypto-mac", optional = true, path = "../crypto-mac" }


### PR DESCRIPTION
### Changed
- Unify `block-cipher` and `stream-cipher` into `cipher` ([#337])

[#337]: https://github.com/RustCrypto/traits/pull/337