### PR TITLE
crypto-mac v0.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,7 +105,7 @@ checksum = "8aebca1129a03dc6dc2b127edd729435bbc4a37e1d5f4d7513165089ceb02634"
 
 [[package]]
 name = "crypto-mac"
-version = "0.10.0-pre"
+version = "0.10.0"
 dependencies = [
  "blobby 0.3.0",
  "cipher",

--- a/crypto-mac/CHANGELOG.md
+++ b/crypto-mac/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.10.0 (2020-10-15)
+### Changed
+- Replace `block-cipher` crate with new `cipher` crate ([#337], [#338])
+
+[#338]: https://github.com/RustCrypto/traits/pull/338
+[#337]: https://github.com/RustCrypto/traits/pull/337
+
 ## 0.9.1 (2020-08-12)
 ### Added
 - Re-export the `block-cipher` crate ([#257])

--- a/crypto-mac/Cargo.toml
+++ b/crypto-mac/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "crypto-mac"
 description = "Trait for Message Authentication Code (MAC) algorithms"
-version = "0.10.0-pre"
+version = "0.10.0"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/cryptography/Cargo.toml
+++ b/cryptography/Cargo.toml
@@ -16,7 +16,7 @@ aead = { version = "0.3", optional = true, path = "../aead" }
 cipher = { version = "0.2", optional = true, path = "../cipher" }
 digest = { version = "0.9", optional = true, path = "../digest" }
 elliptic-curve = { version = "0.6", optional = true, path = "../elliptic-curve" }
-mac = { version = "=0.10.0-pre", package = "crypto-mac", optional = true, path = "../crypto-mac" }
+mac = { version = "0.10", package = "crypto-mac", optional = true, path = "../crypto-mac" }
 signature = { version = "1.2.0", optional = true, default-features = false, path = "../signature" }
 universal-hash = { version = "0.4", optional = true, path = "../universal-hash" }
 


### PR DESCRIPTION
### Changed
- Replace `block-cipher` crate with new `cipher` crate ([#337], [#338])

[#338]: https://github.com/RustCrypto/traits/pull/338
[#337]: https://github.com/RustCrypto/traits/pull/337