### PR TITLE
elliptic-curve v0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,7 +145,7 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.7.0-pre"
+version = "0.7.0"
 dependencies = [
  "bitvec",
  "digest 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 aead = { version = "0.3", optional = true, path = "../aead" }
 cipher = { version = "=0.3.0-pre", optional = true, path = "../cipher" }
 digest = { version = "0.9", optional = true, path = "../digest" }
-elliptic-curve = { version = "=0.7.0-pre", optional = true, path = "../elliptic-curve" }
+elliptic-curve = { version = "0.7", optional = true, path = "../elliptic-curve" }
 mac = { version = "=0.11.0-pre", package = "crypto-mac", optional = true, path = "../crypto-mac" }
 signature = { version = "1.2.0", optional = true, default-features = false, path = "../signature" }
 universal-hash = { version = "0.4", optional = true, path = "../universal-hash" }

--- a/elliptic-curve/CHANGELOG.md
+++ b/elliptic-curve/CHANGELOG.md
@@ -4,6 +4,34 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.7.0 (2020-12-06)
+### Added
+- Impl `pkcs8::FromPublicKey` for `PublicKey<C>` ([#385])
+- Impl `pkcs8::FromPrivateKey` trait for `SecretKey<C>` ([#381], [#383])
+- PKCS#8 PEM support ([#382])
+- `SecretKey::secret_value()` method ([#375])
+- `PublicKey<C>` type ([#363], [#366])
+
+### Changed
+- Rename `PublicKey::from_bytes()` to `::from_sec1_bytes()` ([#376])
+- `sec1::EncodedPoint` uses `Option` instead of `subtle::CtOption` ([#367])
+- Bump `const-oid` to v0.3; MSRV 1.46+ ([#365], [#381])
+
+### Fixed
+- `ecdh` rustdoc ([#364])
+
+[#385]: https://github.com/RustCrypto/traits/pull/385
+[#383]: https://github.com/RustCrypto/traits/pull/383
+[#382]: https://github.com/RustCrypto/traits/pull/382
+[#381]: https://github.com/RustCrypto/traits/pull/381
+[#376]: https://github.com/RustCrypto/traits/pull/376
+[#375]: https://github.com/RustCrypto/traits/pull/375
+[#367]: https://github.com/RustCrypto/traits/pull/367
+[#366]: https://github.com/RustCrypto/traits/pull/366
+[#365]: https://github.com/RustCrypto/traits/pull/365
+[#364]: https://github.com/RustCrypto/traits/pull/364
+[#363]: https://github.com/RustCrypto/traits/pull/363
+
 ## 0.6.6 (2020-10-08)
 ### Added
 - Derive `Clone` on `SecretBytes` ([#330])

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -5,7 +5,7 @@ General purpose Elliptic Curve Cryptography (ECC) support, including types
 and traits for representing various elliptic curve forms, scalars, points,
 and public/secret keys composed thereof.
 """
-version    = "0.7.0-pre" # Also update html_root_url in lib.rs when bumping this
+version    = "0.7.0" # Also update html_root_url in lib.rs when bumping this
 authors    = ["RustCrypto Developers"]
 license    = "Apache-2.0 OR MIT"
 repository = "https://github.com/RustCrypto/traits/tree/master/elliptic-curve"


### PR DESCRIPTION
### Added
- Impl `pkcs8::FromPublicKey` for `PublicKey<C>` ([#385])
- Impl `pkcs8::FromPrivateKey` trait for `SecretKey<C>` ([#381], [#383])
- PKCS#8 PEM support ([#382])
- `SecretKey::secret_value()` method ([#375])
- `PublicKey<C>` type ([#363], [#366])

### Changed
- Rename `PublicKey::from_bytes()` to `::from_sec1_bytes()` ([#376])
- `sec1::EncodedPoint` uses `Option` instead of `subtle::CtOption` ([#367])
- Bump `const-oid` to v0.3; MSRV 1.46+ ([#365], [#381])

### Fixed
- `ecdh` rustdoc ([#364])

[#385]: https://github.com/RustCrypto/traits/pull/385
[#383]: https://github.com/RustCrypto/traits/pull/383
[#382]: https://github.com/RustCrypto/traits/pull/382
[#381]: https://github.com/RustCrypto/traits/pull/381
[#376]: https://github.com/RustCrypto/traits/pull/376
[#375]: https://github.com/RustCrypto/traits/pull/375
[#367]: https://github.com/RustCrypto/traits/pull/367
[#366]: https://github.com/RustCrypto/traits/pull/366
[#365]: https://github.com/RustCrypto/traits/pull/365
[#364]: https://github.com/RustCrypto/traits/pull/364
[#363]: https://github.com/RustCrypto/traits/pull/363