### PR TITLE
Made PublicKey a newtype that does point validation upon deserialization

### DIFF
--- a/elliptic-curve/src/ecdh.rs
+++ b/elliptic-curve/src/ecdh.rs
@@ -24,11 +24,16 @@ use crate::{
     consts::U1,
     generic_array::ArrayLength,
     scalar::NonZeroScalar,
-    sec1::{self, FromEncodedPoint, UncompressedPointSize, UntaggedPointSize},
+    sec1::{
+        EncodedPoint, FromEncodedPoint, ToEncodedPoint, UncompressedPointSize, UntaggedPointSize,
+    },
     weierstrass::Curve,
     AffinePoint, Error, FieldBytes, ProjectiveArithmetic, Scalar,
 };
-use core::ops::{Add, Mul};
+use core::{
+    fmt::Debug,
+    ops::{Add, Mul},
+};
 use ff::PrimeField;
 use group::{Curve as _, Group};
 use rand_core::{CryptoRng, RngCore};
@@ -36,8 +41,66 @@ use zeroize::Zeroize;
 
 /// Elliptic Curve Diffie-Hellman public keys.
 ///
-/// These are SEC1-encoded elliptic curve points.
-pub type PublicKey<C> = sec1::EncodedPoint<C>;
+/// These are [`AffinePoint`]s. That is, they are non-identity curve points.
+#[derive(Clone, Debug)]
+pub struct PublicKey<C>
+where
+    C: Curve + ProjectiveArithmetic,
+    FieldBytes<C>: From<Scalar<C>> + for<'r> From<&'r Scalar<C>>,
+    Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
+    AffinePoint<C>: Clone + Debug + Default + FromEncodedPoint<C> + ToEncodedPoint<C>,
+    UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
+    UncompressedPointSize<C>: ArrayLength<u8>,
+{
+    point: AffinePoint<C>,
+}
+
+impl<C> PublicKey<C>
+where
+    C: Curve + ProjectiveArithmetic,
+    FieldBytes<C>: From<Scalar<C>> + for<'r> From<&'r Scalar<C>>,
+    Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
+    AffinePoint<C>: Clone + Debug + Default + FromEncodedPoint<C> + ToEncodedPoint<C>,
+    UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
+    UncompressedPointSize<C>: ArrayLength<u8>,
+{
+    /// Initialize [`PublicKey`] from a SEC1-encoded public key
+    pub fn new(bytes: &[u8]) -> Result<Self, Error> {
+        EncodedPoint::from_bytes(bytes)
+            .map_err(|_| Error)
+            .and_then(|point| Self::from_encoded_point(&point))
+    }
+
+    /// Initialize [`PublicKey`] from an [`EncodedPoint`]
+    pub fn from_encoded_point(encoded_point: &EncodedPoint<C>) -> Result<Self, Error> {
+        let affine_point = AffinePoint::<C>::from_encoded_point(encoded_point);
+
+        // No need to return a CtOption when the input is assumed to be public
+        if affine_point.is_some().into() {
+            Ok(Self {
+                point: affine_point.unwrap(),
+            })
+        } else {
+            Err(Error)
+        }
+    }
+}
+
+impl<C> ToEncodedPoint<C> for PublicKey<C>
+where
+    C: Curve + ProjectiveArithmetic,
+    FieldBytes<C>: From<Scalar<C>> + for<'r> From<&'r Scalar<C>>,
+    Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
+    AffinePoint<C>: Clone + Debug + Default + FromEncodedPoint<C> + ToEncodedPoint<C>,
+    UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
+    UncompressedPointSize<C>: ArrayLength<u8>,
+{
+    /// Serialize this [`PublicKey`] as a SEC1 [`EncodedPoint`], optionally applying
+    /// point compression
+    fn to_encoded_point(&self, compress: bool) -> EncodedPoint<C> {
+        self.point.to_encoded_point(compress)
+    }
+}
 
 /// Ephemeral Diffie-Hellman Secret.
 ///
@@ -57,8 +120,14 @@ where
     C: Curve + ProjectiveArithmetic,
     FieldBytes<C>: From<Scalar<C>> + for<'r> From<&'r Scalar<C>>,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>> + Clone + Zeroize,
-    AffinePoint<C>: FromEncodedPoint<C> + Mul<NonZeroScalar<C>, Output = AffinePoint<C>> + Zeroize,
-    PublicKey<C>: From<AffinePoint<C>>,
+    AffinePoint<C>: Clone
+        + Debug
+        + Default
+        + Into<EncodedPoint<C>>
+        + FromEncodedPoint<C>
+        + ToEncodedPoint<C>
+        + Mul<NonZeroScalar<C>, Output = AffinePoint<C>>
+        + Zeroize,
     UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
     UncompressedPointSize<C>: ArrayLength<u8>,
 {
@@ -74,22 +143,19 @@ where
     /// The `compress` flag enables point compression.
     pub fn public_key(&self) -> PublicKey<C> {
         #[allow(clippy::op_ref)]
-        (C::ProjectivePoint::generator() * &*self.scalar)
-            .to_affine()
-            .into()
+        let pubkey_point = (C::ProjectivePoint::generator() * &*self.scalar).to_affine();
+
+        PublicKey {
+            point: pubkey_point,
+        }
     }
 
     /// Compute a Diffie-Hellman shared secret from an ephemeral secret and the
     /// public key of the other participant in the exchange.
-    pub fn diffie_hellman(&self, public_key: &PublicKey<C>) -> Result<SharedSecret<C>, Error> {
-        let affine_point = AffinePoint::<C>::from_encoded_point(public_key);
-
-        if affine_point.is_some().into() {
-            let shared_secret = affine_point.unwrap() * self.scalar;
-            Ok(SharedSecret::new(shared_secret.into()))
-        } else {
-            Err(Error)
-        }
+    pub fn diffie_hellman(&self, public_key: &PublicKey<C>) -> SharedSecret<C> {
+        let shared_secret = public_key.point.clone() * self.scalar;
+        // SharedSecret::new expects an uncompressed point
+        SharedSecret::new(shared_secret.to_encoded_point(false))
     }
 }
 
@@ -98,8 +164,14 @@ where
     C: Curve + ProjectiveArithmetic,
     FieldBytes<C>: From<Scalar<C>> + for<'r> From<&'r Scalar<C>>,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>> + Clone + Zeroize,
-    AffinePoint<C>: FromEncodedPoint<C> + Mul<NonZeroScalar<C>, Output = AffinePoint<C>> + Zeroize,
-    PublicKey<C>: From<AffinePoint<C>>,
+    AffinePoint<C>: Clone
+        + Debug
+        + Default
+        + Into<EncodedPoint<C>>
+        + FromEncodedPoint<C>
+        + ToEncodedPoint<C>
+        + Mul<NonZeroScalar<C>, Output = AffinePoint<C>>
+        + Zeroize,
     UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
     UncompressedPointSize<C>: ArrayLength<u8>,
 {
@@ -163,7 +235,7 @@ where
     UncompressedPointSize<C>: ArrayLength<u8>,
 {
     /// Create a new shared secret from the given uncompressed curve point
-    fn new(mut encoded_point: sec1::EncodedPoint<C>) -> Self {
+    fn new(mut encoded_point: EncodedPoint<C>) -> Self {
         let secret_bytes = encoded_point.x().clone();
         encoded_point.zeroize();
         Self { secret_bytes }


### PR DESCRIPTION
This change, coupled with some changes in the `elliptic_curve` trait, should fix https://github.com/RustCrypto/elliptic-curves/issues/236

I know it's kinda messy, but this was the minimal solution I could come up with. It resembles `ecdsa::VerifyKey`