### PR TITLE
elliptic-curve v0.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -180,7 +180,7 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.9.0-pre"
+version = "0.9.0"
 dependencies = [
  "base64ct",
  "ff",

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 aead = { version = "0.4", optional = true, path = "../aead" }
 cipher = { version = "=0.3.0-pre.4", optional = true, path = "../cipher" }
 digest = { version = "0.10.0-pre", optional = true, path = "../digest" }
-elliptic-curve = { version = "=0.9.0-pre", optional = true, path = "../elliptic-curve" }
+elliptic-curve = { version = "0.9", optional = true, path = "../elliptic-curve" }
 mac = { version = "=0.11.0-pre", package = "crypto-mac", optional = true, path = "../crypto-mac" }
 password-hash = { version = "0.1", optional = true, path = "../password-hash" }
 signature = { version = "1.3.0", optional = true, default-features = false, path = "../signature" }

--- a/elliptic-curve/CHANGELOG.md
+++ b/elliptic-curve/CHANGELOG.md
@@ -4,6 +4,34 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.9.0 (2021-02-10)
+### Added
+- JWK support ([#483])
+- `sec1::ValidatePublicKey` trait ([#485])
+- `hazmat` crate feature ([#487])
+- `Result` alias ([#534])
+
+### Changed
+- Bump `ff` and `group` crates to v0.9 ([#452])
+- Simplify ECDH trait bounds ([#475])
+- Flatten API ([#487])
+- Bump `pkcs8` crate dependency to v0.4 ([#493])
+
+### Removed
+- Direct `bitvec` dependency ([#484])
+- `FromDigest` trait ([#532])
+
+[#452]: https://github.com/RustCrypto/traits/pull/452
+[#475]: https://github.com/RustCrypto/traits/pull/475
+[#483]: https://github.com/RustCrypto/traits/pull/483
+[#484]: https://github.com/RustCrypto/traits/pull/484
+[#485]: https://github.com/RustCrypto/traits/pull/485
+[#487]: https://github.com/RustCrypto/traits/pull/487
+[#493]: https://github.com/RustCrypto/traits/pull/493
+[#432]: https://github.com/RustCrypto/traits/pull/432
+[#532]: https://github.com/RustCrypto/traits/pull/532
+[#534]: https://github.com/RustCrypto/traits/pull/534
+
 ## 0.8.4 (2020-12-23)
 ### Fixed
 - Rust `nightly` regression ([#432])

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -5,7 +5,7 @@ General purpose Elliptic Curve Cryptography (ECC) support, including types
 and traits for representing various elliptic curve forms, scalars, points,
 and public/secret keys composed thereof.
 """
-version    = "0.9.0-pre" # Also update html_root_url in lib.rs when bumping this
+version    = "0.9.0" # Also update html_root_url in lib.rs when bumping this
 authors    = ["RustCrypto Developers"]
 license    = "Apache-2.0 OR MIT"
 repository = "https://github.com/RustCrypto/traits/tree/master/elliptic-curve"

--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -16,7 +16,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/elliptic-curve/0.8.4"
+    html_root_url = "https://docs.rs/elliptic-curve/0.9.0"
 )]
 
 #[cfg(feature = "alloc")]


### PR DESCRIPTION
### Added
- JWK support ([#483])
- `sec1::ValidatePublicKey` trait ([#485])
- `hazmat` crate feature ([#487])
- `Result` alias ([#534])

### Changed
- Bump `ff` and `group` crates to v0.9 ([#452])
- Simplify ECDH trait bounds ([#475])
- Flatten API ([#487])
- Bump `pkcs8` crate dependency to v0.4 ([#493])

### Removed
- Direct `bitvec` dependency ([#484])
- `FromDigest` trait ([#532])

[#452]: https://github.com/RustCrypto/traits/pull/452
[#475]: https://github.com/RustCrypto/traits/pull/475
[#483]: https://github.com/RustCrypto/traits/pull/483
[#484]: https://github.com/RustCrypto/traits/pull/484
[#485]: https://github.com/RustCrypto/traits/pull/485
[#487]: https://github.com/RustCrypto/traits/pull/487
[#493]: https://github.com/RustCrypto/traits/pull/493
[#432]: https://github.com/RustCrypto/traits/pull/432
[#532]: https://github.com/RustCrypto/traits/pull/532
[#534]: https://github.com/RustCrypto/traits/pull/534