### PR TITLE
elliptic-curve: remove FromDigest trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,7 +183,6 @@ name = "elliptic-curve"
 version = "0.9.0-pre"
 dependencies = [
  "base64ct",
- "digest 0.9.0",
  "ff",
  "generic-array 0.14.4",
  "group",

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -16,7 +16,6 @@ keywords   = ["crypto", "ecc", "elliptic", "weierstrass"]
 
 [dependencies]
 base64ct = { version = "0.2", optional = true, default-features = false }
-digest = { version = "0.9", optional = true }
 ff = { version = "0.9", optional = true, default-features = false }
 group = { version = "0.9", optional = true, default-features = false }
 hex-literal = { version = "0.3", optional = true }
@@ -35,7 +34,7 @@ hex-literal = "0.3"
 default = ["arithmetic"]
 alloc = []
 arithmetic = ["ff", "group"]
-dev = ["arithmetic", "digest", "hex-literal", "pem", "zeroize"]
+dev = ["arithmetic", "hex-literal", "pem", "zeroize"]
 ecdh = ["arithmetic", "zeroize"]
 hazmat = []
 jwk = ["alloc", "base64ct/alloc", "serde", "serde_json", "zeroize/alloc"]

--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -69,9 +69,6 @@ pub use {
     group::{self, Group},
 };
 
-#[cfg(feature = "digest")]
-pub use digest::{self, Digest};
-
 #[cfg(all(feature = "hazmat", feature = "zeroize"))]
 pub use secret_key::{SecretBytes, SecretValue};
 
@@ -117,19 +114,6 @@ pub trait Curve: Clone + Debug + Default + Eq + Ord + Send + Sync {
 
 /// Byte representation of a base/scalar field element of a given curve.
 pub type FieldBytes<C> = GenericArray<u8, <C as Curve>::FieldSize>;
-
-/// Instantiate this type from the output of a digest.
-///
-/// This can be used for implementing hash-to-scalar (e.g. as in ECDSA) or
-/// hash-to-curve algorithms.
-#[cfg(feature = "digest")]
-#[cfg_attr(docsrs, doc(cfg(feature = "digest")))]
-pub trait FromDigest<C: Curve> {
-    /// Instantiate this type from a [`Digest`] instance
-    fn from_digest<D>(digest: D) -> Self
-    where
-        D: Digest<OutputSize = C::FieldSize>;
-}
 
 /// Associate an [`ObjectIdentifier`][`pkcs8::ObjectIdentifier`] (OID) with an
 /// elliptic curve algorithm implementation.


### PR DESCRIPTION
As discussed in #481, this removes the `FromDigest` trait, and with it any dependency on the `digest` crate (at least for now).

The reasoning is `FromDigest` in its current form exists to solve a single concern: hash-to-scalar for the specific purposes of ECDSA, which is implemented in the `k256` and `p256` crates as a "narrow" reduction per the requirements of ECDSA.

Given that, this trait is best moved to the `ecdsa` crate, clearing the way for a move generally useful, well-considered, and well-specified and standardized hash-to-curve construction as requested in #481.

The plan after this is to provide an identical trait, but in the `ecdsa` crate instead of the `elliptic-curve` crate.