### PR TITLE
[WIP] exploring a `BlockCipher` marker trait (not for merge)

### DIFF
--- a/cipher/src/block.rs
+++ b/cipher/src/block.rs
@@ -26,11 +26,11 @@ use generic_array::{typenum::Unsigned, ArrayLength, GenericArray};
 /// Key for an algorithm that implements [`NewBlockCipher`].
 pub type Key<B> = GenericArray<u8, <B as NewBlockCipher>::KeySize>;
 
-/// Block on which a [`BlockCipher`] operates.
-pub type Block<B> = GenericArray<u8, <B as BlockCipher>::BlockSize>;
-
-/// Blocks being acted over in parallel.
-pub type ParBlocks<B> = GenericArray<Block<B>, <B as BlockCipher>::ParBlocks>;
+// /// Block on which a [`BlockCipher`] operates.
+// pub type Block<B> = GenericArray<u8, <B as BlockCipher>::BlockSize>;
+//
+// /// Blocks being acted over in parallel.
+// pub type ParBlocks<B> = GenericArray<Block<B>, <B as BlockCipher>::ParBlocks>;
 
 /// Instantiate a [`BlockCipher`] algorithm.
 pub trait NewBlockCipher: Sized {
@@ -55,81 +55,13 @@ pub trait NewBlockCipher: Sized {
 
 /// The trait which defines in-place encryption and decryption
 /// over single block or several blocks in parallel.
-pub trait BlockCipher {
-    /// Size of the block in bytes
-    type BlockSize: ArrayLength<u8>;
-
-    /// Number of blocks which can be processed in parallel by
-    /// cipher implementation
-    type ParBlocks: ArrayLength<Block<Self>>;
-
-    /// Encrypt block in-place
-    fn encrypt_block(&self, block: &mut Block<Self>);
-
-    /// Decrypt block in-place
-    fn decrypt_block(&self, block: &mut Block<Self>);
-
-    /// Encrypt several blocks in parallel using instruction level parallelism
-    /// if possible.
-    ///
-    /// If `ParBlocks` equals to 1 it's equivalent to `encrypt_block`.
-    #[inline]
-    fn encrypt_blocks(&self, blocks: &mut ParBlocks<Self>) {
-        for block in blocks.iter_mut() {
-            self.encrypt_block(block);
-        }
-    }
-
-    /// Encrypt a slice of blocks, leveraging parallelism when available.
-    #[inline]
-    fn encrypt_slice(&self, mut blocks: &mut [Block<Self>]) {
-        let pb = Self::ParBlocks::to_usize();
-
-        if pb > 1 {
-            let mut iter = blocks.chunks_exact_mut(pb);
-
-            for chunk in &mut iter {
-                self.encrypt_blocks(chunk.try_into().unwrap())
-            }
-
-            blocks = iter.into_remainder();
-        }
-
-        for block in blocks {
-            self.encrypt_block(block);
-        }
-    }
-
-    /// Decrypt several blocks in parallel using instruction level parallelism
-    /// if possible.
-    ///
-    /// If `ParBlocks` equals to 1 it's equivalent to `decrypt_block`.
-    #[inline]
-    fn decrypt_blocks(&self, blocks: &mut ParBlocks<Self>) {
-        for block in blocks.iter_mut() {
-            self.decrypt_block(block);
-        }
-    }
-
-    /// Decrypt a slice of blocks, leveraging parallelism when available.
-    #[inline]
-    fn decrypt_slice(&self, mut blocks: &mut [Block<Self>]) {
-        let pb = Self::ParBlocks::to_usize();
-
-        if pb > 1 {
-            let mut iter = blocks.chunks_exact_mut(pb);
-
-            for chunk in &mut iter {
-                self.decrypt_blocks(chunk.try_into().unwrap())
-            }
-
-            blocks = iter.into_remainder();
-        }
-
-        for block in blocks {
-            self.decrypt_block(block);
-        }
-    }
+pub trait BlockCipher<BlockSize, ParBlocks>
+where
+    BlockSize: ArrayLength<u8>,
+    ParBlocks: ArrayLength<GenericArray<u8, BlockSize>>,
+    Self: Encrypt<BlockSize = BlockSize, ParBlocks = ParBlocks>
+        + Decrypt<BlockSize = BlockSize, ParBlocks = ParBlocks>,
+{
 }
 
 /// Stateful block cipher which permits `&mut self` access.
@@ -147,44 +79,44 @@ pub trait BlockCipherMut {
     fn decrypt_block(&mut self, block: &mut GenericArray<u8, Self::BlockSize>);
 }
 
-impl<Alg: BlockCipher> BlockCipherMut for Alg {
-    type BlockSize = Alg::BlockSize;
+// impl<Alg: BlockCipher> BlockCipherMut for Alg {
+//     type BlockSize = Alg::BlockSize;
+//
+//     #[inline]
+//     fn encrypt_block(&mut self, block: &mut GenericArray<u8, Self::BlockSize>) {
+//         <Self as BlockCipher>::encrypt_block(self, block);
+//     }
+//
+//     #[inline]
+//     fn decrypt_block(&mut self, block: &mut GenericArray<u8, Self::BlockSize>) {
+//         <Self as BlockCipher>::decrypt_block(self, block);
+//     }
+// }
 
-    #[inline]
-    fn encrypt_block(&mut self, block: &mut GenericArray<u8, Self::BlockSize>) {
-        <Self as BlockCipher>::encrypt_block(self, block);
-    }
-
-    #[inline]
-    fn decrypt_block(&mut self, block: &mut GenericArray<u8, Self::BlockSize>) {
-        <Self as BlockCipher>::decrypt_block(self, block);
-    }
-}
-
-impl<Alg: BlockCipher> BlockCipher for &Alg {
-    type BlockSize = Alg::BlockSize;
-    type ParBlocks = Alg::ParBlocks;
-
-    #[inline]
-    fn encrypt_block(&self, block: &mut Block<Self>) {
-        Alg::encrypt_block(self, block);
-    }
-
-    #[inline]
-    fn decrypt_block(&self, block: &mut Block<Self>) {
-        Alg::decrypt_block(self, block);
-    }
-
-    #[inline]
-    fn encrypt_blocks(&self, blocks: &mut ParBlocks<Self>) {
-        Alg::encrypt_blocks(self, blocks);
-    }
-
-    #[inline]
-    fn decrypt_blocks(&self, blocks: &mut ParBlocks<Self>) {
-        Alg::decrypt_blocks(self, blocks);
-    }
-}
+// impl<Alg: BlockCipher> BlockCipher for &Alg {
+//     type BlockSize = Alg::BlockSize;
+//     type ParBlocks = Alg::ParBlocks;
+//
+//     #[inline]
+//     fn encrypt_block(&self, block: &mut Block<Self>) {
+//         Alg::encrypt_block(self, block);
+//     }
+//
+//     #[inline]
+//     fn decrypt_block(&self, block: &mut Block<Self>) {
+//         Alg::decrypt_block(self, block);
+//     }
+//
+//     #[inline]
+//     fn encrypt_blocks(&self, blocks: &mut ParBlocks<Self>) {
+//         Alg::encrypt_blocks(self, blocks);
+//     }
+//
+//     #[inline]
+//     fn decrypt_blocks(&self, blocks: &mut ParBlocks<Self>) {
+//         Alg::decrypt_blocks(self, blocks);
+//     }
+// }
 
 /// Encrypt-only functionality for block ciphers
 pub trait Encrypt {


### PR DESCRIPTION
Attempt at refactoring `BlockCipher` into a trait which marks a type as being capable of both `Encrypt` and `Decrypt`.

As far as I can tell this requires the unfortunate change of making the block size and parallel block parameters generic.