### PR TITLE
elliptic-curve: simplify PublicKey trait bounds

### DIFF
--- a/elliptic-curve/src/ecdh.rs
+++ b/elliptic-curve/src/ecdh.rs
@@ -24,9 +24,7 @@ use crate::{
     consts::U1,
     public_key::PublicKey,
     scalar::NonZeroScalar,
-    sec1::{
-        EncodedPoint, FromEncodedPoint, ToEncodedPoint, UncompressedPointSize, UntaggedPointSize,
-    },
+    sec1::{EncodedPoint, ToEncodedPoint, UncompressedPointSize, UntaggedPointSize},
     weierstrass::Curve,
     AffinePoint, FieldBytes, ProjectiveArithmetic, ProjectivePoint, Scalar,
 };
@@ -55,13 +53,7 @@ where
     C: Curve + ProjectiveArithmetic,
     FieldBytes<C>: From<Scalar<C>> + for<'r> From<&'r Scalar<C>>,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>> + Clone + Zeroize,
-    AffinePoint<C>: Clone
-        + Debug
-        + Default
-        + Into<EncodedPoint<C>>
-        + FromEncodedPoint<C>
-        + ToEncodedPoint<C>
-        + Zeroize,
+    AffinePoint<C>: Copy + Clone + Debug + ToEncodedPoint<C> + Zeroize,
     ProjectivePoint<C>: From<AffinePoint<C>>,
     UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
     UncompressedPointSize<C>: ArrayLength<u8>,
@@ -94,13 +86,7 @@ where
     C: Curve + ProjectiveArithmetic,
     FieldBytes<C>: From<Scalar<C>> + for<'r> From<&'r Scalar<C>>,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>> + Clone + Zeroize,
-    AffinePoint<C>: Clone
-        + Debug
-        + Default
-        + Into<EncodedPoint<C>>
-        + FromEncodedPoint<C>
-        + ToEncodedPoint<C>
-        + Zeroize,
+    AffinePoint<C>: Copy + Clone + Debug + ToEncodedPoint<C> + Zeroize,
     ProjectivePoint<C>: From<AffinePoint<C>>,
     UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
     UncompressedPointSize<C>: ArrayLength<u8>,

--- a/elliptic-curve/src/public_key.rs
+++ b/elliptic-curve/src/public_key.rs
@@ -20,16 +20,13 @@ use generic_array::ArrayLength;
 ///
 /// These are a thin wrapper around [`AffinePoint`] which simplifies
 /// encoding/decoding.
-#[derive(Clone, Debug)]
+#[derive(Copy, Clone, Debug)]
 pub struct PublicKey<C>
 where
     C: Curve + ProjectiveArithmetic,
     FieldBytes<C>: From<Scalar<C>> + for<'r> From<&'r Scalar<C>>,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
-    AffinePoint<C>: Clone + Debug + Default + FromEncodedPoint<C> + ToEncodedPoint<C>,
-    ProjectivePoint<C>: From<AffinePoint<C>>,
-    UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
-    UncompressedPointSize<C>: ArrayLength<u8>,
+    AffinePoint<C>: Copy + Clone + Debug,
 {
     point: AffinePoint<C>,
 }
@@ -39,10 +36,7 @@ where
     C: Curve + ProjectiveArithmetic,
     FieldBytes<C>: From<Scalar<C>> + for<'r> From<&'r Scalar<C>>,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
-    AffinePoint<C>: Clone + Debug + Default + FromEncodedPoint<C> + ToEncodedPoint<C>,
-    ProjectivePoint<C>: From<AffinePoint<C>>,
-    UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
-    UncompressedPointSize<C>: ArrayLength<u8>,
+    AffinePoint<C>: Copy + Clone + Debug,
 {
     /// Convert an [`AffinePoint`] into a [`PublicKey`]
     pub fn from_affine(point: AffinePoint<C>) -> Self {
@@ -55,7 +49,12 @@ where
     /// 2.3.3 (page 10).
     ///
     /// <http://www.secg.org/sec1-v2.pdf>
-    pub fn from_sec1_bytes(bytes: &[u8]) -> Result<Self, Error> {
+    pub fn from_sec1_bytes(bytes: &[u8]) -> Result<Self, Error>
+    where
+        Self: TryFrom<EncodedPoint<C>, Error = Error>,
+        UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
+        UncompressedPointSize<C>: ArrayLength<u8>,
+    {
         EncodedPoint::from_bytes(bytes)
             .map_err(|_| Error)
             .and_then(TryInto::try_into)
@@ -69,7 +68,10 @@ where
     }
 
     /// Convert this [`PublicKey`] to a [`ProjectivePoint`] for the given curve
-    pub fn to_projective(&self) -> ProjectivePoint<C> {
+    pub fn to_projective(&self) -> ProjectivePoint<C>
+    where
+        ProjectivePoint<C>: From<AffinePoint<C>>,
+    {
         self.point.clone().into()
     }
 }
@@ -79,10 +81,7 @@ where
     C: Curve + ProjectiveArithmetic,
     FieldBytes<C>: From<Scalar<C>> + for<'r> From<&'r Scalar<C>>,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
-    AffinePoint<C>: Clone + Debug + Default + FromEncodedPoint<C> + ToEncodedPoint<C>,
-    ProjectivePoint<C>: From<AffinePoint<C>>,
-    UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
-    UncompressedPointSize<C>: ArrayLength<u8>,
+    AffinePoint<C>: Copy + Clone + Debug,
 {
     fn as_ref(&self) -> &AffinePoint<C> {
         self.as_affine()
@@ -94,7 +93,7 @@ where
     C: Curve + ProjectiveArithmetic,
     FieldBytes<C>: From<Scalar<C>> + for<'r> From<&'r Scalar<C>>,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
-    AffinePoint<C>: Clone + Debug + Default + FromEncodedPoint<C> + ToEncodedPoint<C>,
+    AffinePoint<C>: Copy + Clone + Debug + Default + FromEncodedPoint<C> + ToEncodedPoint<C>,
     ProjectivePoint<C>: From<AffinePoint<C>>,
     UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
     UncompressedPointSize<C>: ArrayLength<u8>,
@@ -111,7 +110,7 @@ where
     C: Curve + ProjectiveArithmetic,
     FieldBytes<C>: From<Scalar<C>> + for<'r> From<&'r Scalar<C>>,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
-    AffinePoint<C>: Clone + Debug + Default + FromEncodedPoint<C> + ToEncodedPoint<C>,
+    AffinePoint<C>: Copy + Clone + Debug + Default + FromEncodedPoint<C> + ToEncodedPoint<C>,
     ProjectivePoint<C>: From<AffinePoint<C>>,
     UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
     UncompressedPointSize<C>: ArrayLength<u8>,
@@ -128,7 +127,7 @@ where
     C: Curve + ProjectiveArithmetic + point::Compression,
     FieldBytes<C>: From<Scalar<C>> + for<'r> From<&'r Scalar<C>>,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
-    AffinePoint<C>: Clone + Debug + Default + FromEncodedPoint<C> + ToEncodedPoint<C>,
+    AffinePoint<C>: Copy + Clone + Debug + Default + FromEncodedPoint<C> + ToEncodedPoint<C>,
     ProjectivePoint<C>: From<AffinePoint<C>>,
     UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
     UncompressedPointSize<C>: ArrayLength<u8>,
@@ -143,7 +142,7 @@ where
     C: Curve + ProjectiveArithmetic + point::Compression,
     FieldBytes<C>: From<Scalar<C>> + for<'r> From<&'r Scalar<C>>,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
-    AffinePoint<C>: Clone + Debug + Default + FromEncodedPoint<C> + ToEncodedPoint<C>,
+    AffinePoint<C>: Copy + Clone + Debug + Default + FromEncodedPoint<C> + ToEncodedPoint<C>,
     ProjectivePoint<C>: From<AffinePoint<C>>,
     UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
     UncompressedPointSize<C>: ArrayLength<u8>,
@@ -158,7 +157,7 @@ where
     C: Curve + ProjectiveArithmetic,
     FieldBytes<C>: From<Scalar<C>> + for<'r> From<&'r Scalar<C>>,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
-    AffinePoint<C>: Clone + Debug + Default + FromEncodedPoint<C> + ToEncodedPoint<C>,
+    AffinePoint<C>: Copy + Clone + Debug + Default + FromEncodedPoint<C> + ToEncodedPoint<C>,
     ProjectivePoint<C>: From<AffinePoint<C>>,
     UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
     UncompressedPointSize<C>: ArrayLength<u8>,
@@ -174,7 +173,7 @@ where
     C: Curve + ProjectiveArithmetic,
     FieldBytes<C>: From<Scalar<C>> + for<'r> From<&'r Scalar<C>>,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
-    AffinePoint<C>: Clone + Debug + Default + FromEncodedPoint<C> + ToEncodedPoint<C>,
+    AffinePoint<C>: Copy + Clone + Debug + Default + FromEncodedPoint<C> + ToEncodedPoint<C>,
     ProjectivePoint<C>: From<AffinePoint<C>>,
     UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
     UncompressedPointSize<C>: ArrayLength<u8>,
@@ -184,18 +183,6 @@ where
     fn to_encoded_point(&self, compress: bool) -> EncodedPoint<C> {
         self.point.to_encoded_point(compress)
     }
-}
-
-impl<C> Copy for PublicKey<C>
-where
-    C: Curve + ProjectiveArithmetic,
-    FieldBytes<C>: From<Scalar<C>> + for<'r> From<&'r Scalar<C>>,
-    Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
-    AffinePoint<C>: Copy + Clone + Debug + Default + FromEncodedPoint<C> + ToEncodedPoint<C>,
-    ProjectivePoint<C>: From<AffinePoint<C>>,
-    UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
-    UncompressedPointSize<C>: ArrayLength<u8>,
-{
 }
 
 impl<C> Eq for PublicKey<C>

--- a/elliptic-curve/src/secret_key.rs
+++ b/elliptic-curve/src/secret_key.rs
@@ -17,16 +17,12 @@ use zeroize::Zeroize;
 
 #[cfg(feature = "arithmetic")]
 use crate::{
-    consts::U1,
     ff::PrimeField,
-    generic_array::ArrayLength,
     group::{Curve as _, Group},
-    ops::Add,
     public_key::PublicKey,
     rand_core::{CryptoRng, RngCore},
     scalar::{NonZeroScalar, Scalar},
-    sec1::{FromEncodedPoint, ToEncodedPoint, UncompressedPointSize, UntaggedPointSize},
-    weierstrass, AffinePoint, ProjectiveArithmetic, ProjectivePoint,
+    weierstrass, AffinePoint, ProjectiveArithmetic,
 };
 
 /// Inner value stored by a [`SecretKey`].
@@ -157,10 +153,7 @@ where
         C: weierstrass::Curve + ProjectiveArithmetic + SecretValue<Secret = NonZeroScalar<C>>,
         FieldBytes<C>: From<Scalar<C>> + for<'a> From<&'a Scalar<C>>,
         Scalar<C>: PrimeField<Repr = FieldBytes<C>> + Zeroize,
-        AffinePoint<C>: Clone + Debug + Default + FromEncodedPoint<C> + ToEncodedPoint<C>,
-        ProjectivePoint<C>: From<AffinePoint<C>>,
-        UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
-        UncompressedPointSize<C>: ArrayLength<u8>,
+        AffinePoint<C>: Copy + Clone + Debug + Default,
     {
         PublicKey::from_affine((C::ProjectivePoint::generator() * self.secret_scalar()).to_affine())
     }


### PR DESCRIPTION
Decouples `PublicKey` from SEC1 encoding-related concerns, which allows the trait bounds for anything which interacts with `PublicKey`s to be dramatically simplified.