### PR TITLE
elliptic-curve: PKCS#8 support for `SecretKey`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,9 +93,8 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fc33f77ab0b4232f30cb9049a156775c5ad814b030e929d234d14cd6d7ec17f"
+version = "0.3.0-pre"
+source = "git+https://github.com/RustCrypto/utils.git#a9ebedcd9be0af538c9aef319d2025fa607e9566"
 
 [[package]]
 name = "cpuid-bool"
@@ -148,12 +147,12 @@ name = "elliptic-curve"
 version = "0.7.0-pre"
 dependencies = [
  "bitvec",
- "const-oid",
  "digest 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ff",
  "generic-array 0.14.4",
  "group",
  "hex-literal",
+ "pkcs8",
  "rand_core",
  "subtle",
  "zeroize",
@@ -260,6 +259,14 @@ name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+
+[[package]]
+name = "pkcs8"
+version = "0.0.0"
+source = "git+https://github.com/RustCrypto/utils.git#a9ebedcd9be0af538c9aef319d2025fa607e9566"
+dependencies = [
+ "const-oid",
+]
 
 [[package]]
 name = "proc-macro-hack"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,7 @@ members = [
     "signature/async",
     "universal-hash",
 ]
+
+[patch.crates-io]
+const-oid = { git = "https://github.com/RustCrypto/utils.git" }
+pkcs8 = { git = "https://github.com/RustCrypto/utils.git" }

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -20,7 +20,7 @@ digest = { version = "0.9", optional = true }
 ff = { version = "0.8", optional = true, default-features = false }
 group = { version = "0.8", optional = true, default-features = false }
 generic-array = { version = "0.14", default-features = false }
-oid = { package = "const-oid", version = "0.2", optional = true }
+pkcs8 = { version = "0", optional = true }
 rand_core = { version = "0.5", default-features = false }
 subtle = { version = "2.3", default-features = false }
 zeroize = { version = "1", optional = true,  default-features = false }

--- a/elliptic-curve/src/ecdh.rs
+++ b/elliptic-curve/src/ecdh.rs
@@ -75,7 +75,8 @@ where
     /// Compute a Diffie-Hellman shared secret from an ephemeral secret and the
     /// public key of the other participant in the exchange.
     pub fn diffie_hellman(&self, public_key: &PublicKey<C>) -> SharedSecret<C> {
-        let shared_secret = public_key.to_projective() * &self.scalar;
+        #[allow(clippy::op_ref)]
+        let shared_secret = public_key.to_projective() * &*self.scalar;
         // SharedSecret::new expects an uncompressed point
         SharedSecret::new(shared_secret.to_affine().to_encoded_point(false))
     }

--- a/elliptic-curve/src/error.rs
+++ b/elliptic-curve/src/error.rs
@@ -12,5 +12,12 @@ impl Display for Error {
     }
 }
 
+#[cfg(feature = "pkcs8")]
+impl From<pkcs8::Error> for Error {
+    fn from(_: pkcs8::Error) -> Error {
+        Error
+    }
+}
+
 #[cfg(feature = "std")]
 impl std::error::Error for Error {}

--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -71,8 +71,8 @@ pub use group::{self, Group};
 #[cfg(feature = "digest")]
 pub use digest::{self, Digest};
 
-#[cfg(feature = "oid")]
-pub use oid;
+#[cfg(feature = "pkcs8")]
+pub use pkcs8;
 
 #[cfg(feature = "zeroize")]
 pub use secret_key::SecretKey;
@@ -81,6 +81,13 @@ pub use zeroize;
 
 use core::{fmt::Debug, ops::Add};
 use generic_array::{typenum::Unsigned, ArrayLength, GenericArray};
+
+/// Algorithm [`ObjectIdentifier`] for elliptic curve public key cryptography.
+/// <https://oid-info.com/get/1.2.840.10045.2.1>
+#[cfg(feature = "pkcs8")]
+#[cfg_attr(docsrs, doc(cfg(feature = "pkcs8")))]
+pub const ALGORITHM_OID: pkcs8::ObjectIdentifier =
+    pkcs8::ObjectIdentifier::new(&[1, 2, 840, 10045, 2, 1]);
 
 /// Elliptic curve.
 ///
@@ -115,10 +122,15 @@ pub trait FromDigest<C: Curve> {
         D: Digest<OutputSize = C::FieldSize>;
 }
 
-/// Associate an object identifier (OID) with a curve
-#[cfg(feature = "oid")]
-#[cfg_attr(docsrs, doc(cfg(feature = "oid")))]
-pub trait Identifier: Curve {
+/// Associate an [`ObjectIdentifier`][`pkcs8::ObjectIdentifier`] (OID) with an
+/// elliptic curve algorithm implementation.
+///
+/// This is used as as the `parameters` of an `AlgorithmIdentifier` as
+/// described in RFC 5280 Section 4.1.1.2:
+/// <https://tools.ietf.org/html/rfc5280#section-4.1.1.2>
+#[cfg(feature = "pkcs8")]
+#[cfg_attr(docsrs, doc(cfg(feature = "pkcs8")))]
+pub trait AlgorithmParameters: Curve {
     /// Object Identifier (OID) for this curve
-    const OID: oid::ObjectIdentifier;
+    const OID: pkcs8::ObjectIdentifier;
 }


### PR DESCRIPTION
Adds initial support for parsing PKCS#8-encoded ECC secret keys.

This is presently somewhat difficult to test within this crate (which should be addressed regardless) as it relies on generic parameters of a curve implementation, however this has been tested concretely against the `p256` crate which has tests that exercise it in this PR:

https://github.com/RustCrypto/elliptic-curves/pull/243