### PR TITLE
elliptic-curve v0.9.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -191,7 +191,7 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "base64ct",
  "ff",

--- a/elliptic-curve/CHANGELOG.md
+++ b/elliptic-curve/CHANGELOG.md
@@ -4,7 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.9.5 (2021-03-17)
+## 0.9.6 (2021-03-22)
+### Changed
+- Bump `pkcs8` dependency to v0.6 ([#585])
+
+[#585]: https://github.com/RustCrypto/traits/pull/585
+
+## 0.9.5 (2021-03-17) [YANKED]
 ### Added
 - Implement `{to,char}_le_bits` for `MockCurve` ([#565])
 - Implement `one()` for mock `Scalar` ([#566])

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -5,7 +5,7 @@ General purpose Elliptic Curve Cryptography (ECC) support, including types
 and traits for representing various elliptic curve forms, scalars, points,
 and public/secret keys composed thereof.
 """
-version    = "0.9.5" # Also update html_root_url in lib.rs when bumping this
+version    = "0.9.6" # Also update html_root_url in lib.rs when bumping this
 authors    = ["RustCrypto Developers"]
 license    = "Apache-2.0 OR MIT"
 repository = "https://github.com/RustCrypto/traits/tree/master/elliptic-curve"

--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -16,7 +16,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
-    html_root_url = "https://docs.rs/elliptic-curve/0.9.5"
+    html_root_url = "https://docs.rs/elliptic-curve/0.9.6"
 )]
 
 #[cfg(feature = "alloc")]


### PR DESCRIPTION
### Changed
- Bump `pkcs8` dependency to v0.6 ([#585])

[#585]: https://github.com/RustCrypto/traits/pull/585