### PR TITLE
elliptic-curve: fix nightly regression (and add nightly CI)

### DIFF
--- a/.github/workflows/elliptic-curve.yml
+++ b/.github/workflows/elliptic-curve.yml
@@ -50,6 +50,7 @@ jobs:
         rust:
           - 1.46.0 # MSRV
           - stable
+          - nightly
     steps:
     - uses: actions/checkout@v1
     - uses: actions-rs/toolchain@v1

--- a/elliptic-curve/src/ecdh.rs
+++ b/elliptic-curve/src/ecdh.rs
@@ -74,7 +74,8 @@ where
     UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
     UncompressedPointSize<C>: ArrayLength<u8>,
 {
-    let shared_secret = ProjectivePoint::<C>::from(*public_key.borrow()) * secret_key.borrow();
+    let shared_secret =
+        ProjectivePoint::<C>::from(*public_key.borrow()) * secret_key.borrow().as_ref();
 
     // SharedSecret::new expects an uncompressed point
     // TODO(tarcieri): avoid point encoding when computing shared secret


### PR DESCRIPTION
Closes #431.

This is the second such regression we've had recently (see also #412).

It seems to be some sort of trait resolution change/breakage, although beyond that I'm not sure what the problem is.