### PR TITLE
ci: add `override: true` to clippy and rustfmt

### DIFF
--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -16,10 +16,12 @@ jobs:
     - uses: actions/checkout@v1
     - uses: actions-rs/toolchain@v1
       with:
-        profile: minimal
-        toolchain: 1.44.0 # Highest MSRV in repo
+        toolchain: 1.47.0 # Highest MSRV in repo
         components: clippy
+        override: true
+        profile: minimal
     - run: cargo clippy --all --all-features -- -D warnings
+
   rustfmt:
     runs-on: ubuntu-latest
     steps:
@@ -29,9 +31,10 @@ jobs:
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1
         with:
-          profile: minimal
           toolchain: stable
           components: rustfmt
+          override: true
+          profile: minimal
 
       - name: Run cargo fmt
         uses: actions-rs/cargo@v1


### PR DESCRIPTION
We intended to run clippy at lowest MSRV, but this directive was accidentally omitted leading to unintended breakages when new `stable` releases added new lints:

https://github.com/RustCrypto/traits/pull/554/checks?check_run_id=1922987991