### PR TITLE
password-hash: ParamsString refactor

### DIFF
--- a/password-hash/src/errors.rs
+++ b/password-hash/src/errors.rs
@@ -69,7 +69,7 @@ pub enum HasherError {
     Output(OutputError),
 
     /// Invalid parameter.
-    Param,
+    Params(ParamsError),
 
     /// Parse error.
     Parse(ParseError),
@@ -85,7 +85,7 @@ impl fmt::Display for HasherError {
             Self::B64(err) => write!(f, "{}", err),
             Self::Crypto => write!(f, "cryptographic error"),
             Self::Output(err) => write!(f, "PHF output error: {}", err),
-            Self::Param => write!(f, "invalid algorithm parameter"),
+            Self::Params(err) => write!(f, "{}", err),
             Self::Parse(err) => write!(f, "{}", err),
             Self::Password => write!(f, "invalid password"),
         }
@@ -104,6 +104,12 @@ impl From<OutputError> for HasherError {
     }
 }
 
+impl From<ParamsError> for HasherError {
+    fn from(err: ParamsError) -> HasherError {
+        HasherError::Params(err)
+    }
+}
+
 impl From<ParseError> for HasherError {
     fn from(err: ParseError) -> HasherError {
         HasherError::Parse(err)
@@ -119,6 +125,12 @@ pub enum ParamsError {
     /// Duplicate parameter name encountered.
     DuplicateName,
 
+    /// Invalid parameter name.
+    InvalidName,
+
+    /// Invalid parameter value.
+    InvalidValue,
+
     /// Maximum number of parameters exceeded.
     MaxExceeded,
 
@@ -130,6 +142,8 @@ impl fmt::Display for ParamsError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         match self {
             Self::DuplicateName => f.write_str("duplicate parameter"),
+            Self::InvalidName => f.write_str("invalid parameter name"),
+            Self::InvalidValue => f.write_str("invalid parameter value"),
             Self::MaxExceeded => f.write_str("maximum number of parameters reached"),
             Self::Parse(err) => write!(f, "{}", err),
         }

--- a/password-hash/src/salt.rs
+++ b/password-hash/src/salt.rs
@@ -1,6 +1,6 @@
 //! Salt string support.
 
-use crate::{b64, errors::ParseError, ValueStr};
+use crate::{b64, errors::ParseError, Value};
 use core::{
     convert::{TryFrom, TryInto},
     fmt, str,
@@ -71,7 +71,7 @@ use core::{
 /// [2]: https://github.com/P-H-C/phc-string-format/blob/master/phc-sf-spec.md#function-duties
 /// [3]: https://github.com/P-H-C/phc-string-format/blob/master/phc-sf-spec.md#argon2-encoding
 #[derive(Copy, Clone, Eq, PartialEq)]
-pub struct Salt<'a>(ValueStr<'a>);
+pub struct Salt<'a>(Value<'a>);
 
 impl<'a> Salt<'a> {
     /// Minimum length of a [`Salt`] string: 2-bytes.
@@ -86,7 +86,7 @@ impl<'a> Salt<'a> {
     ///
     /// See type-level documentation about [`Salt`] for more information.
     pub const fn max_len() -> usize {
-        ValueStr::max_len()
+        Value::max_len()
     }
 
     /// Recommended length of a salt: 16-bytes.

--- a/password-hash/tests/encoding.rs
+++ b/password-hash/tests/encoding.rs
@@ -7,7 +7,7 @@
 #![cfg(feature = "registry")]
 
 use core::convert::TryInto;
-use password_hash::{algorithm::argon2, Algorithm, ParamsBuf, PasswordHash};
+use password_hash::{algorithm::argon2, Algorithm, ParamsString, PasswordHash};
 
 const EXAMPLE_ALGORITHM: Algorithm = Algorithm::Argon2(argon2::Variant::D);
 const EXAMPLE_SALT: &[u8] = &[
@@ -19,8 +19,8 @@ const EXAMPLE_HASH: &[u8] = &[
 ];
 
 /// Example parameters
-fn example_params() -> ParamsBuf {
-    ParamsBuf::from_slice(&[
+fn example_params() -> ParamsString {
+    ParamsString::from_pairs(&[
         ("a".parse().unwrap(), 1u32.into()),
         ("b".parse().unwrap(), 2u32.into()),
         ("c".parse().unwrap(), 3u32.into()),
@@ -59,7 +59,7 @@ fn params() {
 fn salt() {
     let ph = PasswordHash {
         algorithm: EXAMPLE_ALGORITHM,
-        params: ParamsBuf::new(),
+        params: ParamsString::new(),
         salt: Some(EXAMPLE_SALT.try_into().unwrap()),
         hash: None,
     };
@@ -73,7 +73,7 @@ fn salt() {
 
 #[test]
 fn one_param_and_salt() {
-    let params = ParamsBuf::from_slice(&[("a".parse().unwrap(), 1u32.into())]).unwrap();
+    let params = ParamsString::from_pairs(&[("a".parse().unwrap(), 1u32.into())]).unwrap();
 
     let ph = PasswordHash {
         algorithm: EXAMPLE_ALGORITHM,
@@ -109,7 +109,7 @@ fn params_and_salt() {
 fn salt_and_hash() {
     let ph = PasswordHash {
         algorithm: EXAMPLE_ALGORITHM,
-        params: ParamsBuf::default(),
+        params: ParamsString::default(),
         salt: Some(EXAMPLE_SALT.try_into().unwrap()),
         hash: Some(EXAMPLE_HASH.try_into().unwrap()),
     };

--- a/password-hash/tests/hashing.rs
+++ b/password-hash/tests/hashing.rs
@@ -1,7 +1,7 @@
 //! Password hashing tests
 
 pub use password_hash::{
-    HasherError, Ident, Output, ParamsBuf, PasswordHash, PasswordHasher, Salt, VerifyError,
+    HasherError, Ident, Output, ParamsString, PasswordHash, PasswordHasher, Salt, VerifyError,
 };
 use std::convert::{TryFrom, TryInto};
 
@@ -45,18 +45,18 @@ impl PasswordHasher for StubPasswordHasher {
 }
 
 /// Stub parameters
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct StubParams;
 
-impl<'a> TryFrom<&'a ParamsBuf<'a>> for StubParams {
+impl<'a> TryFrom<&'a ParamsString> for StubParams {
     type Error = HasherError;
 
-    fn try_from(_: &'a ParamsBuf<'a>) -> Result<Self, HasherError> {
+    fn try_from(_: &'a ParamsString) -> Result<Self, HasherError> {
         Ok(Self)
     }
 }
 
-impl<'a> TryFrom<StubParams> for ParamsBuf<'a> {
+impl<'a> TryFrom<StubParams> for ParamsString {
     type Error = HasherError;
 
     fn try_from(_: StubParams) -> Result<Self, HasherError> {
@@ -68,7 +68,7 @@ impl<'a> TryFrom<StubParams> for ParamsBuf<'a> {
 fn verify_password_hash() {
     let valid_password = "test password";
     let salt = Salt::new("test-salt").unwrap();
-    let params = ParamsBuf::new();
+    let params = ParamsString::new();
     let hash = PasswordHash::generate(StubPasswordHasher, valid_password, salt, &params).unwrap();
 
     // Sanity tests for StubFunction impl above

--- a/password-hash/tests/test_vectors.rs
+++ b/password-hash/tests/test_vectors.rs
@@ -13,10 +13,10 @@ fn argon2id() {
     let ph = PasswordHash::new(ARGON2D_HASH).unwrap();
     assert_eq!(ph.algorithm, Ident::new("argon2d"));
     assert_eq!(ph.version, Some(19));
-    assert_eq!(ph.params.len(), 3);
-    assert_eq!(ph.params["m"].decimal().unwrap(), 512);
-    assert_eq!(ph.params["t"].decimal().unwrap(), 3);
-    assert_eq!(ph.params["p"].decimal().unwrap(), 2);
+    assert_eq!(ph.params.iter().count(), 3);
+    assert_eq!(ph.params.get_decimal("m").unwrap(), 512);
+    assert_eq!(ph.params.get_decimal("t").unwrap(), 3);
+    assert_eq!(ph.params.get_decimal("p").unwrap(), 2);
     assert_eq!(ph.salt.unwrap().as_ref(), "5VtWOO3cGWYQHEMaYGbsfQ");
     assert_eq!(ph.hash.unwrap().to_string(), "AcmqasQgW/wI6wAHAMk4aQ");
     assert_eq!(ph.to_string(), ARGON2D_HASH);


### PR DESCRIPTION
Replaces a structured type with a builder for params strings which can also parse the in-place via an iterator.

The previous implementation had a size of 320(!) bytes despite the fact all of the string data was borrowed. It's considerably more efficient to have a buffer type that can build the parameter string which is internally stored as a byte array.

The new implementation uses a 127-byte array with a 1-byte length for a struct which is a total of 128-bytes.

This length was picked in part by adding headroom to a maximally long Argon2 params string, which looks roughly like this:

```
m=4294967296,t=4294967296,keyid=XXXXXXXXXXX,data=XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
```

This string contains all Argon2 parameters at maximum length which comes to a total of 92-bytes, which means 127 provides 35 bytes of headroom.

The implementation is written in such a way that it should be easy to swap out a `String` for backing storage when the `alloc` feature is enabled, if it turns out the 128-byte size is suboptimal.