### PR TITLE
password-hash: rustdoc fixups

### DIFF
--- a/password-hash/src/errors.rs
+++ b/password-hash/src/errors.rs
@@ -175,7 +175,7 @@ impl fmt::Display for ParseError {
 #[cfg(feature = "std")]
 impl std::error::Error for ParseError {}
 
-/// Errors generating password hashes using a [`PasswordHashingFunction`].
+/// Errors generating password hashes using a [`PasswordHasher`].
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum PhfError {
     /// Unsupported algorithm.

--- a/password-hash/src/ident.rs
+++ b/password-hash/src/ident.rs
@@ -56,8 +56,8 @@ impl<'a> Ident<'a> {
     /// This method is intended for use in a `const` context where instead of
     /// panicking it will cause a compile error.
     ///
-    /// For fallible non-panicking parsing of an [`Ident`], use the [`FromStr`]
-    /// impl on this type instead, e.g. `s.parse::<Ident>()`.
+    /// For fallible non-panicking parsing of an [`Ident`], use the [`TryFrom`]
+    /// impl on this type instead.
     pub const fn new(s: &'a str) -> Self {
         let input = s.as_bytes();
 

--- a/password-hash/src/lib.rs
+++ b/password-hash/src/lib.rs
@@ -64,8 +64,9 @@ const PASSWORD_HASH_SEPARATOR: char = '$';
 
 /// Trait for password hashing functions.
 pub trait PasswordHasher {
-    /// Compute a [`PasswordHash`] from the given [`Algorithm`] (or the
-    /// recommended default), password, salt, and optional [`Params`].
+    /// Compute a [`PasswordHash`] with the given algorithm [`Ident`]
+    /// (or `None` for the recommended default), password, salt, and optional
+    /// [`Params`].
     ///
     /// Use [`Params::new`] or [`Params::default`] to use the default
     /// parameters for a given algorithm.
@@ -129,7 +130,7 @@ pub trait PasswordHasher {
 /// [1]: https://github.com/P-H-C/phc-string-format/blob/master/phc-sf-spec.md#specification
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct PasswordHash<'a> {
-    /// Password hashing [`Algorithm`].
+    /// Password hashing algorithm identifier.
     ///
     /// This corresponds to the `<id>` field in a PHC string, a.k.a. the
     /// symbolic name for the function.
@@ -220,7 +221,7 @@ impl<'a> PasswordHash<'a> {
     }
 
     /// Verify this password hash using the specified set of supported
-    /// [`PasswordHashingFunction`] objects.
+    /// [`PasswordHasher`] trait objects.
     pub fn verify_password(
         &self,
         phfs: &[&dyn PasswordHasher],

--- a/password-hash/src/params/value.rs
+++ b/password-hash/src/params/value.rs
@@ -130,7 +130,7 @@ impl<'a> fmt::Debug for Value<'a> {
 /// # Additional Notes
 /// The PHC spec allows for algorithm-defined maximum lengths for parameter
 /// values, however in the interest of interoperability this library defines a
-/// [`Value::max_len`] of 48 ASCII characters.
+/// [`ValueStr::max_len`] of 48 ASCII characters.
 ///
 /// [1]: https://github.com/P-H-C/phc-string-format/blob/master/phc-sf-spec.md
 /// [2]: https://github.com/P-H-C/phc-string-format/blob/master/phc-sf-spec.md#argon2-encoding


### PR DESCRIPTION
Fixes some dangling rustdoc links left over from refactoring.