### PR TITLE
cipher v0.2.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,7 +85,7 @@ checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "cipher"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "blobby 0.3.0",
  "generic-array 0.14.4",

--- a/cipher/CHANGELOG.md
+++ b/cipher/CHANGELOG.md
@@ -5,13 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.2.3 (2020-11-01)
+## 0.2.4 (2020-11-01)
+### Fixed
+- Macro expansion error ([#358])
+
+[#358]: https://github.com/RustCrypto/traits/pull/358
+
+## 0.2.3 (2020-11-01) [YANKED]
 ### Fixed
 - Legacy macro wrappers ([#356])
 
 [#356]: https://github.com/RustCrypto/traits/pull/356
 
-## 0.2.2 (2020-11-01)
+## 0.2.2 (2020-11-01) [YANKED]
 ### Added
 - `BlockCipher::{encrypt_slice, decrypt_slice}` methods ([#351])
 

--- a/cipher/Cargo.toml
+++ b/cipher/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cipher"
 description = "Traits for describing block ciphers and stream ciphers"
-version = "0.2.3"
+version = "0.2.4"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
### Fixed
- Macro expansion error ([#358])

[#358]: https://github.com/RustCrypto/traits/pull/358