### PR TITLE
signature v1.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -337,7 +337,7 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "1.2.2"
+version = "1.3.0"
 dependencies = [
  "digest 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex-literal",

--- a/signature/CHANGELOG.md
+++ b/signature/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.3.0 (2021-01-06)
+### Changed
+- Bump `rand_core` to v0.6 ([#457])
+- Bump `signature-derive` v1.0.0-pre.3 ([#459])
+
+[#457]: https://github.com/RustCrypto/traits/pull/457
+[#459]: https://github.com/RustCrypto/traits/pull/459
+
 ## 1.2.2 (2020-07-29)
 ### Added
 - `RandomizedDigestSigner` ([#235])

--- a/signature/Cargo.toml
+++ b/signature/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name          = "signature"
 description   = "Traits for cryptographic signature algorithms (e.g. ECDSA, Ed25519)"
-version       = "1.2.2" # Also update html_root_url in lib.rs when bumping this
+version       = "1.3.0" # Also update html_root_url in lib.rs when bumping this
 authors       = ["RustCrypto Developers"]
 license       = "Apache-2.0 OR MIT"
 documentation = "https://docs.rs/signature"

--- a/signature/src/lib.rs
+++ b/signature/src/lib.rs
@@ -160,7 +160,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/signature/1.2.2"
+    html_root_url = "https://docs.rs/signature/1.3.0"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]


### PR DESCRIPTION
### Changed
- Bump `rand_core` to v0.6 ([#457])
- Bump `signature-derive` v1.0.0-pre.3 ([#459])

[#457]: https://github.com/RustCrypto/traits/pull/457
[#459]: https://github.com/RustCrypto/traits/pull/459