### PR TITLE
elliptic-curve: extract toplevel PublicKey; add functionality

### DIFF
--- a/elliptic-curve/src/ecdh.rs
+++ b/elliptic-curve/src/ecdh.rs
@@ -22,85 +22,20 @@
 
 use crate::{
     consts::U1,
-    generic_array::ArrayLength,
+    public_key::PublicKey,
     scalar::NonZeroScalar,
     sec1::{
         EncodedPoint, FromEncodedPoint, ToEncodedPoint, UncompressedPointSize, UntaggedPointSize,
     },
     weierstrass::Curve,
-    AffinePoint, Error, FieldBytes, ProjectiveArithmetic, Scalar,
+    AffinePoint, FieldBytes, ProjectiveArithmetic, ProjectivePoint, Scalar,
 };
-use core::{
-    fmt::Debug,
-    ops::{Add, Mul},
-};
+use core::{fmt::Debug, ops::Add};
 use ff::PrimeField;
+use generic_array::ArrayLength;
 use group::{Curve as _, Group};
 use rand_core::{CryptoRng, RngCore};
 use zeroize::Zeroize;
-
-/// Elliptic Curve Diffie-Hellman public keys.
-///
-/// These are [`AffinePoint`]s. That is, they are non-identity curve points.
-#[derive(Clone, Debug)]
-pub struct PublicKey<C>
-where
-    C: Curve + ProjectiveArithmetic,
-    FieldBytes<C>: From<Scalar<C>> + for<'r> From<&'r Scalar<C>>,
-    Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
-    AffinePoint<C>: Clone + Debug + Default + FromEncodedPoint<C> + ToEncodedPoint<C>,
-    UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
-    UncompressedPointSize<C>: ArrayLength<u8>,
-{
-    point: AffinePoint<C>,
-}
-
-impl<C> PublicKey<C>
-where
-    C: Curve + ProjectiveArithmetic,
-    FieldBytes<C>: From<Scalar<C>> + for<'r> From<&'r Scalar<C>>,
-    Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
-    AffinePoint<C>: Clone + Debug + Default + FromEncodedPoint<C> + ToEncodedPoint<C>,
-    UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
-    UncompressedPointSize<C>: ArrayLength<u8>,
-{
-    /// Initialize [`PublicKey`] from a SEC1-encoded public key
-    pub fn new(bytes: &[u8]) -> Result<Self, Error> {
-        EncodedPoint::from_bytes(bytes)
-            .map_err(|_| Error)
-            .and_then(|point| Self::from_encoded_point(&point))
-    }
-
-    /// Initialize [`PublicKey`] from an [`EncodedPoint`]
-    pub fn from_encoded_point(encoded_point: &EncodedPoint<C>) -> Result<Self, Error> {
-        let affine_point = AffinePoint::<C>::from_encoded_point(encoded_point);
-
-        // No need to return a CtOption when the input is assumed to be public
-        if affine_point.is_some().into() {
-            Ok(Self {
-                point: affine_point.unwrap(),
-            })
-        } else {
-            Err(Error)
-        }
-    }
-}
-
-impl<C> ToEncodedPoint<C> for PublicKey<C>
-where
-    C: Curve + ProjectiveArithmetic,
-    FieldBytes<C>: From<Scalar<C>> + for<'r> From<&'r Scalar<C>>,
-    Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
-    AffinePoint<C>: Clone + Debug + Default + FromEncodedPoint<C> + ToEncodedPoint<C>,
-    UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
-    UncompressedPointSize<C>: ArrayLength<u8>,
-{
-    /// Serialize this [`PublicKey`] as a SEC1 [`EncodedPoint`], optionally applying
-    /// point compression
-    fn to_encoded_point(&self, compress: bool) -> EncodedPoint<C> {
-        self.point.to_encoded_point(compress)
-    }
-}
 
 /// Ephemeral Diffie-Hellman Secret.
 ///
@@ -126,8 +61,8 @@ where
         + Into<EncodedPoint<C>>
         + FromEncodedPoint<C>
         + ToEncodedPoint<C>
-        + Mul<NonZeroScalar<C>, Output = AffinePoint<C>>
         + Zeroize,
+    ProjectivePoint<C>: From<AffinePoint<C>>,
     UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
     UncompressedPointSize<C>: ArrayLength<u8>,
 {
@@ -142,20 +77,15 @@ where
     ///
     /// The `compress` flag enables point compression.
     pub fn public_key(&self) -> PublicKey<C> {
-        #[allow(clippy::op_ref)]
-        let pubkey_point = (C::ProjectivePoint::generator() * &*self.scalar).to_affine();
-
-        PublicKey {
-            point: pubkey_point,
-        }
+        PublicKey::from_affine((C::ProjectivePoint::generator() * self.scalar.as_ref()).to_affine())
     }
 
     /// Compute a Diffie-Hellman shared secret from an ephemeral secret and the
     /// public key of the other participant in the exchange.
     pub fn diffie_hellman(&self, public_key: &PublicKey<C>) -> SharedSecret<C> {
-        let shared_secret = public_key.point.clone() * self.scalar;
+        let shared_secret = public_key.to_projective() * &self.scalar;
         // SharedSecret::new expects an uncompressed point
-        SharedSecret::new(shared_secret.to_encoded_point(false))
+        SharedSecret::new(shared_secret.to_affine().to_encoded_point(false))
     }
 }
 
@@ -170,8 +100,8 @@ where
         + Into<EncodedPoint<C>>
         + FromEncodedPoint<C>
         + ToEncodedPoint<C>
-        + Mul<NonZeroScalar<C>, Output = AffinePoint<C>>
         + Zeroize,
+    ProjectivePoint<C>: From<AffinePoint<C>>,
     UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
     UncompressedPointSize<C>: ArrayLength<u8>,
 {

--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -36,6 +36,9 @@ pub mod weierstrass;
 pub mod point;
 #[cfg(feature = "arithmetic")]
 #[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
+pub mod public_key;
+#[cfg(feature = "arithmetic")]
+#[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
 pub mod scalar;
 
 #[cfg(feature = "ecdh")]
@@ -55,6 +58,7 @@ pub use subtle;
 #[cfg(feature = "arithmetic")]
 pub use self::{
     point::{AffinePoint, ProjectiveArithmetic, ProjectivePoint},
+    public_key::PublicKey,
     scalar::Scalar,
 };
 #[cfg(feature = "arithmetic")]

--- a/elliptic-curve/src/public_key.rs
+++ b/elliptic-curve/src/public_key.rs
@@ -1,0 +1,200 @@
+//! Elliptic curve public keys.
+
+use crate::{
+    consts::U1,
+    sec1::{
+        EncodedPoint, FromEncodedPoint, ToEncodedPoint, UncompressedPointSize, UntaggedPointSize,
+    },
+    weierstrass::{point, Curve},
+    AffinePoint, Error, FieldBytes, ProjectiveArithmetic, ProjectivePoint, Scalar,
+};
+use core::{
+    convert::TryFrom,
+    fmt::Debug,
+    ops::{Add, Deref},
+};
+use ff::PrimeField;
+use generic_array::ArrayLength;
+use subtle::CtOption;
+
+/// Elliptic curve public keys.
+///
+/// These are a thin wrapper around [`AffinePoint`] which simplifies
+/// encoding/decoding.
+#[derive(Clone, Debug)]
+pub struct PublicKey<C>
+where
+    C: Curve + ProjectiveArithmetic,
+    FieldBytes<C>: From<Scalar<C>> + for<'r> From<&'r Scalar<C>>,
+    Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
+    AffinePoint<C>: Clone + Debug + Default + FromEncodedPoint<C> + ToEncodedPoint<C>,
+    ProjectivePoint<C>: From<AffinePoint<C>>,
+    UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
+    UncompressedPointSize<C>: ArrayLength<u8>,
+{
+    point: AffinePoint<C>,
+}
+
+impl<C> PublicKey<C>
+where
+    C: Curve + ProjectiveArithmetic,
+    FieldBytes<C>: From<Scalar<C>> + for<'r> From<&'r Scalar<C>>,
+    Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
+    AffinePoint<C>: Clone + Debug + Default + FromEncodedPoint<C> + ToEncodedPoint<C>,
+    ProjectivePoint<C>: From<AffinePoint<C>>,
+    UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
+    UncompressedPointSize<C>: ArrayLength<u8>,
+{
+    /// Initialize [`PublicKey`] from a SEC1-encoded public key
+    pub fn new(bytes: &[u8]) -> Result<Self, Error> {
+        EncodedPoint::from_bytes(bytes)
+            .map_err(|_| Error)
+            .and_then(|point| Self::try_from(&point))
+    }
+
+    /// Convert an [`AffinePoint`] into a [`PublicKey`]
+    pub fn from_affine(point: AffinePoint<C>) -> Self {
+        Self { point }
+    }
+
+    /// Convert this [`PublicKey`] to a [`ProjectivePoint`] for the given curve
+    pub fn to_projective(&self) -> ProjectivePoint<C> {
+        self.point.clone().into()
+    }
+}
+
+impl<C> AsRef<AffinePoint<C>> for PublicKey<C>
+where
+    C: Curve + ProjectiveArithmetic,
+    FieldBytes<C>: From<Scalar<C>> + for<'r> From<&'r Scalar<C>>,
+    Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
+    AffinePoint<C>: Clone + Debug + Default + FromEncodedPoint<C> + ToEncodedPoint<C>,
+    ProjectivePoint<C>: From<AffinePoint<C>>,
+    UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
+    UncompressedPointSize<C>: ArrayLength<u8>,
+{
+    fn as_ref(&self) -> &AffinePoint<C> {
+        &self.point
+    }
+}
+
+impl<C> Deref for PublicKey<C>
+where
+    C: Curve + ProjectiveArithmetic,
+    FieldBytes<C>: From<Scalar<C>> + for<'r> From<&'r Scalar<C>>,
+    Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
+    AffinePoint<C>: Clone + Debug + Default + FromEncodedPoint<C> + ToEncodedPoint<C>,
+    ProjectivePoint<C>: From<AffinePoint<C>>,
+    UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
+    UncompressedPointSize<C>: ArrayLength<u8>,
+{
+    type Target = AffinePoint<C>;
+
+    fn deref(&self) -> &AffinePoint<C> {
+        &self.point
+    }
+}
+
+impl<C> TryFrom<&EncodedPoint<C>> for PublicKey<C>
+where
+    C: Curve + ProjectiveArithmetic,
+    FieldBytes<C>: From<Scalar<C>> + for<'r> From<&'r Scalar<C>>,
+    Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
+    AffinePoint<C>: Clone + Debug + Default + FromEncodedPoint<C> + ToEncodedPoint<C>,
+    ProjectivePoint<C>: From<AffinePoint<C>>,
+    UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
+    UncompressedPointSize<C>: ArrayLength<u8>,
+{
+    type Error = Error;
+
+    fn try_from(encoded_point: &EncodedPoint<C>) -> Result<Self, Error> {
+        let public_key = Self::from_encoded_point(encoded_point);
+
+        // No need to return a CtOption when the input is assumed to be public
+        if public_key.is_some().into() {
+            Ok(public_key.unwrap())
+        } else {
+            Err(Error)
+        }
+    }
+}
+
+impl<C> From<PublicKey<C>> for EncodedPoint<C>
+where
+    C: Curve + ProjectiveArithmetic + point::Compression,
+    FieldBytes<C>: From<Scalar<C>> + for<'r> From<&'r Scalar<C>>,
+    Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
+    AffinePoint<C>: Clone + Debug + Default + FromEncodedPoint<C> + ToEncodedPoint<C>,
+    ProjectivePoint<C>: From<AffinePoint<C>>,
+    UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
+    UncompressedPointSize<C>: ArrayLength<u8>,
+{
+    fn from(public_key: PublicKey<C>) -> EncodedPoint<C> {
+        EncodedPoint::<C>::from(&public_key)
+    }
+}
+
+impl<C> From<&PublicKey<C>> for EncodedPoint<C>
+where
+    C: Curve + ProjectiveArithmetic + point::Compression,
+    FieldBytes<C>: From<Scalar<C>> + for<'r> From<&'r Scalar<C>>,
+    Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
+    AffinePoint<C>: Clone + Debug + Default + FromEncodedPoint<C> + ToEncodedPoint<C>,
+    ProjectivePoint<C>: From<AffinePoint<C>>,
+    UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
+    UncompressedPointSize<C>: ArrayLength<u8>,
+{
+    fn from(public_key: &PublicKey<C>) -> EncodedPoint<C> {
+        public_key.to_encoded_point(C::COMPRESS_POINTS)
+    }
+}
+
+impl<C> FromEncodedPoint<C> for PublicKey<C>
+where
+    C: Curve + ProjectiveArithmetic,
+    FieldBytes<C>: From<Scalar<C>> + for<'r> From<&'r Scalar<C>>,
+    Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
+    AffinePoint<C>: Clone + Debug + Default + FromEncodedPoint<C> + ToEncodedPoint<C>,
+    ProjectivePoint<C>: From<AffinePoint<C>>,
+    UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
+    UncompressedPointSize<C>: ArrayLength<u8>,
+{
+    /// Initialize [`PublicKey`] from an [`EncodedPoint`]
+    fn from_encoded_point(encoded_point: &EncodedPoint<C>) -> CtOption<Self> {
+        let affine_point = AffinePoint::<C>::from_encoded_point(encoded_point);
+
+        // Note: not constant time, but these are public keys
+        if affine_point.is_some().into() {
+            CtOption::new(
+                Self {
+                    point: affine_point.unwrap(),
+                },
+                1.into(),
+            )
+        } else {
+            CtOption::new(
+                Self {
+                    point: Default::default(),
+                },
+                0.into(),
+            )
+        }
+    }
+}
+
+impl<C> ToEncodedPoint<C> for PublicKey<C>
+where
+    C: Curve + ProjectiveArithmetic,
+    FieldBytes<C>: From<Scalar<C>> + for<'r> From<&'r Scalar<C>>,
+    Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
+    AffinePoint<C>: Clone + Debug + Default + FromEncodedPoint<C> + ToEncodedPoint<C>,
+    ProjectivePoint<C>: From<AffinePoint<C>>,
+    UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
+    UncompressedPointSize<C>: ArrayLength<u8>,
+{
+    /// Serialize this [`PublicKey`] as a SEC1 [`EncodedPoint`], optionally applying
+    /// point compression
+    fn to_encoded_point(&self, compress: bool) -> EncodedPoint<C> {
+        self.point.to_encoded_point(compress)
+    }
+}


### PR DESCRIPTION
This PR refactors the `ecdh::PublicKey` type introduced in #363 into a toplevel `public_key::PublicKey` type which is generally useful anywhere a public key is required.

It additionally adds a number of additional impls including `AsRef`, `Deref`, and various `From`/`TryFrom` conversions.

It also promotes the `from_encoded_point` method into a proper impl of the `FromEncodedPoint` trait, leveraging a `TryFrom` impl instead as a more convenient API.

cc @rozbb 