### PR TITLE
cipher: fix `cipher::block` test macros

### DIFF
--- a/cipher/src/block/dev.rs
+++ b/cipher/src/block/dev.rs
@@ -9,7 +9,9 @@ macro_rules! block_cipher_test {
     ($name:ident, $test_name:expr, $cipher:ty) => {
         #[test]
         fn $name() {
-            use cipher::block::{dev::blobby::Blob3Iterator, BlockCipher, NewBlockCipher};
+            use cipher::block::{
+                dev::blobby::Blob3Iterator, BlockCipher, BlockDecrypt, BlockEncrypt, NewBlockCipher,
+            };
             use cipher::generic_array::{typenum::Unsigned, GenericArray};
 
             fn run_test(key: &[u8], pt: &[u8], ct: &[u8]) -> bool {
@@ -111,7 +113,7 @@ macro_rules! block_cipher_bench {
     ($cipher:path, $key_len:expr) => {
         extern crate test;
 
-        use cipher::block::{BlockCipher, NewBlockCipher};
+        use cipher::block::{BlockCipher, BlockDecrypt, BlockEncrypt, NewBlockCipher};
         use test::Bencher;
 
         #[bench]


### PR DESCRIPTION
Have them import the new `BlockEncrypt` and `BlockDecrypt` traits.