### PR TITLE
password-hash: add encoding support to PasswordHash

### DIFF
--- a/password-hash/src/lib.rs
+++ b/password-hash/src/lib.rs
@@ -249,6 +249,11 @@ pub struct PasswordHash<'a> {
 impl<'a> PasswordHash<'a> {
     /// Parse a password hash from a string in the PHC string format.
     pub fn new(s: &'a str) -> Result<Self, HashError> {
+        Self::parse(s, Encoding::B64)
+    }
+
+    /// Parse a password hash from the given [`Encoding`].
+    pub fn parse(s: &'a str, encoding: Encoding) -> Result<Self, HashError> {
         if s.is_empty() {
             return Err(ParseError::Empty.into());
         }
@@ -301,7 +306,7 @@ impl<'a> PasswordHash<'a> {
         }
 
         if let Some(field) = fields.next() {
-            hash = Some(field.parse()?);
+            hash = Some(Output::decode(field, encoding)?);
         }
 
         if fields.next().is_some() {
@@ -340,6 +345,11 @@ impl<'a> PasswordHash<'a> {
         }
 
         Err(VerifyError)
+    }
+
+    /// Get the [`Encoding`] that this [`PasswordHash`] is serialized with.
+    pub fn encoding(&self) -> Encoding {
+        self.hash.map(|h| h.encoding()).unwrap_or_default()
     }
 }
 

--- a/password-hash/src/output.rs
+++ b/password-hash/src/output.rs
@@ -143,7 +143,7 @@ impl Output {
         &self.bytes[..self.len()]
     }
 
-    /// Get the encoding that this [`Output`] will be serialized with.
+    /// Get the [`Encoding`] that this [`Output`] is serialized with.
     pub fn encoding(&self) -> Encoding {
         self.encoding
     }


### PR DESCRIPTION
More work towards being able to use `PasswordHash` with SHA-crypt, which uses a PHC-like hash/params, but with `crypt(3)` encoding.

This change is also trying to be purely additive to avoid having to cut new minor releases of everything.