### PR TITLE
aead: disable alloc by default (closes #273)

### DIFF
--- a/.github/workflows/aead.yml
+++ b/.github/workflows/aead.yml
@@ -36,6 +36,7 @@ jobs:
           target: ${{ matrix.target }}
           override: true
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features alloc
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features stream
 
   test:

--- a/aead/Cargo.toml
+++ b/aead/Cargo.toml
@@ -20,10 +20,9 @@ heapless = { version = "0.5", optional = true }
 blobby = { version = "0.3", optional = true }
 
 [features]
-default = ["alloc"]
+std = ["alloc"]
 alloc = []
 dev = ["blobby"]
-std = ["alloc"]
 stream = []
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
The `alloc` feature used to be a mandatory part of the `aead` API, but in the time since we've introduced in-place traits that allow for fully heapless usage.

This commit removes it as a default feature.