### PR TITLE
elliptic-curve: bump pkcs8 to v0.4.0-pre

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -129,9 +129,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.1.0"
+version = "0.2.0-pre"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51f59c66c30bb7445c8320a5f9233e437e3572368099f25532a59054328899b4"
+checksum = "ce3c2453c3322800962d0630f6e4e64a398ffea370e43a4ceb24d02f724441f4"
 dependencies = [
  "const-oid",
 ]
@@ -277,9 +277,9 @@ version = "0.0.0"
 
 [[package]]
 name = "pkcs8"
-version = "0.3.3"
+version = "0.4.0-pre"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4839a901843f3942576e65857f0ebf2e190ef7024d3c62a94099ba3f819ad1d"
+checksum = "9df125c6bec8ba2195e9ef3064e610c9aa00362b38f502ca348e4383eaeef102"
 dependencies = [
  "der",
  "subtle-encoding",

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -20,7 +20,7 @@ digest = { version = "0.9", optional = true }
 ff = { version = "0.9", optional = true, default-features = false }
 group = { version = "0.9", optional = true, default-features = false }
 generic-array = { version = "0.14", default-features = false }
-pkcs8 = { version = "0.3.3", optional = true }
+pkcs8 = { version = "0.4.0-pre", optional = true }
 rand_core = { version = "0.6", default-features = false }
 subtle = { version = "2.4", default-features = false }
 zeroize = { version = "1", optional = true,  default-features = false }


### PR DESCRIPTION
This prerelease includes this change which handles decoding/encoding the leading octet of ASN.1 BIT STRINGs:

https://github.com/RustCrypto/utils/pull/193