### PR TITLE
password-hash: add `version` field

### DIFF
--- a/password-hash/tests/hashing.rs
+++ b/password-hash/tests/hashing.rs
@@ -32,6 +32,7 @@ impl PasswordHasher for StubFunction {
 
         Ok(PasswordHash {
             algorithm: ALG,
+            version: None,
             params,
             salt: Some(salt),
             hash: Some(hash),

--- a/password-hash/tests/test_vectors.rs
+++ b/password-hash/tests/test_vectors.rs
@@ -1,38 +1,32 @@
 //! Test vectors for commonly used password hashing algorithms.
 
-#![cfg(feature = "registry")]
+use password_hash::{Ident, PasswordHash};
 
-use password_hash::{
-    algorithm::{argon2, bcrypt},
-    Algorithm, PasswordHash,
-};
-
-const ARGON2ID_HASH: &str =
-    "$argon2id$m=65536,t=3,p=2$c29tZXNhbHQ$RdescudvJCsgt3ub+b+dWRWJTmaaJObG";
+const ARGON2D_HASH: &str =
+    "$argon2d$v=19$m=512,t=3,p=2$5VtWOO3cGWYQHEMaYGbsfQ$AcmqasQgW/wI6wAHAMk4aQ";
 const BCRYPT_HASH: &str = "$2b$MTIzNA$i5btSOiulHhaPHPbgNUGdObga/GCAVG/y5HHY1ra7L0C9dpCaw8u";
 const SCRYPT_HASH: &str =
     "$scrypt$epIxT/h6HbbwHaehFnh/bw$7H0vsXlY8UxxyW/BWx/9GuY7jEvGjT71GFd6O4SZND0";
 
 #[test]
 fn argon2id() {
-    let ph = ARGON2ID_HASH.parse::<PasswordHash>().unwrap();
-    assert_eq!(ph.algorithm, Algorithm::Argon2(argon2::Variant::ID));
+    let ph = PasswordHash::new(ARGON2D_HASH).unwrap();
+    assert_eq!(ph.algorithm, Ident::new("argon2d"));
+    assert_eq!(ph.version, Some(19));
     assert_eq!(ph.params.len(), 3);
-    assert_eq!(ph.params["m"], 65536.into());
-    assert_eq!(ph.params["t"], 3.into());
-    assert_eq!(ph.params["p"], 2.into());
-    assert_eq!(ph.salt.unwrap().to_string(), "c29tZXNhbHQ");
-    assert_eq!(
-        ph.hash.unwrap().to_string(),
-        "RdescudvJCsgt3ub+b+dWRWJTmaaJObG"
-    );
-    assert_eq!(ph.to_string(), ARGON2ID_HASH);
+    assert_eq!(ph.params["m"].decimal().unwrap(), 512);
+    assert_eq!(ph.params["t"].decimal().unwrap(), 3);
+    assert_eq!(ph.params["p"].decimal().unwrap(), 2);
+    assert_eq!(ph.salt.unwrap().as_ref(), "5VtWOO3cGWYQHEMaYGbsfQ");
+    assert_eq!(ph.hash.unwrap().to_string(), "AcmqasQgW/wI6wAHAMk4aQ");
+    assert_eq!(ph.to_string(), ARGON2D_HASH);
 }
 
 #[test]
 fn bcrypt() {
-    let ph = BCRYPT_HASH.parse::<PasswordHash>().unwrap();
-    assert_eq!(ph.algorithm, Algorithm::Bcrypt(bcrypt::Variant::B));
+    let ph = PasswordHash::new(BCRYPT_HASH).unwrap();
+    assert_eq!(ph.algorithm, Ident::new("2b"));
+    assert_eq!(ph.version, None);
     assert_eq!(ph.params.len(), 0);
     assert_eq!(ph.salt.unwrap().to_string(), "MTIzNA");
     assert_eq!(
@@ -44,8 +38,9 @@ fn bcrypt() {
 
 #[test]
 fn scrypt() {
-    let ph = SCRYPT_HASH.parse::<PasswordHash>().unwrap();
-    assert_eq!(ph.algorithm, Algorithm::Scrypt);
+    let ph = PasswordHash::new(SCRYPT_HASH).unwrap();
+    assert_eq!(ph.algorithm, Ident::new("scrypt"));
+    assert_eq!(ph.version, None);
     assert_eq!(ph.params.len(), 0);
     assert_eq!(ph.salt.unwrap().to_string(), "epIxT/h6HbbwHaehFnh/bw");
     assert_eq!(


### PR DESCRIPTION
Support for PHC string variant with an additional version field:

https://github.com/P-H-C/phc-string-format/pull/4

This is used by Argon2.