### PR TITLE
password-hash: remove B64 restrictions on Salt

### DIFF
--- a/.github/workflows/password-hash.yml
+++ b/.github/workflows/password-hash.yml
@@ -37,8 +37,6 @@ jobs:
           profile: minimal
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features alloc
-      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features rand_core
-      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features alloc,rand_core
 
   test:
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -273,9 +273,6 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 [[package]]
 name = "password-hash"
 version = "0.0.0"
-dependencies = [
- "rand_core",
-]
 
 [[package]]
 name = "pkcs8"

--- a/password-hash/Cargo.toml
+++ b/password-hash/Cargo.toml
@@ -15,10 +15,6 @@ repository = "https://github.com/RustCrypto/traits/tree/master/password-hash"
 categories = ["cryptography", "no-std"]
 keywords = ["crypt", "mcf", "password", "pbkdf", "phc"]
 
-[dependencies]
-rand_core = { version = "0.5", optional = true }
-
 [features]
-default = ["rand_core"]
 alloc = []
 std = ["alloc"]

--- a/password-hash/src/errors.rs
+++ b/password-hash/src/errors.rs
@@ -250,8 +250,8 @@ impl std::error::Error for OutputError {}
 /// Salt-related errors.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum SaltError {
-    /// "B64" encoding error.
-    B64(B64Error),
+    /// Parse errors.
+    Parse(ParseError),
 
     /// Salt too short (min 4-bytes).
     TooShort,
@@ -263,16 +263,16 @@ pub enum SaltError {
 impl fmt::Display for SaltError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         match self {
-            Self::B64(err) => write!(f, "{}", err),
+            Self::Parse(err) => write!(f, "{}", err),
             Self::TooShort => f.write_str("salt too short (min 4-bytes)"),
             Self::TooLong => f.write_str("salt too long (max 48-bytes)"),
         }
     }
 }
 
-impl From<B64Error> for SaltError {
-    fn from(err: B64Error) -> SaltError {
-        SaltError::B64(err)
+impl From<ParseError> for SaltError {
+    fn from(err: ParseError) -> SaltError {
+        SaltError::Parse(err)
     }
 }
 

--- a/password-hash/src/salt.rs
+++ b/password-hash/src/salt.rs
@@ -1,25 +1,13 @@
-//! Salt string support implementing the PHC string format specification's
-//! RECOMMENDED best practices.
+//! Salt string support.
 
-use crate::{b64, errors::SaltError};
-use core::{
-    convert::TryFrom,
-    fmt,
-    ops::Deref,
-    str::{self, FromStr},
+use crate::{
+    errors::{B64Error, SaltError},
+    params::ValueStr,
 };
-
-#[cfg(feature = "rand_core")]
-use rand_core::{CryptoRng, RngCore};
-
-/// Recommended length of a [`Salt`] according to the [PHC string format][1].
-///
-/// [1]: https://github.com/P-H-C/phc-string-format/blob/master/phc-sf-spec.md#function-duties
-#[cfg(feature = "rand_core")]
-const RECOMMENDED_LENGTH: usize = 16;
-
-/// Maximum length of a [`Salt`].
-const MAX_LENGTH: usize = 48;
+use core::{
+    convert::{TryFrom, TryInto},
+    fmt, str,
+};
 
 /// Salt string.
 ///
@@ -50,7 +38,14 @@ const MAX_LENGTH: usize = 48;
 /// See below for rationale.
 ///
 /// # Constraints
-/// The above guidelines are interpreted into the following constraints:
+/// Salt strings are constrained to the following set of characters per the
+/// PHC spec:
+///
+/// > The salt consists in a sequence of characters in: `[a-zA-Z0-9/+.-]`
+/// > (lowercase letters, uppercase letters, digits, /, +, . and -).
+///
+/// Additionally the following length restrictions are enforced based on the
+/// guidelines from the spec:
 ///
 /// - Minimum length: **4**-bytes
 /// - Maximum length: **48**-bytes
@@ -79,18 +74,13 @@ const MAX_LENGTH: usize = 48;
 /// [2]: https://github.com/P-H-C/phc-string-format/blob/master/phc-sf-spec.md#function-duties
 /// [3]: https://github.com/P-H-C/phc-string-format/blob/master/phc-sf-spec.md#argon2-encoding
 #[derive(Copy, Clone, Eq, PartialEq)]
-pub struct Salt {
-    /// Byte array containing a salt value.
-    bytes: [u8; MAX_LENGTH],
+pub struct Salt<'a>(ValueStr<'a>);
 
-    /// Length of the salt in bytes.
-    length: u8,
-}
-
-impl Salt {
+impl<'a> Salt<'a> {
     /// Minimum length of a [`Salt`] string: 2-bytes.
     ///
     /// NOTE: this is below the recommended
+    // TODO(tarcieri): support shorter salts for MCF?
     pub const fn min_len() -> usize {
         4
     }
@@ -99,40 +89,18 @@ impl Salt {
     ///
     /// See type-level documentation about [`Salt`] for more information.
     pub const fn max_len() -> usize {
-        MAX_LENGTH
+        ValueStr::max_len()
     }
 
-    /// Maximum length of a [`Salt`] when encoded as [`b64`] string: 64-bytes
-    /// (i.e. 64 ASCII characters)
-    pub const fn b64_max_len() -> usize {
-        (MAX_LENGTH * 4) / 3
+    /// Recommended length of a salt: 16-bytes.
+    pub const fn recommended_len() -> usize {
+        16
     }
 
-    /// Generate a random [`Salt`] using the provided [`CryptoRng`].
-    ///
-    /// Uses the [PHC string format's recommended guidelines][1] of a 16-byte
-    /// salt value:
-    ///
-    /// > The role of salts is to achieve uniqueness. A random salt is fine for
-    /// > that as long as its length is sufficient; a 16-byte salt would work
-    /// > well (by definition, UUID are very good salts, and they encode over
-    /// > exactly 16 bytes).
-    ///
-    /// [1]: https://github.com/P-H-C/phc-string-format/blob/master/phc-sf-spec.md#function-duties
-    #[cfg(feature = "rand_core")]
-    pub fn random(mut rng: impl CryptoRng + RngCore) -> Self {
-        let mut bytes = [0u8; MAX_LENGTH];
-        rng.fill_bytes(&mut bytes[..RECOMMENDED_LENGTH]);
-
-        Self {
-            bytes,
-            length: RECOMMENDED_LENGTH as u8,
-        }
-    }
-
-    /// Create a [`Salt`] from the given byte slice, validating it according
-    /// to [`Salt::min_len`] and [`Salt::max_len`] length restrictions.
-    pub fn new(input: &[u8]) -> Result<Self, SaltError> {
+    /// Create a [`Salt`] from the given `str`, validating it according to
+    /// [`Salt::min_len`] and [`Salt::max_len`] length restrictions.
+    pub fn new(input: &'a str) -> Result<Self, SaltError> {
+        // TODO(tarcieri): support shorter salts for MCF?
         if input.len() < Self::min_len() {
             return Err(SaltError::TooShort);
         }
@@ -141,82 +109,57 @@ impl Salt {
             return Err(SaltError::TooLong);
         }
 
-        let mut bytes = [0u8; MAX_LENGTH];
-        bytes[..input.len()].copy_from_slice(input);
-
-        Ok(Self {
-            bytes,
-            length: input.len() as u8,
-        })
+        Ok(Self(input.try_into()?))
     }
 
-    /// Parse a [`b64`]-encoded salt string, i.e. using the PHC string
-    /// specification's restricted interpretation of Base64.
-    pub fn b64_decode(input: &str) -> Result<Self, SaltError> {
-        if b64::decoded_len(input) > MAX_LENGTH {
-            return Err(SaltError::TooLong);
-        }
-
-        let mut bytes = [0u8; MAX_LENGTH];
-        b64::decode(input, &mut bytes)
-            .map_err(Into::into)
-            .and_then(Self::new)
-    }
-
-    /// Write [`b64`]-encoded salt string to the provided buffer, returning
-    /// a sub-slice containing the encoded data.
+    /// Attempt to decode a [`b64`][`crate::b64`]-encoded [`Salt`], writing the
+    /// decoded result into the provided buffer, and returning a slice of the
+    /// buffer containing the decoded result on success.
     ///
-    /// Returns an error if the buffer is too short to contain the output.
-    pub fn b64_encode<'a>(&self, out: &'a mut [u8]) -> Result<&'a str, SaltError> {
-        Ok(b64::encode(self.as_ref(), out)?)
+    /// [1]: https://github.com/P-H-C/phc-string-format/blob/master/phc-sf-spec.md#argon2-encoding
+    pub fn b64_decode<'b>(&self, buf: &'b mut [u8]) -> Result<&'b [u8], B64Error> {
+        self.0.b64_decode(buf)
     }
 
-    /// Get the length of this salt string when encoded as [`b64`].
-    pub fn b64_len(&self) -> usize {
-        b64::encoded_len(self.as_ref())
+    /// Borrow this value as a `str`.
+    pub fn as_str(&self) -> &'a str {
+        self.0.as_str()
     }
-}
 
-impl AsRef<[u8]> for Salt {
-    fn as_ref(&self) -> &[u8] {
-        &self.bytes[..(self.length as usize)]
+    /// Borrow this value as bytes.
+    pub fn as_bytes(&self) -> &'a [u8] {
+        self.as_str().as_bytes()
     }
-}
 
-impl Deref for Salt {
-    type Target = [u8];
-
-    fn deref(&self) -> &[u8] {
-        self.as_ref()
+    /// Get the length of this value in ASCII characters.
+    pub fn len(&self) -> usize {
+        self.as_str().len()
     }
 }
 
-impl FromStr for Salt {
-    type Err = SaltError;
-
-    fn from_str(s: &str) -> Result<Self, SaltError> {
-        Self::b64_decode(s)
+impl<'a> AsRef<str> for Salt<'a> {
+    fn as_ref(&self) -> &str {
+        self.as_str()
     }
 }
 
-impl TryFrom<&[u8]> for Salt {
+impl<'a> TryFrom<&'a str> for Salt<'a> {
     type Error = SaltError;
 
-    fn try_from(input: &[u8]) -> Result<Salt, SaltError> {
+    fn try_from(input: &'a str) -> Result<Self, SaltError> {
         Self::new(input)
     }
 }
 
-impl fmt::Display for Salt {
+impl<'a> fmt::Display for Salt<'a> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut buffer = [0u8; Self::b64_max_len()];
-        f.write_str(self.b64_encode(&mut buffer).map_err(|_| fmt::Error)?)
+        f.write_str(self.as_str())
     }
 }
 
-impl fmt::Debug for Salt {
+impl<'a> fmt::Debug for Salt<'a> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "Salt(\"{}\")", self)
+        write!(f, "Salt({:?})", self.as_ref())
     }
 }
 
@@ -226,21 +169,21 @@ mod tests {
 
     #[test]
     fn new_with_valid_min_length_input() {
-        let bytes = [4u8; 4];
-        let salt = Salt::new(&bytes).unwrap();
-        assert_eq!(salt.as_ref(), &bytes);
+        let s = "abcd";
+        let salt = Salt::new(s).unwrap();
+        assert_eq!(salt.as_ref(), s);
     }
 
     #[test]
     fn new_with_valid_max_length_input() {
-        let bytes = [48u8; 48];
-        let salt = Salt::new(&bytes).unwrap();
-        assert_eq!(salt.as_ref(), &bytes);
+        let s = "012345678911234567892123456789312345678941234567";
+        let salt = Salt::new(s).unwrap();
+        assert_eq!(salt.as_ref(), s);
     }
 
     #[test]
     fn reject_new_too_short() {
-        for &too_short in &[&b""[..], &b"\x01"[..], &b"\x02\x02"[..], &b"\x03\x03"[..]] {
+        for &too_short in &["", "a", "ab", "abc"] {
             let err = Salt::new(too_short).err().unwrap();
             assert_eq!(err, SaltError::TooShort);
         }
@@ -248,8 +191,8 @@ mod tests {
 
     #[test]
     fn reject_new_too_long() {
-        let bytes = [49u8; 49];
-        let err = Salt::new(&bytes).err().unwrap();
+        let s = "0123456789112345678921234567893123456789412345678";
+        let err = Salt::new(s).err().unwrap();
         assert_eq!(err, SaltError::TooLong);
     }
 }

--- a/password-hash/tests/b64.rs
+++ b/password-hash/tests/b64.rs
@@ -23,9 +23,12 @@ const EXAMPLE_OUTPUT_RAW: &[u8] =
 
 #[test]
 fn salt_roundtrip() {
-    let salt = EXAMPLE_SALT_B64.parse::<Salt>().unwrap();
-    assert_eq!(salt.as_ref(), EXAMPLE_SALT_RAW);
-    assert_eq!(salt.to_string(), EXAMPLE_SALT_B64);
+    let mut buffer = [0u8; 64];
+    let salt = Salt::new(EXAMPLE_SALT_B64).unwrap();
+    assert_eq!(salt.as_ref(), EXAMPLE_SALT_B64);
+
+    let salt_decoded = salt.b64_decode(&mut buffer).unwrap();
+    assert_eq!(salt_decoded, EXAMPLE_SALT_RAW);
 }
 
 #[test]

--- a/password-hash/tests/hashing.rs
+++ b/password-hash/tests/hashing.rs
@@ -13,7 +13,7 @@ impl PasswordHasher for StubFunction {
         &self,
         algorithm: Option<Ident<'a>>,
         password: &[u8],
-        salt: Salt,
+        salt: Salt<'a>,
         params: Params<'a>,
     ) -> Result<PasswordHash<'a>, PhfError> {
         let mut output = Vec::new();
@@ -24,7 +24,7 @@ impl PasswordHasher for StubFunction {
             }
         }
 
-        for slice in &[b"pw", password, b",salt:", salt.as_ref()] {
+        for slice in &[b"pw", password, b",salt:", salt.as_bytes()] {
             output.extend_from_slice(slice);
         }
 
@@ -42,7 +42,7 @@ impl PasswordHasher for StubFunction {
 #[test]
 fn verify_password_hash() {
     let valid_password = "test password";
-    let salt = Salt::new(b"test salt").unwrap();
+    let salt = Salt::new("test-salt").unwrap();
     let params = Params::new();
     let hash = PasswordHash::generate(StubFunction, valid_password, salt, params.clone()).unwrap();
 


### PR DESCRIPTION
Per [this comment](https://github.com/RustCrypto/traits/issues/450#issuecomment-754750427), changes the `Salt` type to be a simple newtype of `ValueStr`.

Since the `Salt` value is now borrowed, this unfortunately removes the ability to generate a random salt into a buffer, so this PR also removes the `rand_core` dependency.

We can potentially revisit adding a type like `SaltBuf` to use for an owned salt value.