### PR TITLE
elliptic-curve: bump `ff` and `group` crates to v0.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,12 +41,13 @@ dependencies = [
 
 [[package]]
 name = "bitvec"
-version = "0.18.3"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64143ed23541fe0c6e2235905eaae37ceae1ca69e14dce4afcd6ec9643359d00"
+checksum = "f5011ffc90248764d7005b0e10c7294f5aa1bd87d9dd7248f4ad475b347c294d"
 dependencies = [
  "funty",
  "radium",
+ "tap",
  "wyz",
 ]
 
@@ -154,7 +155,7 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.8.4"
+version = "0.9.0-pre"
 dependencies = [
  "bitvec",
  "digest 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -163,19 +164,19 @@ dependencies = [
  "group",
  "hex-literal",
  "pkcs8",
- "rand_core",
+ "rand_core 0.6.1",
  "subtle",
  "zeroize",
 ]
 
 [[package]]
 name = "ff"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01646e077d4ebda82b73f1bca002ea1e91561a77df2431a9e79729bcc31950ef"
+checksum = "72a4d941a5b7c2a75222e2d44fcdf634a67133d9db31e177ae5ff6ecda852bfe"
 dependencies = [
  "bitvec",
- "rand_core",
+ "rand_core 0.6.1",
  "subtle",
 ]
 
@@ -215,12 +216,12 @@ dependencies = [
 
 [[package]]
 name = "group"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc11f9f5fbf1943b48ae7c2bf6846e7d827a512d1be4f23af708f5ca5d01dde1"
+checksum = "61b3c1e8b4f1ca07e6605ea1be903a5f6956aec5c8a67fd44d56076631675ed8"
 dependencies = [
  "ff",
- "rand_core",
+ "rand_core 0.6.1",
  "subtle",
 ]
 
@@ -311,15 +312,21 @@ dependencies = [
 
 [[package]]
 name = "radium"
-version = "0.3.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "def50a86306165861203e7f84ecffbbdfdea79f0e51039b33de1e952358c47ac"
+checksum = "e9e006811e1fdd12672b0820a7f44c18dde429f367d50cec003d22aa9b3c8ddc"
 
 [[package]]
 name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+
+[[package]]
+name = "rand_core"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c026d7df8b298d90ccbbc5190bd04d85e159eaf5576caeacf8741da93ccbd2e5"
 
 [[package]]
 name = "sha2"
@@ -340,7 +347,7 @@ version = "1.2.2"
 dependencies = [
  "digest 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex-literal",
- "rand_core",
+ "rand_core 0.5.1",
  "sha2",
  "signature_derive",
 ]
@@ -398,6 +405,12 @@ dependencies = [
  "syn",
  "unicode-xid",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36474e732d1affd3a6ed582781b3683df3d0563714c59c39591e8ff707cf078e"
 
 [[package]]
 name = "typenum"

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 aead = { version = "0.3", optional = true, path = "../aead" }
 cipher = { version = "=0.3.0-pre.4", optional = true, path = "../cipher" }
 digest = { version = "0.9", optional = true, path = "../digest" }
-elliptic-curve = { version = "0.8", optional = true, path = "../elliptic-curve" }
+elliptic-curve = { version = "=0.9.0-pre", optional = true, path = "../elliptic-curve" }
 mac = { version = "=0.11.0-pre", package = "crypto-mac", optional = true, path = "../crypto-mac" }
 signature = { version = "1.2.0", optional = true, default-features = false, path = "../signature" }
 universal-hash = { version = "0.4", optional = true, path = "../universal-hash" }

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -5,7 +5,7 @@ General purpose Elliptic Curve Cryptography (ECC) support, including types
 and traits for representing various elliptic curve forms, scalars, points,
 and public/secret keys composed thereof.
 """
-version    = "0.8.4" # Also update html_root_url in lib.rs when bumping this
+version    = "0.9.0-pre" # Also update html_root_url in lib.rs when bumping this
 authors    = ["RustCrypto Developers"]
 license    = "Apache-2.0 OR MIT"
 repository = "https://github.com/RustCrypto/traits/tree/master/elliptic-curve"
@@ -15,13 +15,13 @@ categories = ["cryptography", "no-std"]
 keywords   = ["crypto", "ecc", "elliptic", "weierstrass"]
 
 [dependencies]
-bitvec = { version = "0.18", optional = true, default-features = false }
+bitvec = { version = "0.20", optional = true, default-features = false }
 digest = { version = "0.9", optional = true }
-ff = { version = "0.8", optional = true, default-features = false }
-group = { version = "0.8", optional = true, default-features = false }
+ff = { version = "0.9", optional = true, default-features = false }
+group = { version = "0.9", optional = true, default-features = false }
 generic-array = { version = "0.14", default-features = false }
 pkcs8 = { version = "0.3.3", optional = true }
-rand_core = { version = "0.5", default-features = false }
+rand_core = { version = "0.6", default-features = false }
 subtle = { version = "2.4", default-features = false }
 zeroize = { version = "1", optional = true,  default-features = false }
 

--- a/elliptic-curve/src/ecdh.rs
+++ b/elliptic-curve/src/ecdh.rs
@@ -67,7 +67,6 @@ pub fn diffie_hellman<C>(
 ) -> SharedSecret<C>
 where
     C: Curve + ProjectiveArithmetic,
-    FieldBytes<C>: From<Scalar<C>> + for<'r> From<&'r Scalar<C>>,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>> + Clone + Zeroize,
     AffinePoint<C>: Copy + Clone + Debug + ToEncodedPoint<C> + Zeroize,
     ProjectivePoint<C>: From<AffinePoint<C>>,
@@ -107,7 +106,6 @@ where
 pub struct EphemeralSecret<C>
 where
     C: Curve + ProjectiveArithmetic,
-    FieldBytes<C>: From<Scalar<C>> + for<'r> From<&'r Scalar<C>>,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>> + Zeroize,
 {
     scalar: NonZeroScalar<C>,
@@ -116,7 +114,6 @@ where
 impl<C> EphemeralSecret<C>
 where
     C: Curve + ProjectiveArithmetic,
-    FieldBytes<C>: From<Scalar<C>> + for<'r> From<&'r Scalar<C>>,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>> + Clone + Zeroize,
     AffinePoint<C>: Copy + Clone + Debug + ToEncodedPoint<C> + Zeroize,
     ProjectivePoint<C>: From<AffinePoint<C>>,
@@ -147,7 +144,6 @@ where
 impl<C> From<&EphemeralSecret<C>> for PublicKey<C>
 where
     C: Curve + ProjectiveArithmetic,
-    FieldBytes<C>: From<Scalar<C>> + for<'r> From<&'r Scalar<C>>,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>> + Clone + Zeroize,
     AffinePoint<C>: Copy + Clone + Debug + ToEncodedPoint<C> + Zeroize,
     ProjectivePoint<C>: From<AffinePoint<C>>,
@@ -162,7 +158,6 @@ where
 impl<C> Zeroize for EphemeralSecret<C>
 where
     C: Curve + ProjectiveArithmetic,
-    FieldBytes<C>: From<Scalar<C>> + for<'r> From<&'r Scalar<C>>,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>> + Zeroize,
 {
     fn zeroize(&mut self) {
@@ -173,7 +168,6 @@ where
 impl<C> Drop for EphemeralSecret<C>
 where
     C: Curve + ProjectiveArithmetic,
-    FieldBytes<C>: From<Scalar<C>> + for<'r> From<&'r Scalar<C>>,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>> + Zeroize,
 {
     fn drop(&mut self) {
@@ -199,7 +193,6 @@ where
 pub struct SharedSecret<C>
 where
     C: Curve + ProjectiveArithmetic,
-    FieldBytes<C>: From<Scalar<C>> + for<'r> From<&'r Scalar<C>>,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
 {
     /// Computed secret value
@@ -209,7 +202,6 @@ where
 impl<C> SharedSecret<C>
 where
     C: Curve + ProjectiveArithmetic,
-    FieldBytes<C>: From<Scalar<C>> + for<'r> From<&'r Scalar<C>>,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
     AffinePoint<C>: Zeroize,
     UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
@@ -240,7 +232,6 @@ where
 impl<C> Zeroize for SharedSecret<C>
 where
     C: Curve + ProjectiveArithmetic,
-    FieldBytes<C>: From<Scalar<C>> + for<'r> From<&'r Scalar<C>>,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
 {
     fn zeroize(&mut self) {
@@ -251,7 +242,6 @@ where
 impl<C> Drop for SharedSecret<C>
 where
     C: Curve + ProjectiveArithmetic,
-    FieldBytes<C>: From<Scalar<C>> + for<'r> From<&'r Scalar<C>>,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
 {
     fn drop(&mut self) {

--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -60,17 +60,15 @@ pub use rand_core;
 pub use subtle;
 
 #[cfg(feature = "arithmetic")]
-pub use self::{
-    point::{AffinePoint, ProjectiveArithmetic, ProjectivePoint},
-    public_key::PublicKey,
-    scalar::Scalar,
+pub use {
+    crate::{
+        point::{AffinePoint, ProjectiveArithmetic, ProjectivePoint},
+        public_key::PublicKey,
+        scalar::Scalar,
+    },
+    ff::{self, BitView, Field},
+    group::{self, Group},
 };
-#[cfg(feature = "arithmetic")]
-pub use bitvec::view::BitView; // TODO: https://github.com/zkcrypto/ff/pull/40
-#[cfg(feature = "arithmetic")]
-pub use ff::{self, Field};
-#[cfg(feature = "arithmetic")]
-pub use group::{self, Group};
 
 #[cfg(feature = "digest")]
 pub use digest::{self, Digest};

--- a/elliptic-curve/src/point.rs
+++ b/elliptic-curve/src/point.rs
@@ -5,7 +5,6 @@ use crate::{Curve, FieldBytes, Scalar};
 /// Elliptic curve with projective arithmetic implementation.
 pub trait ProjectiveArithmetic: Curve
 where
-    FieldBytes<Self>: From<Scalar<Self>> + for<'r> From<&'r Scalar<Self>>,
     Scalar<Self>: ff::PrimeField<Repr = FieldBytes<Self>>,
 {
     /// Elliptic curve point in projective coordinates.

--- a/elliptic-curve/src/public_key.rs
+++ b/elliptic-curve/src/public_key.rs
@@ -64,7 +64,6 @@ use {
 pub struct PublicKey<C>
 where
     C: Curve + ProjectiveArithmetic,
-    FieldBytes<C>: From<Scalar<C>> + for<'r> From<&'r Scalar<C>>,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
     AffinePoint<C>: Copy + Clone + Debug,
 {
@@ -74,7 +73,6 @@ where
 impl<C> PublicKey<C>
 where
     C: Curve + ProjectiveArithmetic,
-    FieldBytes<C>: From<Scalar<C>> + for<'r> From<&'r Scalar<C>>,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
     AffinePoint<C>: Copy + Clone + Debug,
     ProjectivePoint<C>: From<AffinePoint<C>>,
@@ -146,7 +144,6 @@ where
 impl<C> AsRef<AffinePoint<C>> for PublicKey<C>
 where
     C: Curve + ProjectiveArithmetic,
-    FieldBytes<C>: From<Scalar<C>> + for<'r> From<&'r Scalar<C>>,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
     AffinePoint<C>: Copy + Clone + Debug,
     ProjectivePoint<C>: From<AffinePoint<C>>,
@@ -159,7 +156,6 @@ where
 impl<C> TryFrom<EncodedPoint<C>> for PublicKey<C>
 where
     C: Curve + ProjectiveArithmetic,
-    FieldBytes<C>: From<Scalar<C>> + for<'r> From<&'r Scalar<C>>,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
     AffinePoint<C>: Copy + Clone + Debug + Default + FromEncodedPoint<C> + ToEncodedPoint<C>,
     ProjectivePoint<C>: From<AffinePoint<C>>,
@@ -176,7 +172,6 @@ where
 impl<C> TryFrom<&EncodedPoint<C>> for PublicKey<C>
 where
     C: Curve + ProjectiveArithmetic,
-    FieldBytes<C>: From<Scalar<C>> + for<'r> From<&'r Scalar<C>>,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
     AffinePoint<C>: Copy + Clone + Debug + Default + FromEncodedPoint<C> + ToEncodedPoint<C>,
     ProjectivePoint<C>: From<AffinePoint<C>>,
@@ -193,7 +188,6 @@ where
 impl<C> From<PublicKey<C>> for EncodedPoint<C>
 where
     C: Curve + ProjectiveArithmetic + point::Compression,
-    FieldBytes<C>: From<Scalar<C>> + for<'r> From<&'r Scalar<C>>,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
     AffinePoint<C>: Copy + Clone + Debug + Default + FromEncodedPoint<C> + ToEncodedPoint<C>,
     ProjectivePoint<C>: From<AffinePoint<C>>,
@@ -208,7 +202,6 @@ where
 impl<C> From<&PublicKey<C>> for EncodedPoint<C>
 where
     C: Curve + ProjectiveArithmetic + point::Compression,
-    FieldBytes<C>: From<Scalar<C>> + for<'r> From<&'r Scalar<C>>,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
     AffinePoint<C>: Copy + Clone + Debug + Default + FromEncodedPoint<C> + ToEncodedPoint<C>,
     ProjectivePoint<C>: From<AffinePoint<C>>,
@@ -223,7 +216,6 @@ where
 impl<C> FromEncodedPoint<C> for PublicKey<C>
 where
     C: Curve + ProjectiveArithmetic,
-    FieldBytes<C>: From<Scalar<C>> + for<'r> From<&'r Scalar<C>>,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
     AffinePoint<C>: Copy + Clone + Debug + Default + FromEncodedPoint<C> + ToEncodedPoint<C>,
     ProjectivePoint<C>: From<AffinePoint<C>>,
@@ -240,7 +232,6 @@ where
 impl<C> ToEncodedPoint<C> for PublicKey<C>
 where
     C: Curve + ProjectiveArithmetic,
-    FieldBytes<C>: From<Scalar<C>> + for<'r> From<&'r Scalar<C>>,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
     AffinePoint<C>: Copy + Clone + Debug + Default + FromEncodedPoint<C> + ToEncodedPoint<C>,
     ProjectivePoint<C>: From<AffinePoint<C>>,
@@ -257,7 +248,6 @@ where
 impl<C> Copy for PublicKey<C>
 where
     C: Curve + ProjectiveArithmetic,
-    FieldBytes<C>: From<Scalar<C>> + for<'r> From<&'r Scalar<C>>,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
     AffinePoint<C>: Copy + Clone + Debug,
 {
@@ -266,7 +256,6 @@ where
 impl<C> Eq for PublicKey<C>
 where
     C: Curve + ProjectiveArithmetic,
-    FieldBytes<C>: From<Scalar<C>> + for<'r> From<&'r Scalar<C>>,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
     AffinePoint<C>: Copy + Clone + Debug + Default + FromEncodedPoint<C> + ToEncodedPoint<C>,
     ProjectivePoint<C>: From<AffinePoint<C>>,
@@ -278,7 +267,6 @@ where
 impl<C> PartialEq for PublicKey<C>
 where
     C: Curve + ProjectiveArithmetic,
-    FieldBytes<C>: From<Scalar<C>> + for<'r> From<&'r Scalar<C>>,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
     AffinePoint<C>: Copy + Clone + Debug + Default + FromEncodedPoint<C> + ToEncodedPoint<C>,
     ProjectivePoint<C>: From<AffinePoint<C>>,
@@ -298,7 +286,6 @@ impl<C> FromPublicKey for PublicKey<C>
 where
     Self: TryFrom<EncodedPoint<C>, Error = Error>,
     C: Curve + AlgorithmParameters + ProjectiveArithmetic,
-    FieldBytes<C>: From<Scalar<C>> + for<'r> From<&'r Scalar<C>>,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
     AffinePoint<C>: Copy + Clone + Debug,
     ProjectivePoint<C>: From<AffinePoint<C>>,
@@ -324,7 +311,6 @@ where
 impl<C> ToPublicKey for PublicKey<C>
 where
     C: Curve + AlgorithmParameters + ProjectiveArithmetic,
-    FieldBytes<C>: From<Scalar<C>> + for<'r> From<&'r Scalar<C>>,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
     AffinePoint<C>: Copy + Clone + Debug + Default + FromEncodedPoint<C> + ToEncodedPoint<C>,
     ProjectivePoint<C>: From<AffinePoint<C>>,
@@ -348,7 +334,6 @@ impl<C> FromStr for PublicKey<C>
 where
     Self: TryFrom<EncodedPoint<C>, Error = Error>,
     C: Curve + AlgorithmParameters + ProjectiveArithmetic,
-    FieldBytes<C>: From<Scalar<C>> + for<'r> From<&'r Scalar<C>>,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
     AffinePoint<C>: Copy + Clone + Debug,
     ProjectivePoint<C>: From<AffinePoint<C>>,
@@ -367,7 +352,6 @@ where
 impl<C> ToString for PublicKey<C>
 where
     C: Curve + AlgorithmParameters + ProjectiveArithmetic,
-    FieldBytes<C>: From<Scalar<C>> + for<'r> From<&'r Scalar<C>>,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
     AffinePoint<C>: Copy + Clone + Debug + Default + FromEncodedPoint<C> + ToEncodedPoint<C>,
     ProjectivePoint<C>: From<AffinePoint<C>>,

--- a/elliptic-curve/src/scalar.rs
+++ b/elliptic-curve/src/scalar.rs
@@ -33,7 +33,6 @@ pub type ScalarBits<C> = BitArray<Lsb0, <Scalar<C> as PrimeField>::ReprBits>;
 pub struct NonZeroScalar<C>
 where
     C: Curve + ProjectiveArithmetic,
-    FieldBytes<C>: From<Scalar<C>> + for<'r> From<&'r Scalar<C>>,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
 {
     scalar: Scalar<C>,
@@ -42,7 +41,6 @@ where
 impl<C> NonZeroScalar<C>
 where
     C: Curve + ProjectiveArithmetic,
-    FieldBytes<C>: From<Scalar<C>> + for<'r> From<&'r Scalar<C>>,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
 {
     /// Generate a random `NonZeroScalar`
@@ -74,7 +72,6 @@ where
 impl<C> AsRef<Scalar<C>> for NonZeroScalar<C>
 where
     C: Curve + ProjectiveArithmetic,
-    FieldBytes<C>: From<Scalar<C>> + for<'r> From<&'r Scalar<C>>,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
 {
     fn as_ref(&self) -> &Scalar<C> {
@@ -85,7 +82,6 @@ where
 impl<C> ConditionallySelectable for NonZeroScalar<C>
 where
     C: Curve + ProjectiveArithmetic,
-    FieldBytes<C>: From<Scalar<C>> + for<'r> From<&'r Scalar<C>>,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
 {
     fn conditional_select(a: &Self, b: &Self, choice: Choice) -> Self {
@@ -98,7 +94,6 @@ where
 impl<C> Copy for NonZeroScalar<C>
 where
     C: Curve + ProjectiveArithmetic,
-    FieldBytes<C>: From<Scalar<C>> + for<'r> From<&'r Scalar<C>>,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
 {
 }
@@ -106,7 +101,6 @@ where
 impl<C> Deref for NonZeroScalar<C>
 where
     C: Curve + ProjectiveArithmetic,
-    FieldBytes<C>: From<Scalar<C>> + for<'r> From<&'r Scalar<C>>,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
 {
     type Target = Scalar<C>;
@@ -119,18 +113,16 @@ where
 impl<C> From<NonZeroScalar<C>> for FieldBytes<C>
 where
     C: Curve + ProjectiveArithmetic,
-    FieldBytes<C>: From<Scalar<C>> + for<'r> From<&'r Scalar<C>>,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
 {
     fn from(scalar: NonZeroScalar<C>) -> FieldBytes<C> {
-        scalar.scalar.into()
+        scalar.scalar.to_repr()
     }
 }
 
 impl<C> Invert for NonZeroScalar<C>
 where
     C: Curve + ProjectiveArithmetic,
-    FieldBytes<C>: From<Scalar<C>> + for<'r> From<&'r Scalar<C>>,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>> + Invert,
 {
     type Output = Scalar<C>;
@@ -144,7 +136,6 @@ where
 impl<C> TryFrom<&[u8]> for NonZeroScalar<C>
 where
     C: Curve + ProjectiveArithmetic,
-    FieldBytes<C>: From<Scalar<C>> + for<'r> From<&'r Scalar<C>>,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
 {
     type Error = Error;
@@ -162,7 +153,6 @@ where
 impl<C> Zeroize for NonZeroScalar<C>
 where
     C: Curve + ProjectiveArithmetic,
-    FieldBytes<C>: From<Scalar<C>> + for<'r> From<&'r Scalar<C>>,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>> + Zeroize,
 {
     fn zeroize(&mut self) {

--- a/elliptic-curve/src/sec1.rs
+++ b/elliptic-curve/src/sec1.rs
@@ -132,7 +132,6 @@ where
     pub fn from_secret_key(secret_key: &SecretKey<C>, compress: bool) -> Self
     where
         C: Curve + ProjectiveArithmetic,
-        FieldBytes<C>: From<Scalar<C>> + for<'r> From<&'r Scalar<C>>,
         AffinePoint<C>: ToEncodedPoint<C>,
         Scalar<C>: PrimeField<Repr = FieldBytes<C>> + Zeroize,
     {
@@ -171,7 +170,6 @@ where
     pub fn to_untagged_bytes(&self) -> Option<GenericArray<u8, UntaggedPointSize<C>>>
     where
         C: Curve + ProjectiveArithmetic,
-        FieldBytes<C>: From<Scalar<C>> + for<'r> From<&'r Scalar<C>>,
         Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
         AffinePoint<C>: ConditionallySelectable + Default + Decompress<C> + ToEncodedPoint<C>,
     {
@@ -206,7 +204,6 @@ where
     pub fn decompress(&self) -> Option<Self>
     where
         C: Curve + ProjectiveArithmetic,
-        FieldBytes<C>: From<Scalar<C>> + for<'r> From<&'r Scalar<C>>,
         Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
         AffinePoint<C>: ConditionallySelectable + Default + Decompress<C> + ToEncodedPoint<C>,
     {

--- a/elliptic-curve/src/secret_key.rs
+++ b/elliptic-curve/src/secret_key.rs
@@ -74,7 +74,6 @@ where
     pub fn random(rng: impl CryptoRng + RngCore) -> Self
     where
         C: ProjectiveArithmetic + SecretValue<Secret = NonZeroScalar<C>>,
-        FieldBytes<C>: From<Scalar<C>> + for<'a> From<&'a Scalar<C>>,
         Scalar<C>: PrimeField<Repr = FieldBytes<C>> + Zeroize,
     {
         Self {
@@ -115,7 +114,6 @@ where
     pub fn secret_scalar(&self) -> &NonZeroScalar<C>
     where
         C: ProjectiveArithmetic + SecretValue<Secret = NonZeroScalar<C>>,
-        FieldBytes<C>: From<Scalar<C>> + for<'a> From<&'a Scalar<C>>,
         Scalar<C>: PrimeField<Repr = FieldBytes<C>> + Zeroize,
     {
         &self.secret_value
@@ -127,7 +125,6 @@ where
     pub fn public_key(&self) -> PublicKey<C>
     where
         C: weierstrass::Curve + ProjectiveArithmetic + SecretValue<Secret = NonZeroScalar<C>>,
-        FieldBytes<C>: From<Scalar<C>> + for<'a> From<&'a Scalar<C>>,
         Scalar<C>: PrimeField<Repr = FieldBytes<C>> + Zeroize,
         AffinePoint<C>: Copy + Clone + Debug + Default,
         ProjectivePoint<C>: From<AffinePoint<C>>,
@@ -197,7 +194,6 @@ pub trait SecretValue: Curve {
 impl<C> SecretValue for C
 where
     C: Curve + ProjectiveArithmetic,
-    FieldBytes<C>: From<Scalar<C>> + for<'a> From<&'a Scalar<C>>,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>> + Zeroize,
 {
     type Secret = NonZeroScalar<C>;

--- a/elliptic-curve/src/secret_key/pkcs8.rs
+++ b/elliptic-curve/src/secret_key/pkcs8.rs
@@ -114,7 +114,6 @@ where
 impl<C> ToPrivateKey for SecretKey<C>
 where
     C: weierstrass::Curve + AlgorithmParameters + ProjectiveArithmetic,
-    FieldBytes<C>: From<Scalar<C>> + for<'a> From<&'a Scalar<C>>,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>> + Zeroize,
     AffinePoint<C>: Copy + Clone + Debug + Default + FromEncodedPoint<C> + ToEncodedPoint<C>,
     ProjectivePoint<C>: From<AffinePoint<C>>,


### PR DESCRIPTION
Also bumps `rand_core` to v0.6 (for the `elliptic-curve` crate only).

This is a breaking change, so the `elliptic-curve` crate version is also bumped to v0.9.0-pre.