### PR TITLE
signature/derive: fix rustdoc links

### DIFF
--- a/signature/derive/src/lib.rs
+++ b/signature/derive/src/lib.rs
@@ -45,6 +45,9 @@ decl_derive! {
     /// complete signature algorithm implementation.
     ///
     /// [`Digest`]: https://docs.rs/digest/latest/digest/trait.Digest.html
+    /// [`DigestSigner`]: https://docs.rs/signature/latest/signature/trait.DigestSigner.html
+    /// [`PrehashSignature`]: https://docs.rs/signature/latest/signature/trait.PrehashSignature.html
+    /// [`PrehashSignature::Digest`]: https://docs.rs/signature/latest/signature/trait.PrehashSignature.html#associated-types
     derive_signer
 }
 
@@ -79,6 +82,9 @@ decl_derive! {
     /// complete signature algorithm implementation.
     ///
     /// [`Digest`]: https://docs.rs/digest/latest/digest/trait.Digest.html
+    /// [`DigestVerifier`]: https://docs.rs/signature/latest/signature/trait.DigestVerifier.html
+    /// [`PrehashSignature`]: https://docs.rs/signature/latest/signature/trait.PrehashSignature.html
+    /// [`PrehashSignature::Digest`]: https://docs.rs/signature/latest/signature/trait.PrehashSignature.html#associated-types
     derive_verifier
 }
 


### PR DESCRIPTION
Links were previously busted.

Not sure if there's better way to link to types in an external crate which will render correctly on https://docs.rs but this should at least fix the immediate problem.