### PR TITLE
[WIP] cipher/universal-hash: generic buffer traits

### DIFF
--- a/cipher/src/common.rs
+++ b/cipher/src/common.rs
@@ -1,6 +1,9 @@
 //! Functionality common to block ciphers and stream ciphers
 
-use crate::{errors::InvalidLength, BlockCipher, NewBlockCipher};
+use crate::{
+    errors::{BufferError, InvalidLength},
+    BlockCipher, NewBlockCipher,
+};
 use generic_array::{typenum::Unsigned, ArrayLength, GenericArray};
 
 #[cfg(feature = "rand_core")]
@@ -91,4 +94,22 @@ where
                 })
         }
     }
+}
+
+/// Perform an encryption operation using a specific buffer type.
+///
+/// This gives finer-grained control over the buffer type, which is useful
+/// in cases which have special requirements, e.g. alignment, SIMD.
+pub trait BufferEncrypt<B> {
+    /// Encrypt the provided buffer type in-place
+    fn encrypt_buffer(&self, buffer: &mut B) -> Result<(), BufferError>;
+}
+
+/// Perform an encryption operation on a mutable cipher instance.
+///
+/// This gives finer-grained control over the buffer type, which is useful
+/// in cases which have special requirements, e.g. alignment, SIMD.
+pub trait BufferEncryptMut<B> {
+    /// Encrypt the provided buffer type in-place
+    fn encrypt_buffer_mut(&mut self, buffer: &mut B) -> Result<(), BufferError>;
 }

--- a/cipher/src/errors.rs
+++ b/cipher/src/errors.rs
@@ -2,6 +2,19 @@
 
 use core::fmt;
 
+/// Buffer errors.
+#[derive(Copy, Clone, Debug)]
+pub struct BufferError;
+
+impl fmt::Display for BufferError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        f.write_str("Buffer Error")
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for BufferError {}
+
 /// The error type returned when stream cipher has reached the end of a keystream.
 #[derive(Copy, Clone, Debug)]
 pub struct LoopError;

--- a/universal-hash/src/lib.rs
+++ b/universal-hash/src/lib.rs
@@ -106,6 +106,15 @@ pub trait UniversalHash: Clone {
     }
 }
 
+/// Update a universal hash using a specific buffer type.
+///
+/// This gives finer-grained control over the buffer type, which is useful
+/// in cases which have special requirements, e.g. alignment, SIMD.
+pub trait BufferUpdate<B> {
+    /// Encrypt the provided buffer type in-place
+    fn encrypt_buffer(&self, buffer: &mut B) -> Result<(), Error>;
+}
+
 /// Outputs of universal hash functions which are a thin wrapper around a
 /// byte array. Provides a safe [`Eq`] implementation that runs in constant time,
 /// which is useful for implementing Message Authentication Codes (MACs) based


### PR DESCRIPTION
Adds traits which are generic around a buffer type, allowing more precise control of inputs to encryption and universal hash algorithms.

Potentially resolves #159 and #444.