### PR TITLE
elliptic-curve: regression test for PublicKey::from_encoded_point

### DIFF
--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -41,7 +41,7 @@ pub mod public_key;
 #[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
 pub mod scalar;
 
-#[cfg(feature = "dev")]
+#[cfg(any(feature = "dev"))]
 #[cfg_attr(docsrs, doc(cfg(feature = "dev")))]
 pub mod dev;
 

--- a/elliptic-curve/src/public_key.rs
+++ b/elliptic-curve/src/public_key.rs
@@ -317,3 +317,17 @@ where
         Self::from_public_key_pem(s).map_err(|_| Error)
     }
 }
+
+#[cfg(all(feature = "dev", test))]
+mod tests {
+    use crate::{dev::MockCurve, sec1::FromEncodedPoint};
+
+    type EncodedPoint = crate::sec1::EncodedPoint<MockCurve>;
+    type PublicKey = super::PublicKey<MockCurve>;
+
+    #[test]
+    fn from_encoded_point_rejects_identity() {
+        let identity = EncodedPoint::identity();
+        assert_eq!(PublicKey::from_encoded_point(&identity), None);
+    }
+}


### PR DESCRIPTION
The invariant of `PublicKey` is that the inner affine point is *NOT* the identity, however there was a bug in the `FromEncodedPoint` implementation which was fixed in #416.

However, at the time we couldn't add a regression test because there was no concrete curve type to use for writing such a test.

A `MockCurve` was added in #419, so this commit uses it to write such a regression test.