### PR TITLE
cipher: revamp macro names

### DIFF
--- a/cipher/README.md
+++ b/cipher/README.md
@@ -10,7 +10,7 @@
 Traits which define the functionality of [block ciphers] and [stream ciphers].
 
 See [RustCrypto/block-ciphers] and [RustCrypto/stream-ciphers] for algorithm
-implementations which use this trait.
+implementations which use these traits.
 
 [Documentation][docs-link]
 

--- a/cipher/src/block/dev.rs
+++ b/cipher/src/block/dev.rs
@@ -2,10 +2,10 @@
 
 pub use blobby;
 
-/// Define test
+/// Define block cipher test
 #[macro_export]
 #[cfg_attr(docsrs, doc(cfg(feature = "dev")))]
-macro_rules! new_test {
+macro_rules! block_cipher_test {
     ($name:ident, $test_name:expr, $cipher:ty) => {
         #[test]
         fn $name() {
@@ -104,10 +104,10 @@ macro_rules! new_test {
     };
 }
 
-/// Define benchmark
+/// Define block cipher benchmark
 #[macro_export]
 #[cfg_attr(docsrs, doc(cfg(feature = "dev")))]
-macro_rules! bench {
+macro_rules! block_cipher_bench {
     ($cipher:path, $key_len:expr) => {
         extern crate test;
 
@@ -137,5 +137,27 @@ macro_rules! bench {
             });
             bh.bytes = block.len() as u64;
         }
+    };
+}
+
+//
+// Below are deprecated legacy macro wrappers. They should be removed in v0.3.
+//
+
+/// Define tests
+#[macro_export]
+#[deprecated(since = "0.2.2", note = "use `block_cipher_test!` instead")]
+macro_rules! new_test {
+    ($name:ident, $test_name:expr, $cipher:ty) => {
+        block_cipher_test!($name, $test_name, $cipher)
+    };
+}
+
+/// Define benchmark
+#[macro_export]
+#[deprecated(since = "0.2.2", note = "use `block_cipher_bench!` instead")]
+macro_rules! bench {
+    ($cipher:path, $key_len:expr) => {
+        block_cipher_bench!($cipher, $key_len)
     };
 }

--- a/cipher/src/lib.rs
+++ b/cipher/src/lib.rs
@@ -1,4 +1,4 @@
-//! This crate defines a set of simple traits used to define functionality of
+//! This crate defines a set of traits which describe the functionality of
 //! [block ciphers][1] and [stream ciphers][2].
 //!
 //! [1]: https://en.wikipedia.org/wiki/Block_cipher

--- a/cipher/src/stream/dev.rs
+++ b/cipher/src/stream/dev.rs
@@ -3,7 +3,7 @@
 /// Test core functionality of synchronous stream cipher
 #[macro_export]
 #[cfg_attr(docsrs, doc(cfg(feature = "dev")))]
-macro_rules! new_sync_test {
+macro_rules! stream_cipher_sync_test {
     ($name:ident, $cipher:ty, $test_name:expr) => {
         #[test]
         fn $name() {
@@ -39,7 +39,7 @@ macro_rules! new_sync_test {
 /// Test stream synchronous stream cipher seeking capabilities
 #[macro_export]
 #[cfg_attr(docsrs, doc(cfg(feature = "dev")))]
-macro_rules! new_seek_test {
+macro_rules! stream_cipher_seek_test {
     ($name:ident, $cipher:ty) => {
         #[test]
         fn $name() {
@@ -92,7 +92,7 @@ macro_rules! new_seek_test {
 /// Test core functionality of asynchronous stream cipher
 #[macro_export]
 #[cfg_attr(docsrs, doc(cfg(feature = "dev")))]
-macro_rules! new_async_test {
+macro_rules! stream_cipher_async_test {
     ($name:ident, $test_name:expr, $cipher:ty) => {
         #[test]
         fn $name() {
@@ -153,7 +153,7 @@ macro_rules! new_async_test {
 /// Create synchronous stream cipher benchmarks
 #[macro_export]
 #[cfg_attr(docsrs, doc(cfg(feature = "dev")))]
-macro_rules! bench_sync {
+macro_rules! stream_cipher_sync_bench {
     ($name:ident, $cipher:path, $data_len:expr) => {
         #[bench]
         pub fn $name(bh: &mut Bencher) {
@@ -189,10 +189,10 @@ macro_rules! bench_sync {
     };
 }
 
-/// Create synchronous stream cipher benchmarks
+/// Create asynchronous stream cipher benchmarks
 #[macro_export]
 #[cfg_attr(docsrs, doc(cfg(feature = "dev")))]
-macro_rules! bench_async {
+macro_rules! stream_cipher_async_bench {
     ($enc_name:ident, $dec_name:ident, $cipher:path, $data_len:expr) => {
         #[bench]
         pub fn $enc_name(bh: &mut Bencher) {
@@ -239,5 +239,54 @@ macro_rules! bench_async {
         $crate::bench_async!(encrypt_1000, decrypt_1000, $cipher, 1000);
         $crate::bench_async!(encrypt_10000, decrypt_10000, $cipher, 10000);
         $crate::bench_async!(encrypt_100000, decrypt_100000, $cipher, 100000);
+    };
+}
+
+//
+// Below are deprecated legacy macro wrappers. They should be removed in v0.3.
+//
+
+/// Test core functionality of synchronous stream cipher
+#[macro_export]
+#[deprecated(since = "0.2.2", note = "use `stream_cipher_sync_test!` instead")]
+macro_rules! new_sync_test {
+    ($name:ident, $cipher:ty, $test_name:expr) => {
+        stream_cipher_sync_test!($name, $cipher, $test_name)
+    };
+}
+
+/// Test stream synchronous stream cipher seeking capabilities
+#[macro_export]
+#[deprecated(since = "0.2.2", note = "use `stream_cipher_seek_test!` instead")]
+macro_rules! new_seek_test {
+    ($name:ident, $cipher:ty) => {
+        stream_cipher_seek_test!($name, $cipher)
+    };
+}
+
+/// Test core functionality of asynchronous stream cipher
+#[macro_export]
+#[deprecated(since = "0.2.2", note = "use `stream_cipher_async_test!` instead")]
+macro_rules! new_async_test {
+    ($name:ident, $test_name:expr, $cipher:ty) => {
+        stream_cipher_async_test!($name, $test_name, $cipher)
+    };
+}
+
+/// Create synchronous stream cipher benchmarks
+#[macro_export]
+#[deprecated(since = "0.2.2", note = "use `stream_cipher_sync_bench!` instead")]
+macro_rules! bench_sync {
+    ($name:ident, $cipher:path, $data_len:expr) => {
+        stream_cipher_sync_bench!($name, $cipher, $data_len)
+    };
+}
+
+/// Create asynchronous stream cipher benchmarks
+#[macro_export]
+#[deprecated(since = "0.2.2", note = "use `stream_cipher_async_bench!` instead")]
+macro_rules! bench_async {
+    ($enc_name:ident, $dec_name:ident, $cipher:path, $data_len:expr) => {
+        stream_cipher_async_bench!($enc_name, $dec_name, $cipher, $data_len)
     };
 }


### PR DESCRIPTION
The old macro names come from the `block-cipher` and `stream-cipher` crates, where the crate names disambiguated them.

However, now that they've been merged into the same crate, and being re-exported from the toplevel as macros are, it's now unclear whether a macro is for a block cipher or a stream cipher.

This commit adds `block_cipher*` and `stream_cipher*` to the start of each macro name to disambiguate them.

It also maintains the existing macros as wrappers for the new names for backwards compatibility, but with a `#[deprecated]` attribute added.