### PR TITLE
Bump `const-oid` to v0.2; MSRV 1.46+

### DIFF
--- a/.github/workflows/elliptic-curve.yml
+++ b/.github/workflows/elliptic-curve.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.44.0 # MSRV
+          - 1.46.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -37,14 +37,14 @@ jobs:
           override: true
       - run: cargo build --no-default-features --release --target ${{ matrix.target }}
       - run: cargo build --no-default-features --release --target ${{ matrix.target }} --features arithmetic
-      - run: cargo build --no-default-features --release --target ${{ matrix.target }} --features zeroize
       - run: cargo build --no-default-features --release --target ${{ matrix.target }} --features ecdh
+      - run: cargo build --no-default-features --release --target ${{ matrix.target }} --features zeroize
   test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         rust:
-          - 1.44.0 # MSRV
+          - 1.46.0 # MSRV
           - stable
     steps:
     - uses: actions/checkout@v1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,9 +93,9 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2d9162b7289a46e86208d6af2c686ca5bfde445878c41a458a9fac706252d0b"
+checksum = "6fc33f77ab0b4232f30cb9049a156775c5ad814b030e929d234d14cd6d7ec17f"
 
 [[package]]
 name = "cpuid-bool"
@@ -145,7 +145,7 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.6.6"
+version = "0.7.0-pre"
 dependencies = [
  "bitvec",
  "const-oid",

--- a/cryptography/Cargo.toml
+++ b/cryptography/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 aead = { version = "0.3", optional = true, path = "../aead" }
 cipher = { version = "0.2", optional = true, path = "../cipher" }
 digest = { version = "0.9", optional = true, path = "../digest" }
-elliptic-curve = { version = "0.6", optional = true, path = "../elliptic-curve" }
+elliptic-curve = { version = "=0.7.0-pre", optional = true, path = "../elliptic-curve" }
 mac = { version = "0.10", package = "crypto-mac", optional = true, path = "../crypto-mac" }
 signature = { version = "1.2.0", optional = true, default-features = false, path = "../signature" }
 universal-hash = { version = "0.4", optional = true, path = "../universal-hash" }

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -5,7 +5,7 @@ General purpose Elliptic Curve Cryptography (ECC) support, including types
 and traits for representing various elliptic curve forms, scalars, points,
 and public/secret keys composed thereof.
 """
-version    = "0.6.6" # Also update html_root_url in lib.rs when bumping this
+version    = "0.7.0-pre" # Also update html_root_url in lib.rs when bumping this
 authors    = ["RustCrypto Developers"]
 license    = "Apache-2.0 OR MIT"
 repository = "https://github.com/RustCrypto/traits/tree/master/elliptic-curve"
@@ -20,7 +20,7 @@ digest = { version = "0.9", optional = true }
 ff = { version = "0.8", optional = true, default-features = false }
 group = { version = "0.8", optional = true, default-features = false }
 generic-array = { version = "0.14", default-features = false }
-oid = { package = "const-oid", version = "0.1", optional = true }
+oid = { package = "const-oid", version = "0.2", optional = true }
 rand_core = { version = "0.5", default-features = false }
 subtle = { version = "2.3", default-features = false }
 zeroize = { version = "1", optional = true,  default-features = false }

--- a/elliptic-curve/README.md
+++ b/elliptic-curve/README.md
@@ -15,7 +15,7 @@ and public/secret keys composed thereof.
 
 ## Minimum Supported Rust Version
 
-Requires Rust **1.44** or higher.
+Requires Rust **1.46** or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be
 done with a minor version bump.
@@ -47,7 +47,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/elliptic-curve/badge.svg
 [docs-link]: https://docs.rs/elliptic-curve/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.44+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.46+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260040-elliptic-curves
 [build-image]: https://github.com/RustCrypto/elliptic-curves/workflows/elliptic-curve%20crate/badge.svg?branch=master&event=push

--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -4,7 +4,7 @@
 //!
 //! ## Minimum Supported Rust Version
 //!
-//! Rust **1.44** or higher.
+//! Rust **1.46** or higher.
 //!
 //! Minimum supported Rust version can be changed in the future, but it will be
 //! done with a minor version bump.


### PR DESCRIPTION
As MSRV bump is considered a breaking change; this also bumps the Cargo.toml version to v0.7.0-pre.

This version of `const-oid` uses the new `const fn` features to provide some basic OID validation.

While this alone may be a silly reason to bump MSRV to 1.46+, many of the elliptic curve crates could also benefit from using `const fn` in a similar manner, so bumping MSRV is generally useful.