### PR TITLE
digest: allow DynDigest usage without `alloc` enabled

### DIFF
--- a/digest/src/digest.rs
+++ b/digest/src/digest.rs
@@ -4,8 +4,10 @@ use generic_array::{ArrayLength, GenericArray};
 
 /// The `Digest` trait specifies an interface common for digest functions.
 ///
-/// It's a convenience wrapper around [`Update`], [`FixedOutput`], [`Reset`],
-/// [`Clone`], and [`Default`] traits. It also provides additional convenience methods.
+/// It's a convenience wrapper around [`Update`], [`FixedOutput`],
+/// [`Reset`][`crate::Reset`], [`Clone`], and [`Default`] traits.
+///
+/// It also provides additional convenience methods.
 pub trait Digest {
     /// Output size for `Digest`
     type OutputSize: ArrayLength<u8>;

--- a/digest/src/lib.rs
+++ b/digest/src/lib.rs
@@ -50,7 +50,6 @@ pub mod dev;
 #[cfg_attr(docsrs, doc(cfg(feature = "core-api")))]
 pub mod core_api;
 mod digest;
-#[cfg(feature = "alloc")]
 mod dyn_digest;
 
 pub use crate::digest::{Digest, Output};
@@ -58,7 +57,6 @@ use core::fmt;
 #[cfg(feature = "core-api")]
 #[cfg_attr(docsrs, doc(cfg(feature = "core-api")))]
 pub use crypto_common::block_buffer;
-#[cfg(feature = "alloc")]
 pub use dyn_digest::{DynDigest, InvalidBufferLength};
 pub use generic_array::{self, typenum::consts, GenericArray};
 


### PR DESCRIPTION
Moves `alloc`-based gating for `DynDigest` to just the methods that use `Box`, which enables usage of the trait in "heapless" environments.

Closes #545 (cc @rvolgers)