### PR TITLE
cipher: revert SeekNum::from_block_byte change

### DIFF
--- a/cipher/src/stream.rs
+++ b/cipher/src/stream.rs
@@ -114,17 +114,8 @@ macro_rules! impl_seek_num {
             impl SeekNum for $t {
                 fn from_block_byte<T: TryInto<Self>>(block: T, byte: u8, bs: u8) -> Result<Self, OverflowError> {
                     debug_assert!(byte < bs);
-                    let pos = block
-                        .try_into()
-                        .ok()
-                        .and_then(|v| match byte == 0 {
-                            true => Some(v),
-                            // if `byte` is not zero, then block counter was incremented
-                            false => v.checked_sub(1),
-                        })
-                        .and_then(|v| v.checked_mul(bs as Self))
-                        .and_then(|v| v.checked_add(byte as Self))
-                        .ok_or(OverflowError)?;
+                    let block = block.try_into().map_err(|_| OverflowError)?;
+                    let pos = block.checked_mul(bs as Self).ok_or(OverflowError)? + (byte as Self);
                     Ok(pos)
                 }
 


### PR DESCRIPTION
This reverts the implementation of `SeekNum::from_block_byte` which was merged as part of #435.

I'm not exactly sure what the issue is and it's somewhat difficult to debug in that it's code that involves both generics and macros causing an error as part of any failure in a long chain of checked arithmetic, which I'm trying to debug from the context of a concrete stream cipher impl (both `chacha20` and `salsa20`) where it's operating over a generic type.

The error manifests as `OverflowError`:

https://github.com/RustCrypto/stream-ciphers/pull/205#issuecomment-752314229

This commit reverts to the previous implementation, which is at least much simpler.