### PR TITLE
Use `base64ct` v0.1.0 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,6 +46,12 @@ version = "0.0.0"
 source = "git+https://github.com/RustCrypto/utils.git#0fe3e15b868778c92959f3fa03b62b47b6842f60"
 
 [[package]]
+name = "base64ct"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c502cbac2e4ffc38047434d0c88b54da5e7c76829ff16f0a479f90116336d9f3"
+
+[[package]]
 name = "bitvec"
 version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -175,7 +181,7 @@ dependencies = [
 name = "elliptic-curve"
 version = "0.9.0-pre"
 dependencies = [
- "base64ct",
+ "base64ct 0.1.0",
  "digest 0.9.0",
  "ff",
  "generic-array 0.14.4",
@@ -307,7 +313,7 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 name = "password-hash"
 version = "0.0.0"
 dependencies = [
- "base64ct",
+ "base64ct 0.1.0",
 ]
 
 [[package]]
@@ -315,7 +321,7 @@ name = "pkcs8"
 version = "0.4.0-pre"
 source = "git+https://github.com/RustCrypto/utils.git#0fe3e15b868778c92959f3fa03b62b47b6842f60"
 dependencies = [
- "base64ct",
+ "base64ct 0.0.0",
  "der",
  "zeroize",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,4 @@ members = [
 ]
 
 [patch.crates-io]
-base64ct = { git = "https://github.com/RustCrypto/utils.git" }
 pkcs8 = { git = "https://github.com/RustCrypto/utils.git" }

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["cryptography", "no-std"]
 keywords   = ["crypto", "ecc", "elliptic", "weierstrass"]
 
 [dependencies]
-base64ct = { version = "0", optional = true, default-features = false }
+base64ct = { version = "0.1", optional = true, default-features = false }
 digest = { version = "0.9", optional = true }
 ff = { version = "0.9", optional = true, default-features = false }
 group = { version = "0.9", optional = true, default-features = false }

--- a/password-hash/Cargo.toml
+++ b/password-hash/Cargo.toml
@@ -16,7 +16,7 @@ categories = ["cryptography", "no-std"]
 keywords = ["crypt", "mcf", "password", "pbkdf", "phc"]
 
 [dependencies]
-base64ct = "0"
+base64ct = "0.1"
 
 [features]
 alloc = ["base64ct/alloc"]

--- a/password-hash/src/errors.rs
+++ b/password-hash/src/errors.rs
@@ -1,6 +1,7 @@
 //! Error types.
 
-use crate::b64;
+pub use base64ct::Error as B64Error;
+
 use core::fmt;
 
 #[cfg(docsrs)]
@@ -60,7 +61,7 @@ pub enum HasherError {
     Algorithm,
 
     /// "B64" encoding error.
-    B64(b64::Error),
+    B64(B64Error),
 
     /// Cryptographic error.
     Crypto,
@@ -92,15 +93,15 @@ impl fmt::Display for HasherError {
     }
 }
 
-impl From<b64::Error> for HasherError {
-    fn from(err: b64::Error) -> HasherError {
+impl From<B64Error> for HasherError {
+    fn from(err: B64Error) -> HasherError {
         HasherError::B64(err)
     }
 }
 
-impl From<b64::InvalidLengthError> for HasherError {
-    fn from(_: b64::InvalidLengthError) -> HasherError {
-        HasherError::B64(b64::Error::InvalidLength)
+impl From<base64ct::InvalidLengthError> for HasherError {
+    fn from(_: base64ct::InvalidLengthError) -> HasherError {
+        HasherError::B64(B64Error::InvalidLength)
     }
 }
 
@@ -199,7 +200,7 @@ impl std::error::Error for ParseError {}
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum OutputError {
     /// "B64" encoding error.
-    B64(b64::Error),
+    B64(B64Error),
 
     /// Output too short (min 10-bytes).
     TooShort,
@@ -218,15 +219,15 @@ impl fmt::Display for OutputError {
     }
 }
 
-impl From<b64::Error> for OutputError {
-    fn from(err: b64::Error) -> OutputError {
+impl From<B64Error> for OutputError {
+    fn from(err: B64Error) -> OutputError {
         OutputError::B64(err)
     }
 }
 
-impl From<b64::InvalidLengthError> for OutputError {
-    fn from(_: b64::InvalidLengthError) -> OutputError {
-        OutputError::B64(b64::Error::InvalidLength)
+impl From<base64ct::InvalidLengthError> for OutputError {
+    fn from(_: base64ct::InvalidLengthError) -> OutputError {
+        OutputError::B64(B64Error::InvalidLength)
     }
 }
 

--- a/password-hash/src/lib.rs
+++ b/password-hash/src/lib.rs
@@ -58,7 +58,7 @@ pub use crate::{
     value::{Decimal, Value},
 };
 
-pub use base64ct as b64;
+pub use base64ct::unpadded as b64;
 
 use core::{
     convert::{TryFrom, TryInto},

--- a/password-hash/src/output.rs
+++ b/password-hash/src/output.rs
@@ -137,10 +137,6 @@ impl Output {
     /// Parse [`b64`]-encoded [`Output`], i.e. using the PHC string
     /// specification's restricted interpretation of Base64.
     pub fn b64_decode(input: &str) -> Result<Self, OutputError> {
-        if b64::decoded_len(input) > MAX_LENGTH {
-            return Err(OutputError::TooLong);
-        }
-
         let mut bytes = [0u8; MAX_LENGTH];
         b64::decode(input, &mut bytes)
             .map_err(Into::into)

--- a/password-hash/src/salt.rs
+++ b/password-hash/src/salt.rs
@@ -1,6 +1,9 @@
 //! Salt string support.
 
-use crate::{b64, errors::ParseError, Value};
+use crate::{
+    errors::{B64Error, ParseError},
+    Value,
+};
 use core::{
     convert::{TryFrom, TryInto},
     fmt, str,
@@ -114,7 +117,7 @@ impl<'a> Salt<'a> {
     /// buffer containing the decoded result on success.
     ///
     /// [1]: https://github.com/P-H-C/phc-string-format/blob/master/phc-sf-spec.md#argon2-encoding
-    pub fn b64_decode<'b>(&self, buf: &'b mut [u8]) -> Result<&'b [u8], b64::Error> {
+    pub fn b64_decode<'b>(&self, buf: &'b mut [u8]) -> Result<&'b [u8], B64Error> {
         self.0.b64_decode(buf)
     }
 

--- a/password-hash/src/value.rs
+++ b/password-hash/src/value.rs
@@ -13,7 +13,10 @@
 //!
 //! [1]: https://github.com/P-H-C/phc-string-format/blob/master/phc-sf-spec.md
 
-use crate::{b64, errors::ParseError};
+use crate::{
+    b64,
+    errors::{B64Error, ParseError},
+};
 use core::{convert::TryFrom, fmt, str};
 
 /// Maximum size of a parameter value in ASCII characters.
@@ -78,7 +81,7 @@ impl<'a> Value<'a> {
     /// PHC string format specification.
     ///
     /// [1]: https://github.com/P-H-C/phc-string-format/blob/master/phc-sf-spec.md#argon2-encoding
-    pub fn b64_decode<'b>(&self, buf: &'b mut [u8]) -> Result<&'b [u8], b64::Error> {
+    pub fn b64_decode<'b>(&self, buf: &'b mut [u8]) -> Result<&'b [u8], B64Error> {
         b64::decode(self.as_str(), buf)
     }
 


### PR DESCRIPTION
Includes Base64url support (needed by `elliptic-curve` for JWK)