### PR TITLE
cipher: block cipher trait blanket impls for refs

### DIFF
--- a/cipher/src/block.rs
+++ b/cipher/src/block.rs
@@ -156,3 +156,44 @@ impl<Alg: BlockDecrypt> BlockDecryptMut for Alg {
         self.decrypt_block(block);
     }
 }
+
+// Impls of block cipher traits for reference types
+
+impl<Alg: BlockCipher> BlockCipher for &Alg {
+    type BlockSize = Alg::BlockSize;
+    type ParBlocks = Alg::ParBlocks;
+}
+
+impl<Alg: BlockEncrypt> BlockEncrypt for &Alg {
+    #[inline]
+    fn encrypt_block(&self, block: &mut Block<Self>) {
+        Alg::encrypt_block(self, block);
+    }
+
+    #[inline]
+    fn encrypt_par_blocks(&self, blocks: &mut ParBlocks<Self>) {
+        Alg::encrypt_par_blocks(self, blocks);
+    }
+
+    #[inline]
+    fn encrypt_blocks(&self, blocks: &mut [Block<Self>]) {
+        Alg::encrypt_blocks(self, blocks);
+    }
+}
+
+impl<Alg: BlockDecrypt> BlockDecrypt for &Alg {
+    #[inline]
+    fn decrypt_block(&self, block: &mut Block<Self>) {
+        Alg::decrypt_block(self, block);
+    }
+
+    #[inline]
+    fn decrypt_par_blocks(&self, blocks: &mut ParBlocks<Self>) {
+        Alg::decrypt_par_blocks(self, blocks);
+    }
+
+    #[inline]
+    fn decrypt_blocks(&self, blocks: &mut [Block<Self>]) {
+        Alg::decrypt_blocks(self, blocks);
+    }
+}


### PR DESCRIPTION
Previously `cipher` contained blanket impls of block cipher traits for reference types, which was leveraged in e.g. `aes-gcm` and `aes-gcm-siv`. However, somewhere in the course of refactoring they were removed.

This commit adds them back.