### PR TITLE
signature-derive v1.0.0-pre.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -348,7 +348,7 @@ dependencies = [
 
 [[package]]
 name = "signature_derive"
-version = "1.0.0-pre.2"
+version = "1.0.0-pre.3"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/signature/Cargo.toml
+++ b/signature/Cargo.toml
@@ -22,7 +22,7 @@ optional = true
 default-features = false
 
 [dependencies.signature_derive]
-version = "= 1.0.0-pre.2"
+version = "= 1.0.0-pre.3"
 optional = true
 path = "derive"
 

--- a/signature/derive/CHANGELOG.md
+++ b/signature/derive/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.0.0-pre.3 (2021-01-06)
+### Fixed
+- rustdoc links ([#458])
+
+[#458]: https://github.com/RustCrypto/traits/pull/458
+
 ## 1.0.0-pre.2 (2020-04-19)
 ### Changed
 - Rename `DigestSignature` => `PrehashSignature` ([#96])

--- a/signature/derive/Cargo.toml
+++ b/signature/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "signature_derive"
-version       = "1.0.0-pre.2"
+version       = "1.0.0-pre.3"
 authors       = ["RustCrypto Developers"]
 license       = "Apache-2.0 OR MIT"
 description   = "Custom derive support for the 'signature' crate"


### PR DESCRIPTION
### Fixed
- rustdoc links ([#458])

[#458]: https://github.com/RustCrypto/traits/pull/458