### PR TITLE
elliptic-curve v0.8.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,7 +154,7 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "bitvec",
  "digest 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/elliptic-curve/CHANGELOG.md
+++ b/elliptic-curve/CHANGELOG.md
@@ -4,7 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.8.2 (2020-12-22)
+## 0.8.3 (2020-12-22)
+### Fixed
+- Regression in combination of `pem`+`zeroize` features ([#429])
+
+[#429]: https://github.com/RustCrypto/traits/pull/429
+
+## 0.8.2 (2020-12-22) [YANKED]
 ### Added
 - Low-level ECDH API ([#418])
 - `dev` module ([#419])
@@ -28,13 +34,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#425]: https://github.com/RustCrypto/traits/pull/425
 [#427]: https://github.com/RustCrypto/traits/pull/427
 
-## 0.8.1 (2020-12-16)
+## 0.8.1 (2020-12-16) [YANKED]
 ### Fixed
 - Builds on Rust `nightly` compiler ([#412])
 
 [#412]: https://github.com/RustCrypto/traits/pull/412
 
-## 0.8.0 (2020-12-16)
+## 0.8.0 (2020-12-16) [YANKED]
 ### Added
 - Impl `subtle::ConditionallySelectable` for `sec1::EncodedPoint` ([#409])
 - `sec1::EncodedPoint::identity()` method ([#408])

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -5,7 +5,7 @@ General purpose Elliptic Curve Cryptography (ECC) support, including types
 and traits for representing various elliptic curve forms, scalars, points,
 and public/secret keys composed thereof.
 """
-version    = "0.8.2" # Also update html_root_url in lib.rs when bumping this
+version    = "0.8.3" # Also update html_root_url in lib.rs when bumping this
 authors    = ["RustCrypto Developers"]
 license    = "Apache-2.0 OR MIT"
 repository = "https://github.com/RustCrypto/traits/tree/master/elliptic-curve"

--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -16,7 +16,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/elliptic-curve/0.8.2"
+    html_root_url = "https://docs.rs/elliptic-curve/0.8.3"
 )]
 
 #[cfg(feature = "alloc")]


### PR DESCRIPTION
### Fixed
- Regression in combination of `pem`+`zeroize` features ([#429])

[#429]: https://github.com/RustCrypto/traits/pull/429