### PR TITLE
cipher v0.3.0-pre.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,7 +85,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cipher"
-version = "0.3.0-pre.3"
+version = "0.3.0-pre.4"
 dependencies = [
  "blobby 0.3.0",
  "generic-array 0.14.4",

--- a/cipher/Cargo.toml
+++ b/cipher/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cipher"
 description = "Traits for describing block ciphers and stream ciphers"
-version = "0.3.0-pre.3"
+version = "0.3.0-pre.4"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/crypto-mac/Cargo.toml
+++ b/crypto-mac/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["cryptography", "no-std"]
 
 [dependencies]
 generic-array = "0.14"
-cipher = { version = "=0.3.0-pre.3", optional = true, path = "../cipher" }
+cipher = { version = "=0.3.0-pre.4", optional = true, path = "../cipher" }
 subtle = { version = "2", default-features = false }
 blobby = { version = "0.3", optional = true }
 

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 
 [dependencies]
 aead = { version = "0.3", optional = true, path = "../aead" }
-cipher = { version = "=0.3.0-pre.3", optional = true, path = "../cipher" }
+cipher = { version = "=0.3.0-pre.4", optional = true, path = "../cipher" }
 digest = { version = "0.9", optional = true, path = "../digest" }
 elliptic-curve = { version = "0.8", optional = true, path = "../elliptic-curve" }
 mac = { version = "=0.11.0-pre", package = "crypto-mac", optional = true, path = "../crypto-mac" }


### PR DESCRIPTION
I'm trying to get the `AEADs` repo updated, and it's pretty unmanageable with multiple transitive `[patch.crates-io]` directives between `AEADs`, `block-cipher`, `stream-cipher`, and `MACs` (including some circular dependencies).

Cutting prereleases for this is annoying but at least more manageable (and in many ways easier to understand).