### PR TITLE
password-hash: add lifetime to McfHasher::upgrade_mcf_hash

### DIFF
--- a/password-hash/src/lib.rs
+++ b/password-hash/src/lib.rs
@@ -117,7 +117,7 @@ pub trait McfHasher {
     ///
     /// MCF hashes are otherwise largely unstructured and parsed according to
     /// algorithm-specific rules so hashers must parse a raw string themselves.
-    fn upgrade_mcf_hash(&self, hash: &str) -> Result<PasswordHash<'_>, HasherError>;
+    fn upgrade_mcf_hash<'a>(&self, hash: &'a str) -> Result<PasswordHash<'a>, HasherError>;
 
     /// Verify a password hash in MCF format against the provided password.
     fn verify_mcf_hash(&self, password: &[u8], mcf_hash: &str) -> Result<(), VerifyError>


### PR DESCRIPTION
Allows the returned `PasswordHash<'a>` to reference data from the original MCF password hash.