### PR TITLE
password-hash: add basic encoding support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,9 +42,9 @@ dependencies = [
 
 [[package]]
 name = "base64ct"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e96c6b8c1cac2cfe84b4ea97794c43085b401df66c466e9a863744c0489679a7"
+checksum = "b245b005bb8924f38647aeb31388984784a139acbe7ac6d7435fb0a11c4c83d8"
 
 [[package]]
 name = "bitvec"

--- a/password-hash/Cargo.toml
+++ b/password-hash/Cargo.toml
@@ -16,7 +16,7 @@ categories = ["cryptography", "no-std"]
 keywords = ["crypt", "mcf", "password", "pbkdf", "phc"]
 
 [dependencies]
-base64ct = "0.1"
+base64ct = "0.1.2"
 rand_core = { version = "0.6", optional = true, default-features = false }
 
 [features]

--- a/password-hash/src/encoding.rs
+++ b/password-hash/src/encoding.rs
@@ -1,0 +1,72 @@
+//! Base64 encoding variants.
+
+use crate::B64Error;
+use base64ct as base64;
+
+/// Base64 encoding variants.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+pub enum Encoding {
+    /// "B64" encoding: standard Base64 without padding.
+    ///
+    /// ```text
+    /// [A-Z]      [a-z]      [0-9]      +     /
+    /// 0x41-0x5a, 0x61-0x7a, 0x30-0x39, 0x2b, 0x2f
+    /// ```
+    /// <https://github.com/P-H-C/phc-string-format/blob/master/phc-sf-spec.md#b64>
+    B64,
+
+    /// bcrypt encoding.
+    ///
+    /// ```text
+    /// ./         [A-Z]      [a-z]     [0-9]
+    /// 0x2e-0x2f, 0x41-0x5a, 0x61-0x7a, 0x30-0x39
+    /// ```
+    Bcrypt,
+
+    /// `crypt(3)` encoding.
+    ///
+    /// ```text
+    /// [.-9]      [A-Z]      [a-z]
+    /// 0x2e-0x39, 0x41-0x5a, 0x61-0x7a
+    /// ```
+    Crypt,
+}
+
+impl Default for Encoding {
+    fn default() -> Self {
+        Self::B64
+    }
+}
+
+impl Encoding {
+    /// Decode a Base64 string into the provided destination buffer.
+    pub fn decode(self, src: impl AsRef<[u8]>, dst: &mut [u8]) -> Result<&[u8], B64Error> {
+        match self {
+            Self::B64 => base64::unpadded::decode(src, dst),
+            Self::Bcrypt => base64::bcrypt::decode(src, dst),
+            Self::Crypt => base64::crypt::decode(src, dst),
+        }
+    }
+
+    /// Encode the input byte slice as Base64.
+    ///
+    /// Writes the result into the provided destination slice, returning an
+    /// ASCII-encoded Base64 string value.
+    pub fn encode<'a>(self, src: &[u8], dst: &'a mut [u8]) -> Result<&'a str, B64Error> {
+        match self {
+            Self::B64 => base64::unpadded::encode(src, dst),
+            Self::Bcrypt => base64::bcrypt::encode(src, dst),
+            Self::Crypt => base64::crypt::encode(src, dst),
+        }
+        .map_err(Into::into)
+    }
+
+    /// Get the length of Base64 produced by encoding the given bytes.
+    pub fn encoded_len(self, bytes: &[u8]) -> usize {
+        match self {
+            Self::B64 => base64::unpadded::encoded_len(bytes),
+            Self::Bcrypt => base64::bcrypt::encoded_len(bytes),
+            Self::Crypt => base64::crypt::encoded_len(bytes),
+        }
+    }
+}

--- a/password-hash/src/lib.rs
+++ b/password-hash/src/lib.rs
@@ -50,6 +50,7 @@ extern crate alloc;
 #[cfg(feature = "std")]
 extern crate std;
 
+mod encoding;
 mod errors;
 mod ident;
 mod output;
@@ -58,6 +59,7 @@ mod salt;
 mod value;
 
 pub use crate::{
+    encoding::Encoding,
     errors::{B64Error, HashError, HasherError, OutputError, ParamsError, ParseError, VerifyError},
     ident::Ident,
     output::Output,


### PR DESCRIPTION
Support for encoding `Output` using the following Base64 variants:

- B64: for PHC hashes
- bcrypt
- `crypt(3)`: for SHA-crypt