### PR TITLE
digest: variable output traits

### DIFF
--- a/digest/src/core_api.rs
+++ b/digest/src/core_api.rs
@@ -12,8 +12,8 @@ mod rt_variable;
 mod update;
 mod xof_reader;
 
-pub use ct_variable::CtVariableWrapper;
-pub use rt_variable::VariableCoreWrapper;
+pub use ct_variable::CtVariableCoreWrapper;
+pub use rt_variable::RtVariableCoreWrapper;
 pub use update::UpdateCoreWrapper;
 pub use xof_reader::XofReaderCoreWrapper;
 

--- a/digest/src/core_api.rs
+++ b/digest/src/core_api.rs
@@ -1,13 +1,21 @@
-use crate::{ExtendableOutput, FixedOutput, Reset, Update, XofReader};
-use block_buffer::BlockBuffer;
+//! Low-level core API traits.
+//!
+//! Usage of traits in this module in user code is discouraged. Instead use
+//! core algorithm wrapped by the wrapper types, which implement the
+//! higher-level traits.
+use crate::InvalidOutputSize;
 use core::fmt;
 use generic_array::{ArrayLength, GenericArray};
 
-/// Trait which stores algorithm name constant, used in `Debug` implementations.
-pub trait AlgorithmName {
-    /// Algorithm name.
-    const NAME: &'static str;
-}
+mod ct_variable;
+mod rt_variable;
+mod update;
+mod xof_reader;
+
+pub use ct_variable::CtVariableWrapper;
+pub use rt_variable::VariableCoreWrapper;
+pub use update::UpdateCoreWrapper;
+pub use xof_reader::XofReaderCoreWrapper;
 
 /// Trait for updating hasher state with input data divided into blocks.
 pub trait UpdateCore {
@@ -18,12 +26,7 @@ pub trait UpdateCore {
     fn update_blocks(&mut self, blocks: &[GenericArray<u8, Self::BlockSize>]);
 }
 
-/// Trait for fixed-output digest implementations to use to retrieve the
-/// hash output.
-///
-/// Usage of this trait in user code is discouraged. Instead use core algorithm
-/// wrapped by [`BlockBufferWrapper`], which implements the [`FixedOutput`]
-/// trait.
+/// Core trait for hash functions with fixed output size.
 pub trait FixedOutputCore: UpdateCore {
     /// Digest output size in bytes.
     type OutputSize: ArrayLength<u8>;
@@ -37,12 +40,7 @@ pub trait FixedOutputCore: UpdateCore {
     );
 }
 
-/// Trait for extendable-output function (XOF) core implementations to use to
-/// retrieve the hash output.
-///
-/// Usage of this trait in user code is discouraged. Instead use core algorithm
-/// wrapped by [`BlockBufferWrapper`], which implements the
-/// [`ExtendableOutput`] trait.
+/// Core trait for hash functions with extendable (XOF) output size.
 pub trait ExtendableOutputCore: UpdateCore {
     /// XOF reader core state.
     type ReaderCore: XofReaderCore;
@@ -64,123 +62,30 @@ pub trait XofReaderCore {
     fn read_block(&mut self) -> GenericArray<u8, Self::BlockSize>;
 }
 
-/// Wrapper around [`UpdateCore`] implementations.
-///
-/// It handles data buffering and implements the mid-level traits.
-#[derive(Clone, Default)]
-pub struct UpdateCoreWrapper<T: UpdateCore> {
-    core: T,
-    buffer: BlockBuffer<T::BlockSize>,
+/// Core trait for hash functions with variable output size.
+pub trait VariableOutputCore: UpdateCore + Sized {
+    /// Maximum output size.
+    type MaxOutputSize: ArrayLength<u8>;
+
+    /// Initialize hasher state for given output size.
+    ///
+    /// Returns [`InvalidOutputSize`] if `output_size` is equal to zero or
+    /// bigger than `Self::MaxOutputSize`.
+    fn new(output_size: usize) -> Result<Self, InvalidOutputSize>;
+
+    /// Finalize hasher and return result of lenght `output_size` via closure `f`.
+    ///
+    /// `output_size` must be equal to `output_size` used during construction.
+    fn finalize_variable_core(
+        &mut self,
+        buffer: &mut block_buffer::BlockBuffer<Self::BlockSize>,
+        output_size: usize,
+        f: impl FnOnce(&[u8]),
+    );
 }
 
-/// Wrapper around [`XofReaderCore`] implementations.
-///
-/// It handles data buffering and implements the mid-level traits.
-#[derive(Clone, Default)]
-pub struct XofReaderCoreWrapper<T: XofReaderCore> {
-    core: T,
-    buffer: BlockBuffer<T::BlockSize>,
-}
-
-impl<T: UpdateCore + AlgorithmName> fmt::Debug for UpdateCoreWrapper<T> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        f.write_str(T::NAME)?;
-        f.write_str(" { .. }")
-    }
-}
-
-impl<T: XofReaderCore + AlgorithmName> fmt::Debug for XofReaderCoreWrapper<T> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        f.write_str(T::NAME)?;
-        f.write_str(" { .. }")
-    }
-}
-
-impl<D: Default + UpdateCore> Reset for UpdateCoreWrapper<D> {
-    #[inline]
-    fn reset(&mut self) {
-        self.core = Default::default();
-        self.buffer.reset();
-    }
-}
-
-impl<D: UpdateCore> Update for UpdateCoreWrapper<D> {
-    #[inline]
-    fn update(&mut self, input: &[u8]) {
-        let Self { core, buffer } = self;
-        buffer.digest_blocks(input, |blocks| core.update_blocks(blocks));
-    }
-}
-
-impl<D: FixedOutputCore + Default> FixedOutput for UpdateCoreWrapper<D> {
-    type OutputSize = D::OutputSize;
-
-    #[inline]
-    fn finalize_into(mut self, out: &mut GenericArray<u8, Self::OutputSize>) {
-        let Self { core, buffer } = &mut self;
-        core.finalize_fixed_core(buffer, out);
-    }
-
-    #[inline]
-    fn finalize_into_reset(&mut self, out: &mut GenericArray<u8, Self::OutputSize>) {
-        let Self { core, buffer } = self;
-        core.finalize_fixed_core(buffer, out);
-        self.reset();
-    }
-}
-
-impl<R: XofReaderCore> XofReader for XofReaderCoreWrapper<R> {
-    #[inline]
-    fn read(&mut self, buffer: &mut [u8]) {
-        let Self { core, buffer: buf } = self;
-        buf.set_data(buffer, || core.read_block());
-    }
-}
-
-impl<D: ExtendableOutputCore + Default> ExtendableOutput for UpdateCoreWrapper<D> {
-    type Reader = XofReaderCoreWrapper<D::ReaderCore>;
-
-    #[inline]
-    fn finalize_xof(mut self) -> Self::Reader {
-        let Self { core, buffer } = &mut self;
-        let reader_core = core.finalize_xof_core(buffer);
-        XofReaderCoreWrapper {
-            core: reader_core,
-            buffer: Default::default(),
-        }
-    }
-
-    #[inline]
-    fn finalize_xof_reset(&mut self) -> Self::Reader {
-        let Self { core, buffer } = self;
-        let reader_core = core.finalize_xof_core(buffer);
-        self.reset();
-        XofReaderCoreWrapper {
-            core: reader_core,
-            buffer: Default::default(),
-        }
-    }
-}
-
-#[cfg(feature = "std")]
-impl<D: UpdateCore> std::io::Write for UpdateCoreWrapper<D> {
-    #[inline]
-    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        Update::update(self, buf);
-        Ok(buf.len())
-    }
-
-    #[inline]
-    fn flush(&mut self) -> std::io::Result<()> {
-        Ok(())
-    }
-}
-
-#[cfg(feature = "std")]
-impl<R: XofReaderCore> std::io::Read for XofReaderCoreWrapper<R> {
-    #[inline]
-    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
-        XofReader::read(self, buf);
-        Ok(buf.len())
-    }
+/// Trait which stores algorithm name constant, used in `Debug` implementations.
+pub trait AlgorithmName {
+    /// Write algorithm name into `f`.
+    fn write_alg_name(f: &mut fmt::Formatter<'_>) -> fmt::Result;
 }

--- a/digest/src/core_api/ct_variable.rs
+++ b/digest/src/core_api/ct_variable.rs
@@ -1,0 +1,74 @@
+use super::{AlgorithmName, FixedOutputCore, UpdateCore, VariableOutputCore};
+use block_buffer::BlockBuffer;
+use core::{fmt, marker::PhantomData};
+use generic_array::typenum::type_operators::IsLessOrEqual;
+use generic_array::{ArrayLength, GenericArray};
+
+/// Wrapper around [`VariableOutputCore`] which selects output size
+/// at compile time.
+#[derive(Clone)]
+pub struct CtVariableWrapper<T, OutSize>
+where
+    T: VariableOutputCore,
+    OutSize: ArrayLength<u8> + IsLessOrEqual<T::MaxOutputSize>,
+{
+    inner: T,
+    _out: PhantomData<OutSize>,
+}
+
+impl<T, OutSize> UpdateCore for CtVariableWrapper<T, OutSize>
+where
+    T: VariableOutputCore,
+    OutSize: ArrayLength<u8> + IsLessOrEqual<T::MaxOutputSize>,
+{
+    type BlockSize = T::BlockSize;
+
+    #[inline]
+    fn update_blocks(&mut self, blocks: &[GenericArray<u8, Self::BlockSize>]) {
+        self.inner.update_blocks(blocks);
+    }
+}
+
+impl<T, OutSize> FixedOutputCore for CtVariableWrapper<T, OutSize>
+where
+    T: VariableOutputCore,
+    OutSize: ArrayLength<u8> + IsLessOrEqual<T::MaxOutputSize>,
+{
+    type OutputSize = OutSize;
+
+    #[inline]
+    fn finalize_fixed_core(
+        &mut self,
+        buffer: &mut BlockBuffer<Self::BlockSize>,
+        out: &mut GenericArray<u8, Self::OutputSize>,
+    ) {
+        self.inner
+            .finalize_variable_core(buffer, out.len(), |r| out.copy_from_slice(r));
+    }
+}
+
+impl<T, OutSize> Default for CtVariableWrapper<T, OutSize>
+where
+    T: VariableOutputCore,
+    OutSize: ArrayLength<u8> + IsLessOrEqual<T::MaxOutputSize>,
+{
+    #[inline]
+    fn default() -> Self {
+        Self {
+            inner: T::new(OutSize::USIZE).unwrap(),
+            _out: Default::default(),
+        }
+    }
+}
+
+impl<T, OutSize> AlgorithmName for CtVariableWrapper<T, OutSize>
+where
+    T: VariableOutputCore + AlgorithmName,
+    OutSize: ArrayLength<u8> + IsLessOrEqual<T::MaxOutputSize>,
+{
+    fn write_alg_name(f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        T::write_alg_name(f)?;
+        f.write_str("_")?;
+        write!(f, "{}", OutSize::USIZE)
+    }
+}

--- a/digest/src/core_api/ct_variable.rs
+++ b/digest/src/core_api/ct_variable.rs
@@ -1,8 +1,10 @@
 use super::{AlgorithmName, FixedOutputCore, UpdateCore, VariableOutputCore};
 use block_buffer::BlockBuffer;
 use core::{fmt, marker::PhantomData};
-use generic_array::typenum::type_operators::IsLessOrEqual;
-use generic_array::{ArrayLength, GenericArray};
+use generic_array::{
+    typenum::{IsLessOrEqual, LeEq, NonZero},
+    ArrayLength, GenericArray,
+};
 
 /// Wrapper around [`VariableOutputCore`] which selects output size
 /// at compile time.
@@ -11,6 +13,7 @@ pub struct CtVariableCoreWrapper<T, OutSize>
 where
     T: VariableOutputCore,
     OutSize: ArrayLength<u8> + IsLessOrEqual<T::MaxOutputSize>,
+    LeEq<OutSize, T::MaxOutputSize>: NonZero,
 {
     inner: T,
     _out: PhantomData<OutSize>,
@@ -20,6 +23,7 @@ impl<T, OutSize> UpdateCore for CtVariableCoreWrapper<T, OutSize>
 where
     T: VariableOutputCore,
     OutSize: ArrayLength<u8> + IsLessOrEqual<T::MaxOutputSize>,
+    LeEq<OutSize, T::MaxOutputSize>: NonZero,
 {
     type BlockSize = T::BlockSize;
 
@@ -33,6 +37,7 @@ impl<T, OutSize> FixedOutputCore for CtVariableCoreWrapper<T, OutSize>
 where
     T: VariableOutputCore,
     OutSize: ArrayLength<u8> + IsLessOrEqual<T::MaxOutputSize>,
+    LeEq<OutSize, T::MaxOutputSize>: NonZero,
 {
     type OutputSize = OutSize;
 
@@ -51,6 +56,7 @@ impl<T, OutSize> Default for CtVariableCoreWrapper<T, OutSize>
 where
     T: VariableOutputCore,
     OutSize: ArrayLength<u8> + IsLessOrEqual<T::MaxOutputSize>,
+    LeEq<OutSize, T::MaxOutputSize>: NonZero,
 {
     #[inline]
     fn default() -> Self {
@@ -65,6 +71,7 @@ impl<T, OutSize> AlgorithmName for CtVariableCoreWrapper<T, OutSize>
 where
     T: VariableOutputCore + AlgorithmName,
     OutSize: ArrayLength<u8> + IsLessOrEqual<T::MaxOutputSize>,
+    LeEq<OutSize, T::MaxOutputSize>: NonZero,
 {
     fn write_alg_name(f: &mut fmt::Formatter<'_>) -> fmt::Result {
         T::write_alg_name(f)?;

--- a/digest/src/core_api/ct_variable.rs
+++ b/digest/src/core_api/ct_variable.rs
@@ -7,7 +7,7 @@ use generic_array::{ArrayLength, GenericArray};
 /// Wrapper around [`VariableOutputCore`] which selects output size
 /// at compile time.
 #[derive(Clone)]
-pub struct CtVariableWrapper<T, OutSize>
+pub struct CtVariableCoreWrapper<T, OutSize>
 where
     T: VariableOutputCore,
     OutSize: ArrayLength<u8> + IsLessOrEqual<T::MaxOutputSize>,
@@ -16,7 +16,7 @@ where
     _out: PhantomData<OutSize>,
 }
 
-impl<T, OutSize> UpdateCore for CtVariableWrapper<T, OutSize>
+impl<T, OutSize> UpdateCore for CtVariableCoreWrapper<T, OutSize>
 where
     T: VariableOutputCore,
     OutSize: ArrayLength<u8> + IsLessOrEqual<T::MaxOutputSize>,
@@ -29,7 +29,7 @@ where
     }
 }
 
-impl<T, OutSize> FixedOutputCore for CtVariableWrapper<T, OutSize>
+impl<T, OutSize> FixedOutputCore for CtVariableCoreWrapper<T, OutSize>
 where
     T: VariableOutputCore,
     OutSize: ArrayLength<u8> + IsLessOrEqual<T::MaxOutputSize>,
@@ -47,7 +47,7 @@ where
     }
 }
 
-impl<T, OutSize> Default for CtVariableWrapper<T, OutSize>
+impl<T, OutSize> Default for CtVariableCoreWrapper<T, OutSize>
 where
     T: VariableOutputCore,
     OutSize: ArrayLength<u8> + IsLessOrEqual<T::MaxOutputSize>,
@@ -61,7 +61,7 @@ where
     }
 }
 
-impl<T, OutSize> AlgorithmName for CtVariableWrapper<T, OutSize>
+impl<T, OutSize> AlgorithmName for CtVariableCoreWrapper<T, OutSize>
 where
     T: VariableOutputCore + AlgorithmName,
     OutSize: ArrayLength<u8> + IsLessOrEqual<T::MaxOutputSize>,

--- a/digest/src/core_api/rt_variable.rs
+++ b/digest/src/core_api/rt_variable.rs
@@ -1,8 +1,8 @@
 use super::{AlgorithmName, VariableOutputCore};
 use crate::{InvalidOutputSize, VariableOutput};
 use block_buffer::BlockBuffer;
-use generic_array::typenum::Unsigned;
 use core::fmt;
+use generic_array::typenum::Unsigned;
 
 /// Wrapper around [`VariableOutputCore`] which selects output size
 /// at run time.

--- a/digest/src/core_api/rt_variable.rs
+++ b/digest/src/core_api/rt_variable.rs
@@ -1,5 +1,5 @@
-use super::{AlgorithmName, VariableOutputCore};
-use crate::{InvalidOutputSize, VariableOutput};
+use super::{AlgorithmName, UpdateCore, VariableOutputCore};
+use crate::{InvalidOutputSize, Reset, Update, VariableOutput};
 use block_buffer::BlockBuffer;
 use core::fmt;
 use generic_array::typenum::Unsigned;
@@ -7,13 +7,47 @@ use generic_array::typenum::Unsigned;
 /// Wrapper around [`VariableOutputCore`] which selects output size
 /// at run time.
 #[derive(Clone)]
-pub struct RtVariableCoreWrapper<T: VariableOutputCore> {
+pub struct RtVariableCoreWrapper<T>
+where
+    T: VariableOutputCore + UpdateCore,
+{
     core: T,
     buffer: BlockBuffer<T::BlockSize>,
     output_size: usize,
 }
 
-impl<T: VariableOutputCore> VariableOutput for RtVariableCoreWrapper<T> {
+impl<T> Reset for RtVariableCoreWrapper<T>
+where
+    T: VariableOutputCore + UpdateCore,
+{
+    #[inline]
+    fn reset(&mut self) {
+        // For correct implementations `new` should always return `Ok`
+        // since wrapper can be only created with valid `output_size`
+        if let Ok(v) = T::new(self.output_size) {
+            self.core = v;
+        } else {
+            debug_assert!(false);
+        }
+        self.buffer.reset();
+    }
+}
+
+impl<T> Update for RtVariableCoreWrapper<T>
+where
+    T: VariableOutputCore + UpdateCore,
+{
+    #[inline]
+    fn update(&mut self, input: &[u8]) {
+        let Self { core, buffer, .. } = self;
+        buffer.digest_blocks(input, |blocks| core.update_blocks(blocks));
+    }
+}
+
+impl<T> VariableOutput for RtVariableCoreWrapper<T>
+where
+    T: VariableOutputCore + UpdateCore,
+{
     const MAX_OUTPUT_SIZE: usize = T::MaxOutputSize::USIZE;
 
     fn new(output_size: usize) -> Result<Self, InvalidOutputSize> {
@@ -45,20 +79,34 @@ impl<T: VariableOutputCore> VariableOutput for RtVariableCoreWrapper<T> {
             output_size,
         } = self;
         core.finalize_variable_core(buffer, *output_size, f);
-        buffer.reset();
-        // For correct implementations `new` should always return `Ok`
-        // since we have already verified that `output_size` lies in a valid range.
-        if let Ok(v) = T::new(*output_size) {
-            *core = v;
-        } else {
-            debug_assert!(false);
-        }
+        self.reset()
     }
 }
 
-impl<T: VariableOutputCore + AlgorithmName> fmt::Debug for RtVariableCoreWrapper<T> {
+impl<T> fmt::Debug for RtVariableCoreWrapper<T>
+where
+    T: VariableOutputCore + UpdateCore + AlgorithmName,
+{
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         T::write_alg_name(f)?;
         f.write_str(" { .. }")
+    }
+}
+
+#[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+impl<T> std::io::Write for RtVariableCoreWrapper<T>
+where
+    T: VariableOutputCore + UpdateCore,
+{
+    #[inline]
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        Update::update(self, buf);
+        Ok(buf.len())
+    }
+
+    #[inline]
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
     }
 }

--- a/digest/src/core_api/rt_variable.rs
+++ b/digest/src/core_api/rt_variable.rs
@@ -1,6 +1,7 @@
 use super::{AlgorithmName, VariableOutputCore};
 use crate::{InvalidOutputSize, VariableOutput};
 use block_buffer::BlockBuffer;
+use generic_array::typenum::Unsigned;
 use core::fmt;
 
 /// Wrapper around [`VariableOutputCore`] which selects output size
@@ -13,6 +14,8 @@ pub struct RtVariableCoreWrapper<T: VariableOutputCore> {
 }
 
 impl<T: VariableOutputCore> VariableOutput for RtVariableCoreWrapper<T> {
+    const MAX_OUTPUT_SIZE: usize = T::MaxOutputSize::USIZE;
+
     fn new(output_size: usize) -> Result<Self, InvalidOutputSize> {
         let buffer = Default::default();
         T::new(output_size).map(|core| Self {

--- a/digest/src/core_api/rt_variable.rs
+++ b/digest/src/core_api/rt_variable.rs
@@ -6,13 +6,13 @@ use core::fmt;
 /// Wrapper around [`VariableOutputCore`] which selects output size
 /// at run time.
 #[derive(Clone)]
-pub struct VariableCoreWrapper<T: VariableOutputCore> {
+pub struct RtVariableCoreWrapper<T: VariableOutputCore> {
     core: T,
     buffer: BlockBuffer<T::BlockSize>,
     output_size: usize,
 }
 
-impl<T: VariableOutputCore> VariableOutput for VariableCoreWrapper<T> {
+impl<T: VariableOutputCore> VariableOutput for RtVariableCoreWrapper<T> {
     fn new(output_size: usize) -> Result<Self, InvalidOutputSize> {
         let buffer = Default::default();
         T::new(output_size).map(|core| Self {
@@ -53,7 +53,7 @@ impl<T: VariableOutputCore> VariableOutput for VariableCoreWrapper<T> {
     }
 }
 
-impl<T: VariableOutputCore + AlgorithmName> fmt::Debug for VariableCoreWrapper<T> {
+impl<T: VariableOutputCore + AlgorithmName> fmt::Debug for RtVariableCoreWrapper<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         T::write_alg_name(f)?;
         f.write_str(" { .. }")

--- a/digest/src/core_api/rt_variable.rs
+++ b/digest/src/core_api/rt_variable.rs
@@ -1,0 +1,61 @@
+use super::{AlgorithmName, VariableOutputCore};
+use crate::{InvalidOutputSize, VariableOutput};
+use block_buffer::BlockBuffer;
+use core::fmt;
+
+/// Wrapper around [`VariableOutputCore`] which selects output size
+/// at run time.
+#[derive(Clone)]
+pub struct VariableCoreWrapper<T: VariableOutputCore> {
+    core: T,
+    buffer: BlockBuffer<T::BlockSize>,
+    output_size: usize,
+}
+
+impl<T: VariableOutputCore> VariableOutput for VariableCoreWrapper<T> {
+    fn new(output_size: usize) -> Result<Self, InvalidOutputSize> {
+        let buffer = Default::default();
+        T::new(output_size).map(|core| Self {
+            core,
+            buffer,
+            output_size,
+        })
+    }
+
+    fn output_size(&self) -> usize {
+        self.output_size
+    }
+
+    fn finalize_variable(mut self, f: impl FnOnce(&[u8])) {
+        let Self {
+            core,
+            buffer,
+            output_size,
+        } = &mut self;
+        core.finalize_variable_core(buffer, *output_size, f);
+    }
+
+    fn finalize_variable_reset(&mut self, f: impl FnOnce(&[u8])) {
+        let Self {
+            core,
+            buffer,
+            output_size,
+        } = self;
+        core.finalize_variable_core(buffer, *output_size, f);
+        buffer.reset();
+        // For correct implementations `new` should always return `Ok`
+        // since we have already verified that `output_size` lies in a valid range.
+        if let Ok(v) = T::new(*output_size) {
+            *core = v;
+        } else {
+            debug_assert!(false);
+        }
+    }
+}
+
+impl<T: VariableOutputCore + AlgorithmName> fmt::Debug for VariableCoreWrapper<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        T::write_alg_name(f)?;
+        f.write_str(" { .. }")
+    }
+}

--- a/digest/src/core_api/update.rs
+++ b/digest/src/core_api/update.rs
@@ -1,0 +1,96 @@
+use super::{
+    AlgorithmName, ExtendableOutputCore, FixedOutputCore, UpdateCore, XofReaderCoreWrapper,
+};
+use crate::{ExtendableOutput, FixedOutput, Reset, Update};
+use block_buffer::BlockBuffer;
+use core::fmt;
+use generic_array::GenericArray;
+
+/// Wrapper around [`UpdateCore`] implementations.
+///
+/// It handles data buffering and implements the mid-level traits.
+#[derive(Clone, Default)]
+pub struct UpdateCoreWrapper<T: UpdateCore> {
+    core: T,
+    buffer: BlockBuffer<T::BlockSize>,
+}
+
+impl<T: UpdateCore + AlgorithmName> fmt::Debug for UpdateCoreWrapper<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        T::write_alg_name(f)?;
+        f.write_str(" { .. }")
+    }
+}
+
+impl<D: Default + UpdateCore> Reset for UpdateCoreWrapper<D> {
+    #[inline]
+    fn reset(&mut self) {
+        self.core = Default::default();
+        self.buffer.reset();
+    }
+}
+
+impl<D: UpdateCore> Update for UpdateCoreWrapper<D> {
+    #[inline]
+    fn update(&mut self, input: &[u8]) {
+        let Self { core, buffer } = self;
+        buffer.digest_blocks(input, |blocks| core.update_blocks(blocks));
+    }
+}
+
+impl<D: FixedOutputCore + Default> FixedOutput for UpdateCoreWrapper<D> {
+    type OutputSize = D::OutputSize;
+
+    #[inline]
+    fn finalize_into(mut self, out: &mut GenericArray<u8, Self::OutputSize>) {
+        let Self { core, buffer } = &mut self;
+        core.finalize_fixed_core(buffer, out);
+    }
+
+    #[inline]
+    fn finalize_into_reset(&mut self, out: &mut GenericArray<u8, Self::OutputSize>) {
+        let Self { core, buffer } = self;
+        core.finalize_fixed_core(buffer, out);
+        self.reset();
+    }
+}
+
+impl<D: ExtendableOutputCore + Default> ExtendableOutput for UpdateCoreWrapper<D> {
+    type Reader = XofReaderCoreWrapper<D::ReaderCore>;
+
+    #[inline]
+    fn finalize_xof(mut self) -> Self::Reader {
+        let Self { core, buffer } = &mut self;
+        let reader_core = core.finalize_xof_core(buffer);
+        XofReaderCoreWrapper {
+            core: reader_core,
+            buffer: Default::default(),
+        }
+    }
+
+    #[inline]
+    fn finalize_xof_reset(&mut self) -> Self::Reader {
+        let Self { core, buffer } = self;
+        let reader_core = core.finalize_xof_core(buffer);
+        self.reset();
+        XofReaderCoreWrapper {
+            core: reader_core,
+            buffer: Default::default(),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+impl<D: UpdateCore> std::io::Write for UpdateCoreWrapper<D> {
+    #[inline]
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        Update::update(self, buf);
+        Ok(buf.len())
+    }
+
+    #[inline]
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}

--- a/digest/src/core_api/xof_reader.rs
+++ b/digest/src/core_api/xof_reader.rs
@@ -1,0 +1,38 @@
+use super::{AlgorithmName, XofReaderCore};
+use crate::XofReader;
+use block_buffer::BlockBuffer;
+use core::fmt;
+
+/// Wrapper around [`XofReaderCore`] implementations.
+///
+/// It handles data buffering and implements the mid-level traits.
+#[derive(Clone, Default)]
+pub struct XofReaderCoreWrapper<T: XofReaderCore> {
+    pub(super) core: T,
+    pub(super) buffer: BlockBuffer<T::BlockSize>,
+}
+
+impl<T: XofReaderCore + AlgorithmName> fmt::Debug for XofReaderCoreWrapper<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        T::write_alg_name(f)?;
+        f.write_str(" { .. }")
+    }
+}
+
+impl<R: XofReaderCore> XofReader for XofReaderCoreWrapper<R> {
+    #[inline]
+    fn read(&mut self, buffer: &mut [u8]) {
+        let Self { core, buffer: buf } = self;
+        buf.set_data(buffer, || core.read_block());
+    }
+}
+
+#[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+impl<R: XofReaderCore> std::io::Read for XofReaderCoreWrapper<R> {
+    #[inline]
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        XofReader::read(self, buf);
+        Ok(buf.len())
+    }
+}

--- a/digest/src/digest.rs
+++ b/digest/src/digest.rs
@@ -44,15 +44,14 @@ pub trait Digest {
     /// Get output size of the hasher
     fn output_size() -> usize;
 
-    /// Convenience function to compute hash of the `data`. It will handle
-    /// hasher creation, data feeding and finalization.
+    /// Compute hash of `data`.
     ///
     /// Example:
     ///
     /// ```rust,ignore
     /// println!("{:x}", sha2::Sha256::digest(b"Hello world"));
     /// ```
-    fn digest(data: &[u8]) -> Output<Self>;
+    fn digest(data: impl AsRef<[u8]>) -> Output<Self>;
 }
 
 impl<D: Update + FixedOutput + Reset + Clone + Default> Digest for D {
@@ -108,9 +107,9 @@ impl<D: Update + FixedOutput + Reset + Clone + Default> Digest for D {
     }
 
     #[inline]
-    fn digest(data: &[u8]) -> Output<Self> {
+    fn digest(data: impl AsRef<[u8]>) -> Output<Self> {
         let mut hasher = Self::default();
-        Update::update(&mut hasher, data);
+        Update::update(&mut hasher, data.as_ref());
         hasher.finalize_fixed()
     }
 }

--- a/digest/src/digest.rs
+++ b/digest/src/digest.rs
@@ -13,30 +13,23 @@ pub trait Digest {
     /// Create new hasher instance
     fn new() -> Self;
 
-    /// Digest data, updating the internal state.
-    ///
-    /// This method can be called repeatedly for use with streaming messages.
+    /// Process data, updating the internal state.
     fn update(&mut self, data: impl AsRef<[u8]>);
 
-    /// Digest input data in a chained manner.
-    fn chain(self, data: impl AsRef<[u8]>) -> Self
-    where
-        Self: Sized;
+    /// Process input data in a chained manner.
+    fn chain_update(self, data: impl AsRef<[u8]>) -> Self;
 
     /// Retrieve result and consume hasher instance.
     fn finalize(self) -> Output<Self>;
 
     /// Retrieve result and reset hasher instance.
-    ///
-    /// This method sometimes can be more efficient compared to hasher
-    /// re-creation.
     fn finalize_reset(&mut self) -> Output<Self>;
 
     /// Write result into provided array and consume the hasher instance.
-    fn finalize_into(self, out: &mut GenericArray<u8, Self::OutputSize>);
+    fn finalize_into(self, out: &mut Output<Self>);
 
     /// Write result into provided array and reset the hasher instance.
-    fn finalize_into_reset(&mut self, out: &mut GenericArray<u8, Self::OutputSize>);
+    fn finalize_into_reset(&mut self, out: &mut Output<Self>);
 
     /// Reset hasher instance to its initial state.
     fn reset(&mut self);
@@ -45,16 +38,10 @@ pub trait Digest {
     fn output_size() -> usize;
 
     /// Compute hash of `data`.
-    ///
-    /// Example:
-    ///
-    /// ```rust,ignore
-    /// println!("{:x}", sha2::Sha256::digest(b"Hello world"));
-    /// ```
     fn digest(data: impl AsRef<[u8]>) -> Output<Self>;
 }
 
-impl<D: Update + FixedOutput + Reset + Clone + Default> Digest for D {
+impl<D: FixedOutput> Digest for D {
     type OutputSize = <Self as FixedOutput>::OutputSize;
 
     #[inline]
@@ -68,32 +55,29 @@ impl<D: Update + FixedOutput + Reset + Clone + Default> Digest for D {
     }
 
     #[inline]
-    fn chain(mut self, data: impl AsRef<[u8]>) -> Self
-    where
-        Self: Sized,
-    {
+    fn chain_update(mut self, data: impl AsRef<[u8]>) -> Self {
         Update::update(&mut self, data.as_ref());
         self
     }
 
     #[inline]
     fn finalize(self) -> Output<Self> {
-        self.finalize_fixed()
+        FixedOutput::finalize_fixed(self)
     }
 
     #[inline]
     fn finalize_reset(&mut self) -> Output<Self> {
-        self.finalize_fixed_reset()
+        FixedOutput::finalize_fixed_reset(self)
     }
 
     #[inline]
     fn finalize_into(self, out: &mut Output<Self>) {
-        self.finalize_into(out);
+        FixedOutput::finalize_into(self, out);
     }
 
     #[inline]
     fn finalize_into_reset(&mut self, out: &mut Output<Self>) {
-        self.finalize_into_reset(out);
+        FixedOutput::finalize_into_reset(self, out);
     }
 
     #[inline]
@@ -108,9 +92,7 @@ impl<D: Update + FixedOutput + Reset + Clone + Default> Digest for D {
 
     #[inline]
     fn digest(data: impl AsRef<[u8]>) -> Output<Self> {
-        let mut hasher = Self::default();
-        Update::update(&mut hasher, data.as_ref());
-        hasher.finalize_fixed()
+        Self::digest_fixed(data)
     }
 }
 

--- a/digest/src/lib.rs
+++ b/digest/src/lib.rs
@@ -174,6 +174,7 @@ pub trait ExtendableOutput {
 
 /// Trait for variable output size hash functions.
 pub trait VariableOutput: Sized {
+    /// Maximum size of output hash.
     const MAX_OUTPUT_SIZE: usize;
 
     /// Create new hasher instance with the given output size.


### PR DESCRIPTION
The mid-level `VariableOutput` trait is the same as in `digest v0.9`, but on lower-level it's based on the `VariableOutputCore`. Types which implement this core trait can be used in two ways:
- By specifying output size at compile time via `CtVariableCoreWrapper`. This wrapper implements the fixed core traits, so for example `Groestl384` will be defined as `UpdateCoreWrapper<CtVariableCoreWrapperGroestlBigCore, U48>>`.
- By selecting output size at run time via `RtVariableCoreWrapper`. This wrapper implements the `VariableOutput` trait.

This approach could be seen as a bit of generalization overkill, but I think it neatly describes structure of variable hash functions and allows all the flexibility we could want.

Also I have restructured the code a bit. Now the core traits and wrappers reside in the `core_api` module, thus top-level docs are no longer cluttered with them.