### PR TITLE
elliptic-curve: ensure PublicKey is not the identity point

### DIFF
--- a/elliptic-curve/src/ecdh.rs
+++ b/elliptic-curve/src/ecdh.rs
@@ -31,7 +31,7 @@ use crate::{
 use core::{fmt::Debug, ops::Add};
 use ff::PrimeField;
 use generic_array::ArrayLength;
-use group::{Curve as _, Group};
+use group::Curve as _;
 use rand_core::{CryptoRng, RngCore};
 use zeroize::Zeroize;
 
@@ -69,7 +69,7 @@ where
     ///
     /// The `compress` flag enables point compression.
     pub fn public_key(&self) -> PublicKey<C> {
-        PublicKey::from_affine((C::ProjectivePoint::generator() * self.scalar.as_ref()).to_affine())
+        PublicKey::from_secret_scalar(&self.scalar)
     }
 
     /// Compute a Diffie-Hellman shared secret from an ephemeral secret and the

--- a/elliptic-curve/src/secret_key.rs
+++ b/elliptic-curve/src/secret_key.rs
@@ -18,11 +18,10 @@ use zeroize::Zeroize;
 #[cfg(feature = "arithmetic")]
 use crate::{
     ff::PrimeField,
-    group::{Curve as _, Group},
     public_key::PublicKey,
     rand_core::{CryptoRng, RngCore},
     scalar::{NonZeroScalar, Scalar},
-    weierstrass, AffinePoint, ProjectiveArithmetic,
+    weierstrass, AffinePoint, ProjectiveArithmetic, ProjectivePoint,
 };
 
 #[cfg(feature = "pkcs8")]
@@ -133,8 +132,9 @@ where
         FieldBytes<C>: From<Scalar<C>> + for<'a> From<&'a Scalar<C>>,
         Scalar<C>: PrimeField<Repr = FieldBytes<C>> + Zeroize,
         AffinePoint<C>: Copy + Clone + Debug + Default,
+        ProjectivePoint<C>: From<AffinePoint<C>>,
     {
-        PublicKey::from_affine((C::ProjectivePoint::generator() * self.secret_scalar()).to_affine())
+        PublicKey::from_secret_scalar(self.secret_scalar())
     }
 }
 


### PR DESCRIPTION
Adds an invariant to the `AffinePoint` wrapped by a `PublicKey` which ensures it is not the identity point.

This is notable now that we support SEC1 encoding of identity points (#401), as it might be unexpected to end users to receive public keys which encode the identity element.