### PR TITLE
aead v0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,7 +2,7 @@
 # It is not intended for manual editing.
 [[package]]
 name = "aead"
-version = "0.4.0-pre"
+version = "0.4.0"
 dependencies = [
  "blobby",
  "generic-array 0.14.4",

--- a/aead/CHANGELOG.md
+++ b/aead/CHANGELOG.md
@@ -5,15 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.4.0 (UNRELEASED)
+## 0.4.0
 ### Added
-- `stream` module ([#436])
+- `stream` module ([#436], [#445], [#447])
+- `NewAead::generate_key` method gated under `rand_core` feature ([#513])
 
 ### Changed
 - Extract `AeadCore` trait ([#508])
+- Rename `NewAead::new_var` to `::new_from_slice` ([#512])
+- Disable alloc by default ([#514])
+- Bump `heapless` dependency to v0.6 ([#522])
 
 [#436]: https://github.com/RustCrypto/traits/pull/436
+[#445]: https://github.com/RustCrypto/traits/pull/445
+[#447]: https://github.com/RustCrypto/traits/pull/447
 [#508]: https://github.com/RustCrypto/traits/pull/508
+[#512]: https://github.com/RustCrypto/traits/pull/512
+[#513]: https://github.com/RustCrypto/traits/pull/513
+[#514]: https://github.com/RustCrypto/traits/pull/514
+[#522]: https://github.com/RustCrypto/traits/pull/522
 
 ## 0.3.2 (2020-07-01)
 ### Added

--- a/aead/Cargo.toml
+++ b/aead/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aead"
-version = "0.4.0-pre" # Also update html_root_url in lib.rs when bumping this
+version = "0.4.0" # Also update html_root_url in lib.rs when bumping this
 description = """
 Traits for Authenticated Encryption with Associated Data (AEAD) algorithms,
 such as AES-GCM as ChaCha20Poly1305, which provide a high-level API

--- a/aead/src/lib.rs
+++ b/aead/src/lib.rs
@@ -19,7 +19,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/aead/0.4.0-pre"
+    html_root_url = "https://docs.rs/aead/0.4.0"
 )]
 #![warn(missing_docs, rust_2018_idioms)]
 

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-aead = { version = "=0.4.0-pre", optional = true, path = "../aead" }
+aead = { version = "0.4", optional = true, path = "../aead" }
 cipher = { version = "=0.3.0-pre.4", optional = true, path = "../cipher" }
 digest = { version = "0.10.0-pre", optional = true, path = "../digest" }
 elliptic-curve = { version = "=0.9.0-pre", optional = true, path = "../elliptic-curve" }


### PR DESCRIPTION
### Added
- `stream` module ([#436], [#445], [#447])
- `NewAead::generate_key` method gated under `rand_core` feature ([#513])

### Changed
- Extract `AeadCore` trait ([#508])
- Rename `NewAead::new_var` to `::new_from_slice` ([#512])
- Disable alloc by default ([#514])
- Bump `heapless` dependency to v0.6 ([#522])

[#436]: https://github.com/RustCrypto/traits/pull/436
[#445]: https://github.com/RustCrypto/traits/pull/445
[#447]: https://github.com/RustCrypto/traits/pull/447
[#508]: https://github.com/RustCrypto/traits/pull/508
[#512]: https://github.com/RustCrypto/traits/pull/512
[#513]: https://github.com/RustCrypto/traits/pull/513
[#514]: https://github.com/RustCrypto/traits/pull/514
[#522]: https://github.com/RustCrypto/traits/pull/522