### PR TITLE
password-hash: add docs.rs metadata to Cargo.toml

### DIFF
--- a/password-hash/Cargo.toml
+++ b/password-hash/Cargo.toml
@@ -22,3 +22,7 @@ rand_core = { version = "0.6", optional = true, default-features = false }
 [features]
 alloc = ["base64ct/alloc"]
 std = ["alloc", "base64ct/std"]
+
+[package.metadata.docs.rs]
+rustc-args = ["--cfg", "docsrs"]
+features = ["rand_core"]


### PR DESCRIPTION
Based on the following `#[cfg_attr]` it looks like this was the intention but the required lines in Cargo.toml were omitted: https://github.com/RustCrypto/traits/blob/073edacf50e04c257053b6c2ef2fea8276a241e1/password-hash/src/salt.rs#L185