### PR TITLE
elliptic-curve: fix regression for `pem`+`zeroize` features

### DIFF
--- a/.github/workflows/elliptic-curve.yml
+++ b/.github/workflows/elliptic-curve.yml
@@ -42,6 +42,7 @@ jobs:
       - run: cargo build --no-default-features --release --target ${{ matrix.target }} --features pem
       - run: cargo build --no-default-features --release --target ${{ matrix.target }} --features pkcs8
       - run: cargo build --no-default-features --release --target ${{ matrix.target }} --features zeroize
+      - run: cargo build --no-default-features --release --target ${{ matrix.target }} --features pem,zeroize
   test:
     runs-on: ubuntu-latest
     strategy:

--- a/elliptic-curve/src/secret_key/pkcs8.rs
+++ b/elliptic-curve/src/secret_key/pkcs8.rs
@@ -15,10 +15,9 @@ use zeroize::Zeroize;
 
 // Imports for the `ToPrivateKey` impl
 // TODO(tarcieri): use weak activation of `pkcs8/alloc` for gating `ToPrivateKey` impl
-#[cfg(all(feature = "pem"))]
+#[cfg(all(feature = "arithmetic", feature = "pem"))]
 use {
     crate::{
-        error::Error,
         ff::PrimeField,
         scalar::Scalar,
         sec1::{FromEncodedPoint, ToEncodedPoint},
@@ -32,13 +31,13 @@ use {
 
 // Imports for actual PEM support
 #[cfg(feature = "pem")]
-use core::str::FromStr;
+use {crate::error::Error, core::str::FromStr};
 
 /// Version
 const VERSION: i8 = 1;
 
 /// Encoding error message
-#[cfg(feature = "pem")]
+#[cfg(all(feature = "arithmetic", feature = "pem"))]
 const ENCODING_ERROR_MSG: &str = "DER encoding error";
 
 #[cfg_attr(docsrs, doc(cfg(feature = "pkcs8")))]
@@ -109,7 +108,8 @@ where
 // TODO(tarcieri): use weak activation of `pkcs8/alloc` for this when possible
 // It doesn't strictly depend on `pkcs8/pem` but we can't easily activate `pkcs8/alloc`
 // without adding a separate crate feature just for this functionality.
-#[cfg(feature = "pem")]
+#[cfg(all(feature = "arithmetic", feature = "pem"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
 #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
 impl<C> ToPrivateKey for SecretKey<C>
 where


### PR DESCRIPTION
...in the case when the `arithmetic` feature is disabled, as used by the `p384` crate (which does support PKCS#8, but does not provide an arithmetic backend)

Also adds tests for this combination in CI to prevent further regressions.