### PR TITLE
elliptic-curve: add sec1::ValidatePublicKey trait

### DIFF
--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -19,6 +19,7 @@ b64ct = { version = "0.2", optional = true, default-features = false }
 digest = { version = "0.9", optional = true }
 ff = { version = "0.9", optional = true, default-features = false }
 group = { version = "0.9", optional = true, default-features = false }
+hex-literal = { version = "0.3", optional = true }
 generic-array = { version = "0.14", default-features = false }
 pkcs8 = { version = "0.4.0-pre", optional = true }
 rand_core = { version = "0.6", default-features = false }
@@ -34,7 +35,7 @@ hex-literal = "0.3"
 default = ["arithmetic"]
 alloc = []
 arithmetic = ["ff", "group"]
-dev = ["arithmetic", "digest", "pem", "zeroize"]
+dev = ["arithmetic", "digest", "hex-literal", "pem", "zeroize"]
 ecdh = ["arithmetic", "zeroize"]
 jwk = ["alloc", "b64ct/alloc", "serde", "serde_json", "zeroize/alloc"]
 pem = ["alloc", "pkcs8/pem"]


### PR DESCRIPTION
Adds a trait for validating that a given encoded point is correct for a given secret value.

This allows the PKCS#8 and JWK key format parsers to validate that the public key contained in a given keypair matches the corresponding private key.