### PR TITLE
cipher + crypto-mac: use `new_from_slice(s)` naming convention

### DIFF
--- a/cipher/src/block.rs
+++ b/cipher/src/block.rs
@@ -34,7 +34,7 @@ pub trait NewBlockCipher: Sized {
     ///
     /// Default implementation will accept only keys with length equal to
     /// `KeySize`, but some ciphers can accept range of key lengths.
-    fn new_var(key: &[u8]) -> Result<Self, InvalidLength> {
+    fn new_from_slice(key: &[u8]) -> Result<Self, InvalidLength> {
         if key.len() != Self::KeySize::to_usize() {
             Err(InvalidLength)
         } else {

--- a/cipher/src/common.rs
+++ b/cipher/src/common.rs
@@ -17,12 +17,13 @@ pub trait NewCipher: Sized {
     /// Nonce size in bytes
     type NonceSize: ArrayLength<u8>;
 
-    /// Create new stream cipher instance from variable length key and nonce.
+    /// Create new stream cipher instance from key and nonce arrays.
     fn new(key: &CipherKey<Self>, nonce: &Nonce<Self>) -> Self;
 
-    /// Create new stream cipher instance from variable length key and nonce.
+    /// Create new stream cipher instance from variable length key and nonce
+    /// given as byte slices.
     #[inline]
-    fn new_var(key: &[u8], nonce: &[u8]) -> Result<Self, InvalidLength> {
+    fn new_from_slices(key: &[u8], nonce: &[u8]) -> Result<Self, InvalidLength> {
         let kl = Self::KeySize::to_usize();
         let nl = Self::NonceSize::to_usize();
         if key.len() != kl || nonce.len() != nl {
@@ -64,11 +65,11 @@ where
         )
     }
 
-    fn new_var(key: &[u8], nonce: &[u8]) -> Result<Self, InvalidLength> {
+    fn new_from_slices(key: &[u8], nonce: &[u8]) -> Result<Self, InvalidLength> {
         if nonce.len() != Self::NonceSize::USIZE {
             Err(InvalidLength)
         } else {
-            C::BlockCipher::new_var(key)
+            C::BlockCipher::new_from_slice(key)
                 .map_err(|_| InvalidLength)
                 .map(|cipher| {
                     let nonce = GenericArray::from_slice(nonce);

--- a/cipher/src/dev/block.rs
+++ b/cipher/src/dev/block.rs
@@ -15,7 +15,7 @@ macro_rules! block_cipher_test {
             };
 
             fn run_test(key: &[u8], pt: &[u8], ct: &[u8]) -> bool {
-                let state = <$cipher as NewBlockCipher>::new_var(key).unwrap();
+                let state = <$cipher as NewBlockCipher>::new_from_slice(key).unwrap();
 
                 let mut block = GenericArray::clone_from_slice(pt);
                 state.encrypt_block(&mut block);
@@ -37,7 +37,7 @@ macro_rules! block_cipher_test {
                 type Block = GenericArray<u8, BlockSize>;
                 type ParBlock = GenericArray<Block, ParBlocks>;
 
-                let state = <$cipher as NewBlockCipher>::new_var(key).unwrap();
+                let state = <$cipher as NewBlockCipher>::new_from_slice(key).unwrap();
 
                 let block = Block::clone_from_slice(pt);
                 let mut blocks1 = ParBlock::default();
@@ -118,7 +118,7 @@ macro_rules! block_cipher_bench {
 
         #[bench]
         pub fn encrypt(bh: &mut Bencher) {
-            let state = <$cipher>::new_var(&[1u8; $key_len]).unwrap();
+            let state = <$cipher>::new_from_slice(&[1u8; $key_len]).unwrap();
             let mut block = Default::default();
 
             bh.iter(|| {
@@ -130,7 +130,7 @@ macro_rules! block_cipher_bench {
 
         #[bench]
         pub fn decrypt(bh: &mut Bencher) {
-            let state = <$cipher>::new_var(&[1u8; $key_len]).unwrap();
+            let state = <$cipher>::new_from_slice(&[1u8; $key_len]).unwrap();
             let mut block = Default::default();
 
             bh.iter(|| {

--- a/cipher/src/dev/stream.rs
+++ b/cipher/src/dev/stream.rs
@@ -15,7 +15,7 @@ macro_rules! stream_cipher_test {
                 let [key, iv, pt, ct] = row.unwrap();
 
                 for chunk_n in 1..256 {
-                    let mut mode = <$cipher>::new_var(key, iv).unwrap();
+                    let mut mode = <$cipher>::new_from_slices(key, iv).unwrap();
                     let mut pt = pt.to_vec();
                     for chunk in pt.chunks_mut(chunk_n) {
                         mode.apply_keystream(chunk);
@@ -106,7 +106,7 @@ macro_rules! stream_cipher_async_test {
                 ciphertext: &[u8],
             ) -> Option<&'static str> {
                 for n in 1..=plaintext.len() {
-                    let mut mode = <$cipher>::new_var(key, iv).unwrap();
+                    let mut mode = <$cipher>::new_from_slices(key, iv).unwrap();
                     let mut buf = plaintext.to_vec();
                     for chunk in buf.chunks_mut(n) {
                         mode.encrypt(chunk);
@@ -117,7 +117,7 @@ macro_rules! stream_cipher_async_test {
                 }
 
                 for n in 1..=plaintext.len() {
-                    let mut mode = <$cipher>::new_var(key, iv).unwrap();
+                    let mut mode = <$cipher>::new_from_slices(key, iv).unwrap();
                     let mut buf = ciphertext.to_vec();
                     for chunk in buf.chunks_mut(n) {
                         mode.decrypt(chunk);

--- a/crypto-mac/src/dev.rs
+++ b/crypto-mac/src/dev.rs
@@ -13,7 +13,7 @@ macro_rules! new_test {
             use crypto_mac::{Mac, NewMac};
 
             fn run_test(key: &[u8], input: &[u8], tag: &[u8]) -> Option<&'static str> {
-                let mut mac = <$mac as NewMac>::new_varkey(key).unwrap();
+                let mut mac = <$mac as NewMac>::new_from_slice(key).unwrap();
                 mac.update(input);
                 let result = mac.finalize_reset();
                 if &result.into_bytes()[..] != tag {
@@ -25,7 +25,7 @@ macro_rules! new_test {
                     return Some("after reset");
                 }
 
-                let mut mac = <$mac as NewMac>::new_varkey(key).unwrap();
+                let mut mac = <$mac as NewMac>::new_from_slice(key).unwrap();
                 // test reading byte by byte
                 for i in 0..input.len() {
                     mac.update(&input[i..i + 1]);

--- a/crypto-mac/src/lib.rs
+++ b/crypto-mac/src/lib.rs
@@ -45,7 +45,7 @@ pub trait NewMac: Sized {
     ///
     /// Default implementation will accept only keys with length equal to
     /// `KeySize`, but some MACs can accept range of key lengths.
-    fn new_var(key: &[u8]) -> Result<Self, InvalidKeyLength> {
+    fn new_from_slice(key: &[u8]) -> Result<Self, InvalidKeyLength> {
         if key.len() != Self::KeySize::to_usize() {
             Err(InvalidKeyLength)
         } else {
@@ -151,8 +151,8 @@ where
         Self::from_cipher(cipher)
     }
 
-    fn new_var(key: &[u8]) -> Result<Self, InvalidKeyLength> {
-        <Self as FromBlockCipher>::Cipher::new_var(key)
+    fn new_from_slice(key: &[u8]) -> Result<Self, InvalidKeyLength> {
+        <Self as FromBlockCipher>::Cipher::new_from_slice(key)
             .map_err(|_| InvalidKeyLength)
             .map(Self::from_cipher)
     }


### PR DESCRIPTION
Renames `new_var(key)` methods to use `new_from_slice(s)` as discussed earlier here:

https://github.com/RustCrypto/traits/pull/435#discussion_r550227781