### PR TITLE
password-hash: add SaltString type

### DIFF
--- a/.github/workflows/password-hash.yml
+++ b/.github/workflows/password-hash.yml
@@ -37,6 +37,7 @@ jobs:
           profile: minimal
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features alloc
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features rand_core
 
   test:
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -311,6 +311,7 @@ name = "password-hash"
 version = "0.0.0"
 dependencies = [
  "base64ct",
+ "rand_core",
 ]
 
 [[package]]

--- a/password-hash/Cargo.toml
+++ b/password-hash/Cargo.toml
@@ -17,6 +17,7 @@ keywords = ["crypt", "mcf", "password", "pbkdf", "phc"]
 
 [dependencies]
 base64ct = "0.1"
+rand_core = { version = "0.6", optional = true, default-features = false }
 
 [features]
 alloc = ["base64ct/alloc"]

--- a/password-hash/src/lib.rs
+++ b/password-hash/src/lib.rs
@@ -41,8 +41,7 @@ extern crate alloc;
 #[cfg(feature = "std")]
 extern crate std;
 
-pub mod errors;
-
+mod errors;
 mod ident;
 mod output;
 mod params;
@@ -50,11 +49,11 @@ mod salt;
 mod value;
 
 pub use crate::{
-    errors::{HashError, HasherError, VerifyError},
+    errors::{B64Error, HashError, HasherError, OutputError, ParamsError, ParseError, VerifyError},
     ident::Ident,
     output::Output,
     params::ParamsString,
-    salt::Salt,
+    salt::{Salt, SaltString},
     value::{Decimal, Value},
 };
 
@@ -239,8 +238,6 @@ pub struct PasswordHash<'a> {
 impl<'a> PasswordHash<'a> {
     /// Parse a password hash from a string in the PHC string format.
     pub fn new(s: &'a str) -> Result<Self, HashError> {
-        use errors::ParseError;
-
         if s.is_empty() {
             return Err(ParseError::Empty.into());
         }


### PR DESCRIPTION
Add an owned stack-allocated string type for salts, which supports B64 encoding/decoding as well as random generation using rand_core's `CryptoRng`+`RngCore`.