### PR TITLE
cryptography v0.5.0

### DIFF
--- a/cryptography/CHANGELOG.md
+++ b/cryptography/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.5.0 (2020-10-15)
+### Changed
+- Bump `crypto-mac` to v0.10 ([#339])
+- Unify `block-cipher`/`stream-cipher` into `cipher` ([#337], [#338])
+
+[#339]: https://github.com/RustCrypto/traits/pull/339
+[#338]: https://github.com/RustCrypto/traits/pull/338
+[#337]: https://github.com/RustCrypto/traits/pull/337
+
 ## 0.4.1 (2020-09-29)
 ### Added
 - `std` feature ([#317])


### PR DESCRIPTION
### Changed
- Bump `crypto-mac` to v0.10 ([#339])
- Unify `block-cipher`/`stream-cipher` into `cipher` ([#337], [#338])

[#339]: https://github.com/RustCrypto/traits/pull/339
[#338]: https://github.com/RustCrypto/traits/pull/338
[#337]: https://github.com/RustCrypto/traits/pull/337