### PR TITLE
elliptic-curve: add support for SEC1 identity encoding

### DIFF
--- a/elliptic-curve/src/ecdh.rs
+++ b/elliptic-curve/src/ecdh.rs
@@ -153,7 +153,11 @@ where
 {
     /// Create a new shared secret from the given uncompressed curve point
     fn new(mut encoded_point: EncodedPoint<C>) -> Self {
-        let secret_bytes = encoded_point.x().clone();
+        let secret_bytes = encoded_point
+            .x()
+            .cloned()
+            .expect("encoded point is identity");
+
         encoded_point.zeroize();
         Self { secret_bytes }
     }


### PR DESCRIPTION
Closes #399.

The `ToEncodedPoint` trait is infallible. We can either make it fallible (as attempted in #400) or add support for the SEC1 encoding for the identity point.

This commit adds SEC1 support for identity, allowing `ToEncodedPoint` to remain infallible.

Unfortunately breaking as it requires adding new enum variants and some method signature changes.

However, that said, this should make the SEC1 implementation "complete" in that it implements the full `Elliptic-Curve-Point-to-Octet-String` encoding (and decoding).

cc @rozbb 