### PR TITLE
elliptic-curve: use string-based OID constants

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,9 +116,9 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7e8dd5eab3bedc0f623f388e724eee9a880b3d297430e8685672e338f449a27"
+checksum = "fb27bc55bac783b7cfd5eafba8a3e94ff6d420fc4e04970a207980683145af83"
 
 [[package]]
 name = "cpuid-bool"

--- a/elliptic-curve/src/dev.rs
+++ b/elliptic-curve/src/dev.rs
@@ -49,7 +49,7 @@ impl ProjectiveArithmetic for MockCurve {
 
 impl AlgorithmParameters for MockCurve {
     /// OID for NIST P-256
-    const OID: pkcs8::ObjectIdentifier = pkcs8::ObjectIdentifier::new(&[1, 2, 840, 10045, 3, 1, 7]);
+    const OID: pkcs8::ObjectIdentifier = pkcs8::ObjectIdentifier::parse("1.2.840.10045.3.1.7");
 }
 
 #[cfg(feature = "jwk")]

--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -93,7 +93,7 @@ use generic_array::{typenum::Unsigned, ArrayLength, GenericArray};
 #[cfg(feature = "pkcs8")]
 #[cfg_attr(docsrs, doc(cfg(feature = "pkcs8")))]
 pub const ALGORITHM_OID: pkcs8::ObjectIdentifier =
-    pkcs8::ObjectIdentifier::new(&[1, 2, 840, 10045, 2, 1]);
+    pkcs8::ObjectIdentifier::parse("1.2.840.10045.2.1");
 
 /// Elliptic curve.
 ///


### PR DESCRIPTION
Uses the new const-friendly OID string parser added in:

https://github.com/RustCrypto/utils/pull/312