### PR TITLE
cipher: add encrypt/decrypt-only block cipher traits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,7 +85,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cipher"
-version = "0.2.5"
+version = "0.3.0-pre"
 dependencies = [
  "blobby 0.3.0",
  "generic-array 0.14.4",
@@ -118,7 +118,7 @@ dependencies = [
 
 [[package]]
 name = "crypto-mac"
-version = "0.10.0"
+version = "0.11.0-pre"
 dependencies = [
  "blobby 0.3.0",
  "cipher",

--- a/cipher/Cargo.toml
+++ b/cipher/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cipher"
 description = "Traits for describing block ciphers and stream ciphers"
-version = "0.2.5"
+version = "0.3.0-pre"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/cipher/src/block.rs
+++ b/cipher/src/block.rs
@@ -186,11 +186,15 @@ impl<Alg: BlockCipher> BlockCipher for &Alg {
     }
 }
 
-/// Encrypt-only functionality for block ciphers
-pub trait Encrypt {
+/// Marker trait for block size
+// TODO(tarcieri): rename this to `BlockCipher` in the next breaking release
+pub trait BlockSizeMarker {
     /// Size of the block in bytes
     type BlockSize: ArrayLength<u8>;
+}
 
+/// Encrypt-only functionality for block ciphers
+pub trait BlockEncrypt: BlockSizeMarker {
     /// Number of blocks which can be processed in parallel by
     /// cipher implementation
     type ParBlocks: ArrayLength<GenericArray<u8, Self::BlockSize>>;
@@ -234,10 +238,7 @@ pub trait Encrypt {
 }
 
 /// Decrypt-only functionality for block ciphers
-pub trait Decrypt {
-    /// Size of the block in bytes
-    type BlockSize: ArrayLength<u8>;
-
+pub trait BlockDecrypt: BlockSizeMarker {
     /// Number of blocks which can be processed in parallel by
     /// cipher implementation
     type ParBlocks: ArrayLength<GenericArray<u8, Self::BlockSize>>;

--- a/cipher/src/lib.rs
+++ b/cipher/src/lib.rs
@@ -20,7 +20,9 @@ pub mod block;
 pub mod stream;
 
 pub use crate::{
-    block::{BlockCipher, BlockCipherMut, NewBlockCipher},
+    block::{
+        BlockCipher, BlockDecrypt, BlockDecryptMut, BlockEncrypt, BlockEncryptMut, NewBlockCipher,
+    },
     stream::{NewStreamCipher, StreamCipher, SyncStreamCipher, SyncStreamCipherSeek},
 };
 pub use generic_array::{self, typenum::consts};

--- a/cipher/src/stream.rs
+++ b/cipher/src/stream.rs
@@ -16,7 +16,7 @@ pub use generic_array::{self, typenum::consts};
 #[cfg(feature = "dev")]
 pub use blobby;
 
-use crate::block::{BlockCipher, BlockCipherMut, NewBlockCipher};
+use crate::block::{BlockCipher, NewBlockCipher};
 use core::convert::{TryFrom, TryInto};
 use generic_array::typenum::Unsigned;
 use generic_array::{ArrayLength, GenericArray};
@@ -166,46 +166,17 @@ pub trait FromBlockCipher {
     ) -> Self;
 }
 
-/// Trait for initializing a stream cipher from a mutable block cipher
-pub trait FromBlockCipherMut {
-    /// Block cipher
-    type BlockCipher: BlockCipherMut;
-    /// Nonce size in bytes
-    type NonceSize: ArrayLength<u8>;
-
-    /// Instantiate a stream cipher from a block cipher
-    fn from_block_cipher_mut(
-        cipher: Self::BlockCipher,
-        nonce: &GenericArray<u8, Self::NonceSize>,
-    ) -> Self;
-}
-
-impl<C> FromBlockCipherMut for C
-where
-    C: FromBlockCipher,
-{
-    type BlockCipher = <Self as FromBlockCipher>::BlockCipher;
-    type NonceSize = <Self as FromBlockCipher>::NonceSize;
-
-    fn from_block_cipher_mut(
-        cipher: Self::BlockCipher,
-        nonce: &GenericArray<u8, Self::NonceSize>,
-    ) -> C {
-        C::from_block_cipher(cipher, nonce)
-    }
-}
-
 impl<C> NewStreamCipher for C
 where
-    C: FromBlockCipherMut,
+    C: FromBlockCipher,
     C::BlockCipher: NewBlockCipher,
 {
-    type KeySize = <<Self as FromBlockCipherMut>::BlockCipher as NewBlockCipher>::KeySize;
-    type NonceSize = <Self as FromBlockCipherMut>::NonceSize;
+    type KeySize = <<Self as FromBlockCipher>::BlockCipher as NewBlockCipher>::KeySize;
+    type NonceSize = <Self as FromBlockCipher>::NonceSize;
 
     fn new(key: &Key<Self>, nonce: &Nonce<Self>) -> C {
-        C::from_block_cipher_mut(
-            <<Self as FromBlockCipherMut>::BlockCipher as NewBlockCipher>::new(key),
+        C::from_block_cipher(
+            <<Self as FromBlockCipher>::BlockCipher as NewBlockCipher>::new(key),
             nonce,
         )
     }
@@ -218,7 +189,7 @@ where
                 .map_err(|_| InvalidKeyNonceLength)
                 .map(|cipher| {
                     let nonce = GenericArray::from_slice(nonce);
-                    Self::from_block_cipher_mut(cipher, nonce)
+                    Self::from_block_cipher(cipher, nonce)
                 })
         }
     }

--- a/crypto-mac/Cargo.toml
+++ b/crypto-mac/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "crypto-mac"
 description = "Trait for Message Authentication Code (MAC) algorithms"
-version = "0.10.0"
+version = "0.11.0-pre"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
@@ -13,7 +13,7 @@ categories = ["cryptography", "no-std"]
 
 [dependencies]
 generic-array = "0.14"
-cipher = { version = "0.2", optional = true, path = "../cipher" }
+cipher = { version = "=0.3.0-pre", optional = true, path = "../cipher" }
 subtle = { version = "2", default-features = false }
 blobby = { version = "0.3", optional = true }
 

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -13,10 +13,10 @@ edition = "2018"
 
 [dependencies]
 aead = { version = "0.3", optional = true, path = "../aead" }
-cipher = { version = "0.2", optional = true, path = "../cipher" }
+cipher = { version = "=0.3.0-pre", optional = true, path = "../cipher" }
 digest = { version = "0.9", optional = true, path = "../digest" }
 elliptic-curve = { version = "=0.7.0-pre", optional = true, path = "../elliptic-curve" }
-mac = { version = "0.10", package = "crypto-mac", optional = true, path = "../crypto-mac" }
+mac = { version = "=0.11.0-pre", package = "crypto-mac", optional = true, path = "../crypto-mac" }
 signature = { version = "1.2.0", optional = true, default-features = false, path = "../signature" }
 universal-hash = { version = "0.4", optional = true, path = "../universal-hash" }
 


### PR DESCRIPTION
Closes #349

Adds `BlockEncrypt` and `BlockDecrypt` traits which can be used in cases where e.g. only the encryption portion of a block cipher is used, as in CTR mode.

This PR does not otherwise attempt to add things like a blanket impl.