### PR TITLE
elliptic-curve v0.9.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -197,7 +197,7 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "base64ct 1.0.0",
  "ff",

--- a/elliptic-curve/CHANGELOG.md
+++ b/elliptic-curve/CHANGELOG.md
@@ -4,7 +4,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.9.4 (2021-02-18)
+## 0.9.5 (2021-03-17)
+### Added
+- Implement `{to,char}_le_bits` for `MockCurve` ([#565])
+- Implement `one()` for mock `Scalar` ([#566])
+
+### Changed
+- Use string-based OID constants ([#561])
+- Bump `base64ct` dependency to v1.0 ([#581])
+
+[#561]: https://github.com/RustCrypto/traits/pull/561
+[#565]: https://github.com/RustCrypto/traits/pull/565
+[#566]: https://github.com/RustCrypto/traits/pull/566
+[#581]: https://github.com/RustCrypto/traits/pull/581
+
+## 0.9.4 (2021-02-18) [YANKED]
 ### Fixed
 - Breakage related to the `pkcs8` v0.5.1 crate ([#556]) 
 

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -5,7 +5,7 @@ General purpose Elliptic Curve Cryptography (ECC) support, including types
 and traits for representing various elliptic curve forms, scalars, points,
 and public/secret keys composed thereof.
 """
-version    = "0.9.4" # Also update html_root_url in lib.rs when bumping this
+version    = "0.9.5" # Also update html_root_url in lib.rs when bumping this
 authors    = ["RustCrypto Developers"]
 license    = "Apache-2.0 OR MIT"
 repository = "https://github.com/RustCrypto/traits/tree/master/elliptic-curve"

--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -16,7 +16,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
-    html_root_url = "https://docs.rs/elliptic-curve/0.9.4"
+    html_root_url = "https://docs.rs/elliptic-curve/0.9.5"
 )]
 
 #[cfg(feature = "alloc")]


### PR DESCRIPTION
### Added
- Implement `{to,char}_le_bits` for `MockCurve` ([#565])
- Implement `one()` for mock `Scalar` ([#566])

### Changed
- Use string-based OID constants ([#561])
- Bump `base64ct` dependency to v1.0 ([#581])

[#561]: https://github.com/RustCrypto/traits/pull/561
[#565]: https://github.com/RustCrypto/traits/pull/565
[#566]: https://github.com/RustCrypto/traits/pull/566
[#581]: https://github.com/RustCrypto/traits/pull/581