### PR TITLE
elliptic-curve v0.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,7 +145,7 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.8.0-pre"
+version = "0.8.0"
 dependencies = [
  "bitvec",
  "digest 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 aead = { version = "0.3", optional = true, path = "../aead" }
 cipher = { version = "=0.3.0-pre", optional = true, path = "../cipher" }
 digest = { version = "0.9", optional = true, path = "../digest" }
-elliptic-curve = { version = "=0.8.0-pre", optional = true, path = "../elliptic-curve" }
+elliptic-curve = { version = "0.8", optional = true, path = "../elliptic-curve" }
 mac = { version = "=0.11.0-pre", package = "crypto-mac", optional = true, path = "../crypto-mac" }
 signature = { version = "1.2.0", optional = true, default-features = false, path = "../signature" }
 universal-hash = { version = "0.4", optional = true, path = "../universal-hash" }

--- a/elliptic-curve/CHANGELOG.md
+++ b/elliptic-curve/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.8.0 (2020-12-16)
+### Added
+- Impl `subtle::ConditionallySelectable` for `sec1::EncodedPoint` ([#409])
+- `sec1::EncodedPoint::identity()` method ([#408])
+- `sec1::Coordinates::tag` method ([#407])
+- Support for SEC1 identity encoding ([#401])
+
+### Changed
+- Bump `pkcs8` crate dependency to v0.3 ([#405])
+- Ensure `PublicKey<C>` is not the identity point ([#404])
+- Have `SecretKey::secret_scalar` return `NonZeroScalar` ([#402])
+
+### Removed
+- `SecretKey::secret_value` ([#403])
+
+[#409]: https://github.com/RustCrypto/traits/pull/409
+[#408]: https://github.com/RustCrypto/traits/pull/408
+[#407]: https://github.com/RustCrypto/traits/pull/407
+[#405]: https://github.com/RustCrypto/traits/pull/405
+[#404]: https://github.com/RustCrypto/traits/pull/404
+[#403]: https://github.com/RustCrypto/traits/pull/403
+[#402]: https://github.com/RustCrypto/traits/pull/402
+[#401]: https://github.com/RustCrypto/traits/pull/401
+
 ## 0.7.1 (2020-12-07)
 ### Changed
 - Have `SecretKey::secret_value` always return `NonZeroScalar` ([#390])

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -5,7 +5,7 @@ General purpose Elliptic Curve Cryptography (ECC) support, including types
 and traits for representing various elliptic curve forms, scalars, points,
 and public/secret keys composed thereof.
 """
-version    = "0.8.0-pre" # Also update html_root_url in lib.rs when bumping this
+version    = "0.8.0" # Also update html_root_url in lib.rs when bumping this
 authors    = ["RustCrypto Developers"]
 license    = "Apache-2.0 OR MIT"
 repository = "https://github.com/RustCrypto/traits/tree/master/elliptic-curve"

--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -16,7 +16,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/elliptic-curve/0.8.0-pre"
+    html_root_url = "https://docs.rs/elliptic-curve/0.8.0"
 )]
 
 #[cfg(feature = "alloc")]


### PR DESCRIPTION
### Added
- Impl `subtle::ConditionallySelectable` for `sec1::EncodedPoint` ([#409])
- `sec1::EncodedPoint::identity()` method ([#408])
- `sec1::Coordinates::tag` method ([#407])
- Support for SEC1 identity encoding ([#401])

### Changed
- Bump `pkcs8` crate dependency to v0.3 ([#405])
- Ensure `PublicKey<C>` is not the identity point ([#404])
- Have `SecretKey::secret_scalar` return `NonZeroScalar` ([#402])

### Removed
- `SecretKey::secret_value` ([#403])

[#409]: https://github.com/RustCrypto/traits/pull/409
[#408]: https://github.com/RustCrypto/traits/pull/408
[#407]: https://github.com/RustCrypto/traits/pull/407
[#405]: https://github.com/RustCrypto/traits/pull/405
[#404]: https://github.com/RustCrypto/traits/pull/404
[#403]: https://github.com/RustCrypto/traits/pull/403
[#402]: https://github.com/RustCrypto/traits/pull/402
[#401]: https://github.com/RustCrypto/traits/pull/401