### PR TITLE
password-hash v0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -318,7 +318,7 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "password-hash"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "base64ct 0.2.0",
  "rand_core",

--- a/password-hash/CHANGELOG.md
+++ b/password-hash/CHANGELOG.md
@@ -5,5 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.1 (2021-02-01)
+### Added
+- `Encoding` enum with bcrypt and `crypt(3)` Base64 support ([#515])
+- Support for using `PasswordHash` with an alternate `Encoding` ([#518])
+
+### Changed
+- Bump `base64ct` dependency to v0.2 ([#519])
+
+[#515]: https://github.com/RustCrypto/traits/pull/515
+[#518]: https://github.com/RustCrypto/traits/pull/518
+[#519]: https://github.com/RustCrypto/traits/pull/519
+
 ## 0.1.0 (2021-01-28)
 - Initial release

--- a/password-hash/Cargo.toml
+++ b/password-hash/Cargo.toml
@@ -5,7 +5,7 @@ Traits which describe the functionality of password hashing algorithms,
 as well as a `no_std`-friendly implementation of the PHC string format
 (a well-defined subset of the Modular Crypt Format a.k.a. MCF)
 """
-version = "0.1.0"
+version = "0.1.1"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/password-hash/src/lib.rs
+++ b/password-hash/src/lib.rs
@@ -39,7 +39,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/password-hash/0.1.0"
+    html_root_url = "https://docs.rs/password-hash/0.1.1"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]


### PR DESCRIPTION
### Added
- `Encoding` enum with bcrypt and `crypt(3)` Base64 support ([#515])
- Support for using `PasswordHash` with an alternate `Encoding` ([#518])

### Changed
- Bump `base64ct` dependency to v0.2 ([#519])

[#515]: https://github.com/RustCrypto/traits/pull/515
[#518]: https://github.com/RustCrypto/traits/pull/518
[#519]: https://github.com/RustCrypto/traits/pull/519