### PR TITLE
aead+cipher+crypto_mac: add `generate_key` method to `New*` traits

### DIFF
--- a/.github/workflows/aead.yml
+++ b/.github/workflows/aead.yml
@@ -37,6 +37,7 @@ jobs:
           override: true
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features alloc
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features rand_core
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features stream
 
   test:

--- a/.github/workflows/cipher.yml
+++ b/.github/workflows/cipher.yml
@@ -35,7 +35,9 @@ jobs:
           toolchain: ${{ matrix.rust }}
           target: ${{ matrix.target }}
           override: true
-      - run: cargo build --no-default-features --release --target ${{ matrix.target }}
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features rand_core
+
   test:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/crypto-mac.yml
+++ b/.github/workflows/crypto-mac.yml
@@ -35,7 +35,9 @@ jobs:
           toolchain: ${{ matrix.rust }}
           target: ${{ matrix.target }}
           override: true
-      - run: cargo build --no-default-features --release --target ${{ matrix.target }}
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features rand_core
+
   test:
     runs-on: ubuntu-latest
     strategy:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,6 +7,7 @@ dependencies = [
  "blobby",
  "generic-array 0.14.4",
  "heapless",
+ "rand_core",
 ]
 
 [[package]]
@@ -110,6 +111,7 @@ version = "0.3.0-pre.4"
 dependencies = [
  "blobby",
  "generic-array 0.14.4",
+ "rand_core",
 ]
 
 [[package]]
@@ -145,6 +147,7 @@ dependencies = [
  "blobby",
  "cipher",
  "generic-array 0.14.4",
+ "rand_core",
  "subtle",
 ]
 

--- a/aead/Cargo.toml
+++ b/aead/Cargo.toml
@@ -16,8 +16,10 @@ categories = ["cryptography", "no-std"]
 
 [dependencies]
 generic-array = { version = "0.14", default-features = false }
-heapless = { version = "0.5", optional = true }
+
 blobby = { version = "0.3", optional = true }
+heapless = { version = "0.5", optional = true }
+rand_core = { version = "0.6", optional = true }
 
 [features]
 std = ["alloc"]

--- a/aead/src/lib.rs
+++ b/aead/src/lib.rs
@@ -42,6 +42,9 @@ pub use generic_array::{self, typenum::consts};
 #[cfg(feature = "heapless")]
 pub use heapless;
 
+#[cfg(feature = "rand_core")]
+use rand_core::{CryptoRng, RngCore};
+
 use core::fmt;
 use generic_array::{typenum::Unsigned, ArrayLength, GenericArray};
 
@@ -94,6 +97,15 @@ pub trait NewAead {
         } else {
             Ok(Self::new(GenericArray::from_slice(key)))
         }
+    }
+
+    /// Generate a random key for this AEAD using the provided [`CryptoRng`].
+    #[cfg(feature = "rand_core")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "rand_core")))]
+    fn generate_key(mut rng: impl CryptoRng + RngCore) -> Key<Self> {
+        let mut key = Key::<Self>::default();
+        rng.fill_bytes(&mut key);
+        key
     }
 }
 

--- a/cipher/Cargo.toml
+++ b/cipher/Cargo.toml
@@ -13,7 +13,9 @@ categories = ["cryptography", "no-std"]
 
 [dependencies]
 generic-array = "0.14"
+
 blobby = { version = "0.3", optional = true }
+rand_core = { version = "0.6", optional = true }
 
 [features]
 std = []

--- a/cipher/src/block.rs
+++ b/cipher/src/block.rs
@@ -13,6 +13,9 @@ use crate::errors::InvalidLength;
 use core::convert::TryInto;
 use generic_array::{typenum::Unsigned, ArrayLength, GenericArray};
 
+#[cfg(feature = "rand_core")]
+use rand_core::{CryptoRng, RngCore};
+
 /// Key for an algorithm that implements [`NewBlockCipher`].
 pub type BlockCipherKey<B> = GenericArray<u8, <B as NewBlockCipher>::KeySize>;
 
@@ -40,6 +43,15 @@ pub trait NewBlockCipher: Sized {
         } else {
             Ok(Self::new(GenericArray::from_slice(key)))
         }
+    }
+
+    /// Generate a random key for this block cipher using the provided [`CryptoRng`].
+    #[cfg(feature = "rand_core")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "rand_core")))]
+    fn generate_key(mut rng: impl CryptoRng + RngCore) -> BlockCipherKey<Self> {
+        let mut key = BlockCipherKey::<Self>::default();
+        rng.fill_bytes(&mut key);
+        key
     }
 }
 

--- a/cipher/src/common.rs
+++ b/cipher/src/common.rs
@@ -1,5 +1,10 @@
+//! Functionality common to block ciphers and stream ciphers
+
 use crate::{errors::InvalidLength, BlockCipher, NewBlockCipher};
 use generic_array::{typenum::Unsigned, ArrayLength, GenericArray};
+
+#[cfg(feature = "rand_core")]
+use rand_core::{CryptoRng, RngCore};
 
 /// Key for an algorithm that implements [`NewCipher`].
 pub type CipherKey<C> = GenericArray<u8, <C as NewCipher>::KeySize>;
@@ -33,6 +38,15 @@ pub trait NewCipher: Sized {
             let nonce = GenericArray::from_slice(nonce);
             Ok(Self::new(key, nonce))
         }
+    }
+
+    /// Generate a random key for this cipher using the provided [`CryptoRng`].
+    #[cfg(feature = "rand_core")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "rand_core")))]
+    fn generate_key(mut rng: impl CryptoRng + RngCore) -> CipherKey<Self> {
+        let mut key = CipherKey::<Self>::default();
+        rng.fill_bytes(&mut key);
+        key
     }
 }
 

--- a/crypto-mac/Cargo.toml
+++ b/crypto-mac/Cargo.toml
@@ -13,9 +13,11 @@ categories = ["cryptography", "no-std"]
 
 [dependencies]
 generic-array = "0.14"
-cipher = { version = "=0.3.0-pre.4", optional = true, path = "../cipher" }
 subtle = { version = "2", default-features = false }
+
 blobby = { version = "0.3", optional = true }
+cipher = { version = "=0.3.0-pre.4", optional = true, path = "../cipher" }
+rand_core = { version = "0.6", optional = true }
 
 [features]
 dev = ["blobby"]

--- a/crypto-mac/src/lib.rs
+++ b/crypto-mac/src/lib.rs
@@ -30,6 +30,9 @@ use generic_array::typenum::Unsigned;
 use generic_array::{ArrayLength, GenericArray};
 use subtle::{Choice, ConstantTimeEq};
 
+#[cfg(feature = "rand_core")]
+use rand_core::{CryptoRng, RngCore};
+
 /// Key for an algorithm that implements [`NewMac`].
 pub type Key<M> = GenericArray<u8, <M as NewMac>::KeySize>;
 
@@ -51,6 +54,15 @@ pub trait NewMac: Sized {
         } else {
             Ok(Self::new(GenericArray::from_slice(key)))
         }
+    }
+
+    /// Generate a random key for this MAC using the provided [`CryptoRng`].
+    #[cfg(feature = "rand_core")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "rand_core")))]
+    fn generate_key(mut rng: impl CryptoRng + RngCore) -> Key<Self> {
+        let mut key = Key::<Self>::default();
+        rng.fill_bytes(&mut key);
+        key
     }
 }
 


### PR DESCRIPTION
Adds an optional `generate_key` method feature-gated on `rand_core` which uses a provided `CryptoRng` to generate a random key of an appropriate size for a given algorithm.