### PR TITLE
elliptic-curve: remove Deref impl from PublicKey; add ::as_affine()

### DIFF
--- a/elliptic-curve/src/public_key.rs
+++ b/elliptic-curve/src/public_key.rs
@@ -11,7 +11,7 @@ use crate::{
 use core::{
     convert::{TryFrom, TryInto},
     fmt::Debug,
-    ops::{Add, Deref},
+    ops::Add,
 };
 use ff::PrimeField;
 use generic_array::ArrayLength;
@@ -56,6 +56,13 @@ where
         Self { point }
     }
 
+    /// Borrow the inner [`AffinePoint`] from this [`PublicKey`].
+    ///
+    /// In ECC, public keys are elliptic curve points.
+    pub fn as_affine(&self) -> &AffinePoint<C> {
+        &self.point
+    }
+
     /// Convert this [`PublicKey`] to a [`ProjectivePoint`] for the given curve
     pub fn to_projective(&self) -> ProjectivePoint<C> {
         self.point.clone().into()
@@ -73,24 +80,7 @@ where
     UncompressedPointSize<C>: ArrayLength<u8>,
 {
     fn as_ref(&self) -> &AffinePoint<C> {
-        &self.point
-    }
-}
-
-impl<C> Deref for PublicKey<C>
-where
-    C: Curve + ProjectiveArithmetic,
-    FieldBytes<C>: From<Scalar<C>> + for<'r> From<&'r Scalar<C>>,
-    Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
-    AffinePoint<C>: Clone + Debug + Default + FromEncodedPoint<C> + ToEncodedPoint<C>,
-    ProjectivePoint<C>: From<AffinePoint<C>>,
-    UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
-    UncompressedPointSize<C>: ArrayLength<u8>,
-{
-    type Target = AffinePoint<C>;
-
-    fn deref(&self) -> &AffinePoint<C> {
-        &self.point
+        self.as_affine()
     }
 }
 

--- a/elliptic-curve/src/sec1.rs
+++ b/elliptic-curve/src/sec1.rs
@@ -224,7 +224,7 @@ where
     where
         T: FromEncodedPoint<C>,
     {
-        T::from_encoded_point(self).ok_or_else(|| Error)
+        T::from_encoded_point(self).ok_or(Error)
     }
 
     /// Get the SEC1 tag for this [`EncodedPoint`]


### PR DESCRIPTION
Types with `Deref` impls shouldn't have inherent methods, however `PublicKey` has several.

This makes `PublicKey` more than a "smart pointer" type which `Deref` is intended to be used with: it handles encoding and conversions in a way that can be shared across curves.

It already provided an `AsRef` impl for obtaining the `AffinePoint`, however this PR also adds a new inherent `as_affine` method as well for convenience.