### PR TITLE
password-hash: rename `PhfError` => `HasherError`

### DIFF
--- a/password-hash/src/errors.rs
+++ b/password-hash/src/errors.rs
@@ -80,6 +80,46 @@ impl From<ParseError> for HashError {
 #[cfg(feature = "std")]
 impl std::error::Error for HashError {}
 
+/// Errors generating password hashes using a [`PasswordHasher`].
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum HasherError {
+    /// Unsupported algorithm.
+    Algorithm,
+
+    /// Cryptographic error.
+    Crypto,
+
+    /// Error generating output.
+    Output(OutputError),
+
+    /// Invalid parameter.
+    Param,
+
+    /// Invalid password.
+    Password,
+}
+
+impl fmt::Display for HasherError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        match self {
+            Self::Algorithm => write!(f, "unsupported algorithm"),
+            Self::Crypto => write!(f, "cryptographic error"),
+            Self::Output(err) => write!(f, "PHF output error: {}", err),
+            Self::Param => write!(f, "invalid algorithm parameter"),
+            Self::Password => write!(f, "invalid password"),
+        }
+    }
+}
+
+impl From<OutputError> for HasherError {
+    fn from(err: OutputError) -> HasherError {
+        HasherError::Output(err)
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for HasherError {}
+
 /// Parameter-related errors.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum ParamsError {
@@ -142,46 +182,6 @@ impl fmt::Display for ParseError {
 #[cfg(feature = "std")]
 impl std::error::Error for ParseError {}
 
-/// Errors generating password hashes using a [`PasswordHasher`].
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
-pub enum PhfError {
-    /// Unsupported algorithm.
-    Algorithm,
-
-    /// Cryptographic error.
-    Crypto,
-
-    /// Error generating output.
-    Output(OutputError),
-
-    /// Invalid parameter.
-    Param,
-
-    /// Invalid password.
-    Password,
-}
-
-impl fmt::Display for PhfError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        match self {
-            Self::Algorithm => write!(f, "unsupported algorithm"),
-            Self::Crypto => write!(f, "cryptographic error"),
-            Self::Output(err) => write!(f, "PHF output error: {}", err),
-            Self::Param => write!(f, "invalid algorithm parameter"),
-            Self::Password => write!(f, "invalid password"),
-        }
-    }
-}
-
-impl From<OutputError> for PhfError {
-    fn from(err: OutputError) -> PhfError {
-        PhfError::Output(err)
-    }
-}
-
-#[cfg(feature = "std")]
-impl std::error::Error for PhfError {}
-
 /// Password hash function output (i.e. hash/digest) errors.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum OutputError {
@@ -224,8 +224,8 @@ impl fmt::Display for VerifyError {
     }
 }
 
-impl From<PhfError> for VerifyError {
-    fn from(_: PhfError) -> VerifyError {
+impl From<HasherError> for VerifyError {
+    fn from(_: HasherError) -> VerifyError {
         VerifyError
     }
 }

--- a/password-hash/src/lib.rs
+++ b/password-hash/src/lib.rs
@@ -48,7 +48,7 @@ use core::{
 };
 
 pub use crate::{
-    errors::{HashError, PhfError, VerifyError},
+    errors::{HashError, HasherError, VerifyError},
     ident::Ident,
     output::Output,
     params::Params,
@@ -82,7 +82,7 @@ pub trait PasswordHasher {
         password: &[u8],
         salt: Salt<'a>,
         params: Params<'a>,
-    ) -> Result<PasswordHash<'a>, PhfError>;
+    ) -> Result<PasswordHash<'a>, HasherError>;
 
     /// Compute this password hashing function against the provided password
     /// using the parameters from the provided password hash and see if the
@@ -117,7 +117,7 @@ pub trait McfHasher {
     ///
     /// MCF hashes are otherwise largely unstructured and parsed according to
     /// algorithm-specific rules so hashers must parse a raw string themselves.
-    fn upgrade_mcf_hash(hash: &str) -> Result<PasswordHash<'_>, PhfError>;
+    fn upgrade_mcf_hash(hash: &str) -> Result<PasswordHash<'_>, HasherError>;
 
     /// Verify a password hash in MCF format against the provided password.
     fn verify_mcf_hash(&self, password: &[u8], mcf_hash: &str) -> Result<(), VerifyError>
@@ -275,7 +275,7 @@ impl<'a> PasswordHash<'a> {
         password: impl AsRef<[u8]>,
         salt: Salt<'a>,
         params: Params<'a>,
-    ) -> Result<Self, PhfError> {
+    ) -> Result<Self, HasherError> {
         phf.hash_password(None, password.as_ref(), salt, params)
     }
 

--- a/password-hash/tests/hashing.rs
+++ b/password-hash/tests/hashing.rs
@@ -1,6 +1,6 @@
 /// Password hashing tests
 pub use password_hash::{
-    Ident, Output, Params, PasswordHash, PasswordHasher, PhfError, Salt, VerifyError,
+    HasherError, Ident, Output, Params, PasswordHash, PasswordHasher, Salt, VerifyError,
 };
 
 const ALG: Ident = Ident::new("example");
@@ -15,12 +15,12 @@ impl PasswordHasher for StubFunction {
         password: &[u8],
         salt: Salt<'a>,
         params: Params<'a>,
-    ) -> Result<PasswordHash<'a>, PhfError> {
+    ) -> Result<PasswordHash<'a>, HasherError> {
         let mut output = Vec::new();
 
         if let Some(alg) = algorithm {
             if alg != ALG {
-                return Err(PhfError::Algorithm);
+                return Err(HasherError::Algorithm);
             }
         }
 


### PR DESCRIPTION
The previous name is a holdover from the old trait name (`PasswordHashingFunction`)