### PR TITLE
cipher: re-export `generic_array` from toplevel

### DIFF
--- a/cipher/src/block.rs
+++ b/cipher/src/block.rs
@@ -16,6 +16,8 @@ pub mod dev;
 mod errors;
 
 pub use errors::InvalidKeyLength;
+
+// TODO(tarcieri): remove these re-exports in favor of the toplevel one
 pub use generic_array::{self, typenum::consts};
 
 use generic_array::{typenum::Unsigned, ArrayLength, GenericArray};

--- a/cipher/src/lib.rs
+++ b/cipher/src/lib.rs
@@ -23,3 +23,4 @@ pub use crate::{
     block::{BlockCipher, BlockCipherMut, NewBlockCipher},
     stream::{NewStreamCipher, StreamCipher, SyncStreamCipher, SyncStreamCipherSeek},
 };
+pub use generic_array::{self, typenum::consts};

--- a/cipher/src/stream.rs
+++ b/cipher/src/stream.rs
@@ -9,6 +9,8 @@ mod dev;
 mod errors;
 
 pub use errors::{InvalidKeyNonceLength, LoopError, OverflowError};
+
+// TODO(tarcieri): remove these re-exports in favor of the toplevel one
 pub use generic_array::{self, typenum::consts};
 
 #[cfg(feature = "dev")]


### PR DESCRIPTION
...along with `typenum::consts`

Failure to do this was an oversight: it doesn't really make sense to re-export these twice from both the `block` and `stream` modules.

That said, `cipher` v0.2 is already shipped, and it does ease a sed-based migration to keep these re-exports for now.

This commit adds a third re-export from the toplevel, and comments to remove the re-exports from the `block` and `stream` crates. This should happen before `cipher` v0.3 is released.