### PR TITLE
elliptic-curve: use `der` crate to parse `SecretKey`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,9 +93,8 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "069b46dab00267d018567b1154f38b706d6ed93c4915301a2fa73bc24a03a1e7"
+version = "0.4.1"
+source = "git+https://github.com/RustCrypto/utils.git#022007f591e92bfb14a16bd3192309d398d2f2f0"
 
 [[package]]
 name = "cpuid-bool"
@@ -124,6 +123,14 @@ dependencies = [
  "cipher",
  "generic-array 0.14.4",
  "subtle",
+]
+
+[[package]]
+name = "der"
+version = "0.0.0"
+source = "git+https://github.com/RustCrypto/utils.git#022007f591e92bfb14a16bd3192309d398d2f2f0"
+dependencies = [
+ "const-oid",
 ]
 
 [[package]]
@@ -264,10 +271,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 [[package]]
 name = "pkcs8"
 version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9911ed9965aeee333588f226ad2baeabda478bf5ec151550735ed1760df759ba"
+source = "git+https://github.com/RustCrypto/utils.git#022007f591e92bfb14a16bd3192309d398d2f2f0"
 dependencies = [
- "const-oid",
+ "der",
  "subtle-encoding",
  "zeroize",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,6 @@ members = [
     "signature/async",
     "universal-hash",
 ]
+
+[patch.crates-io]
+pkcs8 = { git = "https://github.com/RustCrypto/utils.git" }

--- a/elliptic-curve/src/public_key.rs
+++ b/elliptic-curve/src/public_key.rs
@@ -286,15 +286,12 @@ where
             return Err(pkcs8::Error::Decode);
         }
 
-        // Strip leading `0` byte if it exists
-        // TODO(tarcieri): determine if there's actually any case where this byte doesn't exist
-        let bytes = match spki.subject_public_key.get(0) {
-            Some(0) => &spki.subject_public_key[1..],
-            Some(_) => spki.subject_public_key,
-            None => return Err(pkcs8::Error::Decode),
-        };
+        // Look for a leading `0x00` byte in the bitstring
+        if spki.subject_public_key.get(0).cloned() != Some(0x00) {
+            return Err(pkcs8::Error::Decode);
+        }
 
-        Self::from_sec1_bytes(bytes).map_err(|_| pkcs8::Error::Decode)
+        Self::from_sec1_bytes(&spki.subject_public_key[1..]).map_err(|_| pkcs8::Error::Decode)
     }
 }
 


### PR DESCRIPTION
Replaces the previous handrolled ASN.1 DER parsing code with a parser based on the `der` crate.