### PR TITLE
elliptic-curve v0.7.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,7 +145,7 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "bitvec",
  "digest 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/elliptic-curve/CHANGELOG.md
+++ b/elliptic-curve/CHANGELOG.md
@@ -4,7 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.7.0 (2020-12-06)
+## 0.7.1 (2020-12-07)
+### Changed
+- Have `SecretKey::secret_value` always return `NonZeroScalar` ([#390])
+
+[#390]: https://github.com/RustCrypto/traits/pull/390
+
+## 0.7.0 (2020-12-06) [YANKED]
 ### Added
 - Impl `pkcs8::FromPublicKey` for `PublicKey<C>` ([#385])
 - Impl `pkcs8::FromPrivateKey` trait for `SecretKey<C>` ([#381], [#383])

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -5,7 +5,7 @@ General purpose Elliptic Curve Cryptography (ECC) support, including types
 and traits for representing various elliptic curve forms, scalars, points,
 and public/secret keys composed thereof.
 """
-version    = "0.7.0" # Also update html_root_url in lib.rs when bumping this
+version    = "0.7.1" # Also update html_root_url in lib.rs when bumping this
 authors    = ["RustCrypto Developers"]
 license    = "Apache-2.0 OR MIT"
 repository = "https://github.com/RustCrypto/traits/tree/master/elliptic-curve"


### PR DESCRIPTION
### Changed
- Have `SecretKey::secret_value` always return `NonZeroScalar` ([#390])

[#390]: https://github.com/RustCrypto/traits/pull/390