### PR TITLE
elliptic-curve: remove direct `bitvec` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -179,7 +179,6 @@ name = "elliptic-curve"
 version = "0.9.0-pre"
 dependencies = [
  "b64ct",
- "bitvec",
  "digest 0.9.0",
  "ff",
  "generic-array 0.14.4",

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -16,7 +16,6 @@ keywords   = ["crypto", "ecc", "elliptic", "weierstrass"]
 
 [dependencies]
 b64ct = { version = "0.2", optional = true, default-features = false }
-bitvec = { version = "0.20", optional = true, default-features = false }
 digest = { version = "0.9", optional = true }
 ff = { version = "0.9", optional = true, default-features = false }
 group = { version = "0.9", optional = true, default-features = false }
@@ -34,7 +33,7 @@ hex-literal = "0.3"
 [features]
 default = ["arithmetic"]
 alloc = []
-arithmetic = ["bitvec", "ff", "group"]
+arithmetic = ["ff", "group"]
 dev = ["arithmetic", "digest", "pem", "zeroize"]
 ecdh = ["arithmetic", "zeroize"]
 jwk = ["alloc", "b64ct/alloc", "serde", "serde_json", "zeroize/alloc"]

--- a/elliptic-curve/src/scalar.rs
+++ b/elliptic-curve/src/scalar.rs
@@ -5,9 +5,8 @@ use crate::{
     rand_core::{CryptoRng, RngCore},
     Curve, Error, FieldBytes, ProjectiveArithmetic,
 };
-use bitvec::{array::BitArray, order::Lsb0};
 use core::{convert::TryFrom, ops::Deref};
-use ff::{Field, PrimeField};
+use ff::{Field, FieldBits, PrimeField};
 use generic_array::{typenum::Unsigned, GenericArray};
 use group::Group;
 use subtle::{Choice, ConditionallySelectable, CtOption};
@@ -19,7 +18,7 @@ use zeroize::Zeroize;
 pub type Scalar<C> = <<C as ProjectiveArithmetic>::ProjectivePoint as Group>::Scalar;
 
 /// Bit representation of a scalar field element of a given curve.
-pub type ScalarBits<C> = BitArray<Lsb0, <Scalar<C> as PrimeField>::ReprBits>;
+pub type ScalarBits<C> = FieldBits<<Scalar<C> as PrimeField>::ReprBits>;
 
 /// Non-zero scalar type.
 ///


### PR DESCRIPTION
Now that zkcrypto/ff#40 is merged, the `ff` crate re-exports the types from `bitvec` that we previously needed to import directly.

This means that `elliptic-curve` no-longer needs to depend on the `bitvec` crate directly, but instead we can use it only transitively via the `ff` crate.