### PR TITLE
Add support for PointCompaction trait

### DIFF
--- a/elliptic-curve/src/public_key.rs
+++ b/elliptic-curve/src/public_key.rs
@@ -5,7 +5,7 @@ use crate::{
     sec1::{
         EncodedPoint, FromEncodedPoint, ToEncodedPoint, UncompressedPointSize, UntaggedPointSize,
     },
-    weierstrass::{Curve, PointCompression},
+    weierstrass::{Curve, PointCompaction, PointCompression},
     AffinePoint, Error, FieldBytes, NonZeroScalar, ProjectiveArithmetic, ProjectivePoint, Result,
     Scalar,
 };
@@ -224,7 +224,7 @@ where
 
 impl<C> From<PublicKey<C>> for EncodedPoint<C>
 where
-    C: Curve + ProjectiveArithmetic + PointCompression,
+    C: Curve + ProjectiveArithmetic + PointCompression + PointCompaction,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
     AffinePoint<C>: Copy + Clone + Debug + Default + FromEncodedPoint<C> + ToEncodedPoint<C>,
     ProjectivePoint<C>: From<AffinePoint<C>>,
@@ -238,7 +238,7 @@ where
 
 impl<C> From<&PublicKey<C>> for EncodedPoint<C>
 where
-    C: Curve + ProjectiveArithmetic + PointCompression,
+    C: Curve + ProjectiveArithmetic + PointCompression + PointCompaction,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
     AffinePoint<C>: Copy + Clone + Debug + Default + FromEncodedPoint<C> + ToEncodedPoint<C>,
     ProjectivePoint<C>: From<AffinePoint<C>>,

--- a/elliptic-curve/src/weierstrass.rs
+++ b/elliptic-curve/src/weierstrass.rs
@@ -12,9 +12,21 @@ pub trait PointCompression {
     const COMPRESS_POINTS: bool;
 }
 
+/// Point compaction settings
+pub trait PointCompaction {
+    /// Should point compaction be applied by default?
+    const COMPACT_POINTS: bool;
+}
+
 /// Attempt to decompress an elliptic curve point from its x-coordinate and
 /// a boolean flag indicating whether or not the y-coordinate is odd.
 pub trait DecompressPoint<C: Curve>: Sized {
     /// Attempt to decompress an elliptic curve point.
     fn decompress(x: &FieldBytes<C>, y_is_odd: Choice) -> CtOption<Self>;
+}
+
+/// Attempt to decompact an elliptic curve point from an x-coordinate
+pub trait DecompactPoint<C: Curve>: Sized {
+    /// Attempt to decompact an elliptic curve point
+    fn decompact(x: &FieldBytes<C>) -> CtOption<Self>;
 }


### PR DESCRIPTION
This PR enables support for `PointCompaction` specifically as detailed in [IETF-draft-jivsov-ecc-compact-05](https://tools.ietf.org/html/draft-jivsov-ecc-compact-05#section-3).

The key idea being that the `y` coordinate of a point on the curve can be derived from the `x` coordinate allowing a more concise representation of the points. Note that this is different from `PointCompression`.