### PR TITLE
elliptic-curve: pin `funty` to `=1.1.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,9 +76,9 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.10.0-pre.1"
+version = "0.10.0-pre.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae646bb58db3c82677a9ebece843b3577e1e2e134067c3e69681ebe1e4c75f02"
+checksum = "9bda843099271fe07dc9638389268bf732e981d8a71d7a1472f79eb54cc5a827"
 dependencies = [
  "block-padding",
  "generic-array 0.14.4",
@@ -153,9 +153,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.2.0"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65ade418c7a9e4edd2dab3b4749ef6c56ee4b137bc1600215c158cff8e5d39b2"
+checksum = "b70f809fb1678da4d5ea334095cbe8d6c64fea35fc52836db6c241caee68e17e"
 dependencies = [
  "const-oid",
 ]
@@ -174,7 +174,7 @@ name = "digest"
 version = "0.10.0-pre.3"
 dependencies = [
  "blobby",
- "block-buffer 0.10.0-pre.1",
+ "block-buffer 0.10.0-pre.2",
  "generic-array 0.14.4",
 ]
 
@@ -184,6 +184,7 @@ version = "0.9.2"
 dependencies = [
  "base64ct",
  "ff",
+ "funty",
  "generic-array 0.14.4",
  "group",
  "hex-literal 0.3.1",
@@ -346,18 +347,18 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "991431c3519a3f36861882da93630ce66b52918dcf1b8e2fd66b397fc96f28df"
+checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "radium"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9e006811e1fdd12672b0820a7f44c18dde429f367d50cec003d22aa9b3c8ddc"
+checksum = "643f8f41a8ebc4c5dc4515c82bb8abd397b527fc20fd681b7c011c2aee5d44fb"
 
 [[package]]
 name = "rand_core"
@@ -445,9 +446,9 @@ checksum = "1e81da0851ada1f3e9d4312c704aa4f8806f0f9d69faaf8df2f3464b4a9437c2"
 
 [[package]]
 name = "syn"
-version = "1.0.58"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc60a3d73ea6594cd712d830cc1f0390fd71542d8c8cd24e70cc54cdfd5e05d5"
+checksum = "c700597eca8a5a762beb35753ef6b94df201c81cca676604f547495a0d7f0081"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -468,9 +469,9 @@ dependencies = [
 
 [[package]]
 name = "tap"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36474e732d1affd3a6ed582781b3683df3d0563714c59c39591e8ff707cf078e"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "typenum"

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -17,6 +17,7 @@ keywords   = ["crypto", "ecc", "elliptic", "weierstrass"]
 [dependencies]
 base64ct = { version = "0.2", optional = true, default-features = false }
 ff = { version = "0.9", optional = true, default-features = false }
+funty = { version = "=1.1.0", default-features = false }  # see https://github.com/bitvecto-rs/bitvec/issues/105
 group = { version = "0.9", optional = true, default-features = false }
 hex-literal = { version = "0.3", optional = true }
 generic-array = { version = "0.14", default-features = false }


### PR DESCRIPTION
Workaround for https://github.com/bitvecto-rs/bitvec/issues/105