### PR TITLE
elliptic-curve v0.8.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,7 +154,7 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "bitvec",
  "digest 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/elliptic-curve/CHANGELOG.md
+++ b/elliptic-curve/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.8.2 (2020-12-22)
+### Added
+- Low-level ECDH API ([#418])
+- `dev` module ([#419])
+- Impl `pkcs8::ToPrivateKey` for `SecretKey<C>` ([#423])
+- Impl `pkcs8::ToPublicKey` for `PublicKey<C>` ([#427])
+
+### Changed
+- Bump `subtle` dependency to 2.4.0 ([#414])
+- Bump `pkcs8` dependency to v0.3.3 ([#425])
+- Use `der` crate to parse `SecretKey` ([#422])
+
+### Fixed
+- Make `PublicKey::from_encoded_point` go through `PublicKey::from_affine` ([#416])
+
+[#414]: https://github.com/RustCrypto/traits/pull/414
+[#416]: https://github.com/RustCrypto/traits/pull/416
+[#418]: https://github.com/RustCrypto/traits/pull/418
+[#419]: https://github.com/RustCrypto/traits/pull/419
+[#422]: https://github.com/RustCrypto/traits/pull/422
+[#423]: https://github.com/RustCrypto/traits/pull/423
+[#425]: https://github.com/RustCrypto/traits/pull/425
+[#427]: https://github.com/RustCrypto/traits/pull/427
+
 ## 0.8.1 (2020-12-16)
 ### Fixed
 - Builds on Rust `nightly` compiler ([#412])

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -5,7 +5,7 @@ General purpose Elliptic Curve Cryptography (ECC) support, including types
 and traits for representing various elliptic curve forms, scalars, points,
 and public/secret keys composed thereof.
 """
-version    = "0.8.1" # Also update html_root_url in lib.rs when bumping this
+version    = "0.8.2" # Also update html_root_url in lib.rs when bumping this
 authors    = ["RustCrypto Developers"]
 license    = "Apache-2.0 OR MIT"
 repository = "https://github.com/RustCrypto/traits/tree/master/elliptic-curve"

--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -16,7 +16,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/elliptic-curve/0.8.1"
+    html_root_url = "https://docs.rs/elliptic-curve/0.8.2"
 )]
 
 #[cfg(feature = "alloc")]


### PR DESCRIPTION
### Added
- Low-level ECDH API ([#418])
- `dev` module ([#419])
- Impl `pkcs8::ToPrivateKey` for `SecretKey<C>` ([#423])
- Impl `pkcs8::ToPublicKey` for `PublicKey<C>` ([#427])

### Changed
- Bump `subtle` dependency to 2.4.0 ([#414])
- Bump `pkcs8` dependency to v0.3.3 ([#425])
- Use `der` crate to parse `SecretKey` ([#422])

### Fixed
- Make `PublicKey::from_encoded_point` go through `PublicKey::from_affine` ([#416])

[#414]: https://github.com/RustCrypto/traits/pull/414
[#416]: https://github.com/RustCrypto/traits/pull/416
[#418]: https://github.com/RustCrypto/traits/pull/418
[#419]: https://github.com/RustCrypto/traits/pull/419
[#422]: https://github.com/RustCrypto/traits/pull/422
[#423]: https://github.com/RustCrypto/traits/pull/423
[#425]: https://github.com/RustCrypto/traits/pull/425
[#427]: https://github.com/RustCrypto/traits/pull/427