### PR TITLE
elliptic-curve: add `Result` alias

### DIFF
--- a/elliptic-curve/src/dev.rs
+++ b/elliptic-curve/src/dev.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     consts::U32,
-    error::Error,
+    error::{Error, Result},
     ff::{Field, PrimeField},
     group,
     rand_core::RngCore,
@@ -194,7 +194,7 @@ impl PrimeField for Scalar {
 impl TryFrom<[u64; 4]> for Scalar {
     type Error = Error;
 
-    fn try_from(limbs: [u64; 4]) -> Result<Self, Error> {
+    fn try_from(limbs: [u64; 4]) -> Result<Self> {
         // TODO(tarcieri): reject values that overflow the order
         Ok(Scalar(limbs))
     }

--- a/elliptic-curve/src/error.rs
+++ b/elliptic-curve/src/error.rs
@@ -2,6 +2,9 @@
 
 use core::fmt::{self, Display};
 
+/// Result type
+pub type Result<T> = core::result::Result<T, Error>;
+
 /// Elliptic curve errors
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct Error;

--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -52,7 +52,7 @@ mod jwk;
 #[cfg(feature = "zeroize")]
 mod secret_key;
 
-pub use self::error::Error;
+pub use self::error::{Error, Result};
 
 pub use generic_array::{self, typenum::consts};
 pub use rand_core;

--- a/elliptic-curve/src/public_key.rs
+++ b/elliptic-curve/src/public_key.rs
@@ -7,7 +7,7 @@ use crate::{
         EncodedPoint, FromEncodedPoint, ToEncodedPoint, UncompressedPointSize, UntaggedPointSize,
     },
     weierstrass::{point, Curve},
-    AffinePoint, Error, FieldBytes, ProjectiveArithmetic, ProjectivePoint, Scalar,
+    AffinePoint, Error, FieldBytes, ProjectiveArithmetic, ProjectivePoint, Result, Scalar,
 };
 use core::{
     convert::{TryFrom, TryInto},
@@ -78,7 +78,7 @@ where
     Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
 {
     /// Convert an [`AffinePoint`] into a [`PublicKey`]
-    pub fn from_affine(point: AffinePoint<C>) -> Result<Self, Error> {
+    pub fn from_affine(point: AffinePoint<C>) -> Result<Self> {
         if ProjectivePoint::<C>::from(point).is_identity().into() {
             Err(Error)
         } else {
@@ -101,7 +101,7 @@ where
     /// 2.3.3 (page 10).
     ///
     /// <http://www.secg.org/sec1-v2.pdf>
-    pub fn from_sec1_bytes(bytes: &[u8]) -> Result<Self, Error>
+    pub fn from_sec1_bytes(bytes: &[u8]) -> Result<Self>
     where
         Self: TryFrom<EncodedPoint<C>, Error = Error>,
         UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
@@ -127,7 +127,7 @@ where
     /// Parse a [`JwkEcKey`] JSON Web Key (JWK) into a [`PublicKey`].
     #[cfg(feature = "jwk")]
     #[cfg_attr(docsrs, doc(cfg(feature = "jwk")))]
-    pub fn from_jwk(jwk: &JwkEcKey) -> Result<Self, Error>
+    pub fn from_jwk(jwk: &JwkEcKey) -> Result<Self>
     where
         C: JwkParameters,
         AffinePoint<C>: Default + FromEncodedPoint<C> + ToEncodedPoint<C>,
@@ -140,7 +140,7 @@ where
     /// Parse a string containing a JSON Web Key (JWK) into a [`PublicKey`].
     #[cfg(feature = "jwk")]
     #[cfg_attr(docsrs, doc(cfg(feature = "jwk")))]
-    pub fn from_jwk_str(jwk: &str) -> Result<Self, Error>
+    pub fn from_jwk_str(jwk: &str) -> Result<Self>
     where
         C: JwkParameters,
         AffinePoint<C>: Default + FromEncodedPoint<C> + ToEncodedPoint<C>,
@@ -200,7 +200,7 @@ where
 {
     type Error = Error;
 
-    fn try_from(encoded_point: EncodedPoint<C>) -> Result<Self, Error> {
+    fn try_from(encoded_point: EncodedPoint<C>) -> Result<Self> {
         encoded_point.decode()
     }
 }
@@ -216,7 +216,7 @@ where
 {
     type Error = Error;
 
-    fn try_from(encoded_point: &EncodedPoint<C>) -> Result<Self, Error> {
+    fn try_from(encoded_point: &EncodedPoint<C>) -> Result<Self> {
         encoded_point.decode()
     }
 }
@@ -373,7 +373,7 @@ where
 {
     type Err = Error;
 
-    fn from_str(s: &str) -> Result<Self, Error> {
+    fn from_str(s: &str) -> Result<Self> {
         Self::from_public_key_pem(s).map_err(|_| Error)
     }
 }

--- a/elliptic-curve/src/scalar.rs
+++ b/elliptic-curve/src/scalar.rs
@@ -3,7 +3,7 @@
 use crate::{
     ops::Invert,
     rand_core::{CryptoRng, RngCore},
-    Curve, Error, FieldBytes, ProjectiveArithmetic,
+    Curve, Error, FieldBytes, ProjectiveArithmetic, Result,
 };
 use core::{convert::TryFrom, ops::Deref};
 use ff::{Field, FieldBits, PrimeField};
@@ -142,7 +142,7 @@ where
 {
     type Error = Error;
 
-    fn try_from(bytes: &[u8]) -> Result<Self, Error> {
+    fn try_from(bytes: &[u8]) -> Result<Self> {
         if bytes.len() == C::FieldSize::to_usize() {
             NonZeroScalar::from_repr(GenericArray::clone_from_slice(bytes)).ok_or(Error)
         } else {

--- a/elliptic-curve/src/sec1.rs
+++ b/elliptic-curve/src/sec1.rs
@@ -5,7 +5,7 @@
 //!
 //! <https://www.secg.org/sec1-v2.pdf>
 
-use crate::{weierstrass::Curve, Error, FieldBytes};
+use crate::{weierstrass::Curve, Error, FieldBytes, Result};
 use core::{
     fmt::{self, Debug},
     ops::Add,
@@ -77,7 +77,7 @@ where
     /// 2.3.3 (page 10).
     ///
     /// <http://www.secg.org/sec1-v2.pdf>
-    pub fn from_bytes(input: impl AsRef<[u8]>) -> Result<Self, Error> {
+    pub fn from_bytes(input: impl AsRef<[u8]>) -> Result<Self> {
         let input = input.as_ref();
 
         // Validate tag
@@ -230,7 +230,7 @@ where
     }
 
     /// Decode this [`EncodedPoint`] into the desired type
-    pub fn decode<T>(&self) -> Result<T, Error>
+    pub fn decode<T>(&self) -> Result<T>
     where
         T: FromEncodedPoint<C>,
     {
@@ -411,7 +411,7 @@ pub enum Tag {
 
 impl Tag {
     /// Parse a tag value from a byte
-    pub fn from_u8(byte: u8) -> Result<Self, Error> {
+    pub fn from_u8(byte: u8) -> Result<Self> {
         match byte {
             0 => Ok(Tag::Identity),
             2 => Ok(Tag::CompressedEvenY),
@@ -512,7 +512,7 @@ where
     fn validate_public_key(
         secret_key: &SecretKey<Self>,
         public_key: &EncodedPoint<Self>,
-    ) -> Result<(), Error> {
+    ) -> Result<()> {
         // Provide a default "always succeeds" implementation.
         // This is the intended default for curve implementations which
         // do not provide an arithmetic implementation, since they have no
@@ -534,10 +534,7 @@ where
     UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
     UncompressedPointSize<C>: ArrayLength<u8>,
 {
-    fn validate_public_key(
-        secret_key: &SecretKey<C>,
-        public_key: &EncodedPoint<C>,
-    ) -> Result<(), Error> {
+    fn validate_public_key(secret_key: &SecretKey<C>, public_key: &EncodedPoint<C>) -> Result<()> {
         let pk = secret_key
             .public_key()
             .to_encoded_point(public_key.is_compressed());

--- a/elliptic-curve/src/secret_key.rs
+++ b/elliptic-curve/src/secret_key.rs
@@ -10,7 +10,7 @@
 #[cfg(feature = "pkcs8")]
 mod pkcs8;
 
-use crate::{error::Error, Curve, FieldBytes};
+use crate::{Curve, Error, FieldBytes, Result};
 use core::{
     convert::{TryFrom, TryInto},
     fmt::{self, Debug},
@@ -102,7 +102,7 @@ where
     }
 
     /// Deserialize raw private scalar as a big endian integer
-    pub fn from_bytes(bytes: impl AsRef<[u8]>) -> Result<Self, Error> {
+    pub fn from_bytes(bytes: impl AsRef<[u8]>) -> Result<Self> {
         bytes
             .as_ref()
             .try_into()
@@ -150,7 +150,7 @@ where
     /// Parse a [`JwkEcKey`] JSON Web Key (JWK) into a [`SecretKey`].
     #[cfg(feature = "jwk")]
     #[cfg_attr(docsrs, doc(cfg(feature = "jwk")))]
-    pub fn from_jwk(jwk: &JwkEcKey) -> Result<Self, Error>
+    pub fn from_jwk(jwk: &JwkEcKey) -> Result<Self>
     where
         C: JwkParameters + ValidatePublicKey,
         UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
@@ -162,7 +162,7 @@ where
     /// Parse a string containing a JSON Web Key (JWK) into a [`SecretKey`].
     #[cfg(feature = "jwk")]
     #[cfg_attr(docsrs, doc(cfg(feature = "jwk")))]
-    pub fn from_jwk_str(jwk: &str) -> Result<Self, Error>
+    pub fn from_jwk_str(jwk: &str) -> Result<Self>
     where
         C: JwkParameters + ValidatePublicKey,
         UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
@@ -212,7 +212,7 @@ where
 {
     type Error = Error;
 
-    fn try_from(slice: &[u8]) -> Result<Self, Error> {
+    fn try_from(slice: &[u8]) -> Result<Self> {
         Self::from_bytes(slice)
     }
 }

--- a/elliptic-curve/src/secret_key/pkcs8.rs
+++ b/elliptic-curve/src/secret_key/pkcs8.rs
@@ -3,7 +3,7 @@
 use super::{SecretKey, SecretValue};
 use crate::{
     sec1::{self, UncompressedPointSize, UntaggedPointSize, ValidatePublicKey},
-    weierstrass, AlgorithmParameters, FieldBytes, ALGORITHM_OID,
+    weierstrass, AlgorithmParameters, FieldBytes, Result, ALGORITHM_OID,
 };
 use core::ops::Add;
 use generic_array::{typenum::U1, ArrayLength};
@@ -162,7 +162,7 @@ where
 {
     type Err = Error;
 
-    fn from_str(s: &str) -> Result<Self, Error> {
+    fn from_str(s: &str) -> Result<Self> {
         Self::from_pkcs8_pem(s).map_err(|_| Error)
     }
 }


### PR DESCRIPTION
As this crate has only one (opaque/unit) `Error` type, adds a `Result` type alias for simplifying errors returned using the `Error` type.