### PR TITLE
elliptic-curve: factor out `hazmat`; flatten API

### DIFF
--- a/.github/workflows/elliptic-curve.yml
+++ b/.github/workflows/elliptic-curve.yml
@@ -39,11 +39,12 @@ jobs:
       - run: cargo build --no-default-features --release --target ${{ matrix.target }} --features arithmetic
       - run: cargo build --no-default-features --release --target ${{ matrix.target }} --features dev
       - run: cargo build --no-default-features --release --target ${{ matrix.target }} --features ecdh
+      - run: cargo build --no-default-features --release --target ${{ matrix.target }} --features hazmat
       - run: cargo build --no-default-features --release --target ${{ matrix.target }} --features jwk
       - run: cargo build --no-default-features --release --target ${{ matrix.target }} --features pem
       - run: cargo build --no-default-features --release --target ${{ matrix.target }} --features pkcs8
       - run: cargo build --no-default-features --release --target ${{ matrix.target }} --features zeroize
-      - run: cargo build --no-default-features --release --target ${{ matrix.target }} --features pem,zeroize
+      - run: cargo build --no-default-features --release --target ${{ matrix.target }} --features ecdh,hazmat,jwk,pem
   test:
     runs-on: ubuntu-latest
     strategy:

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -37,10 +37,11 @@ alloc = []
 arithmetic = ["ff", "group"]
 dev = ["arithmetic", "digest", "hex-literal", "pem", "zeroize"]
 ecdh = ["arithmetic", "zeroize"]
+hazmat = []
 jwk = ["alloc", "b64ct/alloc", "serde", "serde_json", "zeroize/alloc"]
 pem = ["alloc", "pkcs8/pem"]
 std = ["alloc"]
 
 [package.metadata.docs.rs]
-all-features = true
+features = ["arithmetic", "ecdh", "jwk", "pem", "std"]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/elliptic-curve/src/ecdh.rs
+++ b/elliptic-curve/src/ecdh.rs
@@ -62,9 +62,9 @@ pub fn diffie_hellman<C>(
 ) -> SharedSecret<C>
 where
     C: Curve + ProjectiveArithmetic,
-    Scalar<C>: PrimeField<Repr = FieldBytes<C>> + Clone + Zeroize,
     AffinePoint<C>: Copy + Clone + Debug + Zeroize,
     ProjectivePoint<C>: From<AffinePoint<C>>,
+    Scalar<C>: PrimeField<Repr = FieldBytes<C>> + Clone + Zeroize,
     SharedSecret<C>: for<'a> From<&'a AffinePoint<C>>,
 {
     let public_point = ProjectivePoint::<C>::from(*public_key.borrow());
@@ -106,9 +106,9 @@ where
 impl<C> EphemeralSecret<C>
 where
     C: Curve + ProjectiveArithmetic,
-    Scalar<C>: PrimeField<Repr = FieldBytes<C>> + Clone + Zeroize,
     AffinePoint<C>: Copy + Clone + Debug + Zeroize,
     ProjectivePoint<C>: From<AffinePoint<C>>,
+    Scalar<C>: PrimeField<Repr = FieldBytes<C>> + Clone + Zeroize,
     SharedSecret<C>: for<'a> From<&'a AffinePoint<C>>,
 {
     /// Generate a cryptographically random [`EphemeralSecret`].
@@ -135,9 +135,9 @@ where
 impl<C> From<&EphemeralSecret<C>> for PublicKey<C>
 where
     C: Curve + ProjectiveArithmetic,
-    Scalar<C>: PrimeField<Repr = FieldBytes<C>> + Clone + Zeroize,
     AffinePoint<C>: Copy + Clone + Debug + Zeroize,
     ProjectivePoint<C>: From<AffinePoint<C>>,
+    Scalar<C>: PrimeField<Repr = FieldBytes<C>> + Clone + Zeroize,
     SharedSecret<C>: for<'a> From<&'a AffinePoint<C>>,
 {
     fn from(ephemeral_secret: &EphemeralSecret<C>) -> Self {

--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -25,21 +25,18 @@ extern crate alloc;
 #[cfg(feature = "std")]
 extern crate std;
 
-pub mod error;
+mod error;
 pub mod ops;
 pub mod sec1;
 pub mod util;
 pub mod weierstrass;
 
 #[cfg(feature = "arithmetic")]
-#[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
-pub mod point;
+mod point;
 #[cfg(feature = "arithmetic")]
-#[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
 mod public_key;
 #[cfg(feature = "arithmetic")]
-#[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
-pub mod scalar;
+mod scalar;
 
 #[cfg(feature = "dev")]
 #[cfg_attr(docsrs, doc(cfg(feature = "dev")))]
@@ -53,8 +50,7 @@ pub mod ecdh;
 mod jwk;
 
 #[cfg(feature = "zeroize")]
-#[cfg_attr(docsrs, doc(cfg(feature = "zeroize")))]
-pub mod secret_key;
+mod secret_key;
 
 pub use self::error::Error;
 
@@ -67,7 +63,7 @@ pub use {
     crate::{
         point::{AffinePoint, ProjectiveArithmetic, ProjectivePoint},
         public_key::PublicKey,
-        scalar::Scalar,
+        scalar::{NonZeroScalar, Scalar, ScalarBits},
     },
     ff::{self, BitView, Field},
     group::{self, Group},
@@ -75,6 +71,9 @@ pub use {
 
 #[cfg(feature = "digest")]
 pub use digest::{self, Digest};
+
+#[cfg(all(feature = "hazmat", feature = "zeroize"))]
+pub use secret_key::{SecretBytes, SecretValue};
 
 #[cfg(feature = "jwk")]
 pub use crate::jwk::{JwkEcKey, JwkParameters};

--- a/elliptic-curve/src/point.rs
+++ b/elliptic-curve/src/point.rs
@@ -3,6 +3,7 @@
 use crate::{Curve, FieldBytes, Scalar};
 
 /// Elliptic curve with projective arithmetic implementation.
+#[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
 pub trait ProjectiveArithmetic: Curve
 where
     Scalar<Self>: ff::PrimeField<Repr = FieldBytes<Self>>,
@@ -13,9 +14,11 @@ where
 
 /// Affine point type for a given curve with a [`ProjectiveArithmetic`]
 /// implementation.
+#[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
 pub type AffinePoint<C> =
     <<C as ProjectiveArithmetic>::ProjectivePoint as group::Curve>::AffineRepr;
 
 /// Projective point type for a given curve with a [`ProjectiveArithmetic`]
 /// implementation.
+#[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
 pub type ProjectivePoint<C> = <C as ProjectiveArithmetic>::ProjectivePoint;

--- a/elliptic-curve/src/public_key.rs
+++ b/elliptic-curve/src/public_key.rs
@@ -59,6 +59,7 @@ use alloc::string::{String, ToString};
 ///
 /// When the `pem` feature of this crate (or a specific RustCrypto elliptic
 /// curve crate) is enabled, a [`FromStr`] impl is also available.
+#[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
 #[derive(Clone, Debug)]
 pub struct PublicKey<C>
 where

--- a/elliptic-curve/src/scalar.rs
+++ b/elliptic-curve/src/scalar.rs
@@ -15,9 +15,11 @@ use subtle::{Choice, ConditionallySelectable, CtOption};
 use zeroize::Zeroize;
 
 /// Scalar field element for a particular elliptic curve.
+#[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
 pub type Scalar<C> = <<C as ProjectiveArithmetic>::ProjectivePoint as Group>::Scalar;
 
 /// Bit representation of a scalar field element of a given curve.
+#[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
 pub type ScalarBits<C> = FieldBits<<Scalar<C> as PrimeField>::ReprBits>;
 
 /// Non-zero scalar type.
@@ -28,6 +30,7 @@ pub type ScalarBits<C> = FieldBits<<Scalar<C> as PrimeField>::ReprBits>;
 ///
 /// In the context of ECC, it's useful for ensuring that scalar multiplication
 /// cannot result in the point at infinity.
+#[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
 #[derive(Clone)]
 pub struct NonZeroScalar<C>
 where

--- a/elliptic-curve/src/sec1.rs
+++ b/elliptic-curve/src/sec1.rs
@@ -173,8 +173,8 @@ where
     pub fn to_untagged_bytes(&self) -> Option<GenericArray<u8, UntaggedPointSize<C>>>
     where
         C: Curve + ProjectiveArithmetic,
-        Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
         AffinePoint<C>: ConditionallySelectable + Default + Decompress<C> + ToEncodedPoint<C>,
+        Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
     {
         self.decompress().map(|point| {
             let mut bytes = GenericArray::<u8, UntaggedPointSize<C>>::default();
@@ -466,10 +466,10 @@ impl From<Tag> for u8 {
 /// This is intended for use with the `AffinePoint` type for a given elliptic curve.
 pub trait FromEncodedPoint<C>
 where
+    Self: Sized,
     C: Curve,
     UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
     UncompressedPointSize<C>: ArrayLength<u8>,
-    Self: Sized,
 {
     /// Deserialize the type this trait is impl'd on from an [`EncodedPoint`].
     ///

--- a/elliptic-curve/src/secret_key.rs
+++ b/elliptic-curve/src/secret_key.rs
@@ -70,6 +70,7 @@ use {crate::pkcs8::FromPrivateKey, core::str::FromStr};
 ///
 /// When the `pem` feature of this crate (or a specific RustCrypto elliptic
 /// curve crate) is enabled, a [`FromStr`] impl is also available.
+#[cfg_attr(docsrs, doc(cfg(feature = "zeroize")))]
 #[derive(Clone)]
 pub struct SecretKey<C: Curve + SecretValue> {
     /// Secret value (i.e. secret scalar)
@@ -236,6 +237,8 @@ where
 }
 
 /// Inner value stored by a [`SecretKey`].
+#[cfg_attr(docsrs, doc(cfg(feature = "hazmat")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "zeroize")))]
 pub trait SecretValue: Curve {
     /// Inner secret value.
     ///
@@ -261,6 +264,7 @@ pub trait SecretValue: Curve {
 }
 
 #[cfg(feature = "arithmetic")]
+#[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
 impl<C> SecretValue for C
 where
     C: Curve + ProjectiveArithmetic,
@@ -276,6 +280,8 @@ where
 /// Newtype wrapper for [`FieldBytes`] which impls [`Zeroize`].
 ///
 /// This allows it to fulfill the [`Zeroize`] bound on [`SecretValue::Secret`].
+#[cfg_attr(docsrs, doc(cfg(feature = "hazmat")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "zeroize")))]
 #[derive(Clone)]
 pub struct SecretBytes<C: Curve>(FieldBytes<C>);
 


### PR DESCRIPTION
Flattens out the API, hiding nested modules except in places where they provide actual value.

Moves some of the more problematic/confusing traits under a `hazmat` feature intended for use by curve implementations only.