### PR TITLE
elliptic-curve: remove BitView re-export

### DIFF
--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -65,7 +65,7 @@ pub use {
         public_key::PublicKey,
         scalar::{NonZeroScalar, Scalar, ScalarBits},
     },
-    ff::{self, BitView, Field},
+    ff::{self, Field},
     group::{self, Group},
 };
 


### PR DESCRIPTION
Removes the re-export of `ff::BitView`, as the `ff` crate itself is already re-exported, so it's available as `elliptic_curve::ff::BitView`.

Note that this is technically a breaking change, however the plan is to release a v0.9.1 and yank the v0.9.0 release. This is acceptable largely because the previous release is not being widely used (released 18 hours ago with 189 downloads) and therefore this change is unlikely to cause problems in practice, especially considering its relatively minor nature.