### PR TITLE
elliptic-curve: fix `SecretKey::from_bytes` slice parsing

### DIFF
--- a/aead/src/stream.rs
+++ b/aead/src/stream.rs
@@ -226,7 +226,7 @@ macro_rules! impl_stream_object {
             pub fn new(key: &Key<A>, nonce: &Nonce<A, S>) -> Self
             where
                 A: NewAead,
-                S: NewStream<A>
+                S: NewStream<A>,
             {
                 Self::from_stream_primitive(S::new(key, nonce))
             }
@@ -237,7 +237,7 @@ macro_rules! impl_stream_object {
             pub fn from_aead(aead: A, nonce: &Nonce<A, S>) -> Self
             where
                 A: NewAead,
-                S: NewStream<A>
+                S: NewStream<A>,
             {
                 Self::from_stream_primitive(S::from_aead(aead, nonce))
             }
@@ -291,7 +291,8 @@ macro_rules! impl_stream_object {
                     return Err(Error);
                 }
 
-                self.stream.$in_place_op(self.position, false, associated_data, buffer)?;
+                self.stream
+                    .$in_place_op(self.position, false, associated_data, buffer)?;
 
                 // Note: overflow checked above
                 self.position += S::COUNTER_INCR;
@@ -322,12 +323,13 @@ macro_rules! impl_stream_object {
             pub fn $last_in_place_method(
                 self,
                 associated_data: &[u8],
-                buffer: &mut dyn Buffer
+                buffer: &mut dyn Buffer,
             ) -> Result<(), Error> {
-                self.stream.$in_place_op(self.position, true, associated_data, buffer)
+                self.stream
+                    .$in_place_op(self.position, true, associated_data, buffer)
             }
         }
-    }
+    };
 }
 
 impl_stream_object!(

--- a/elliptic-curve/tests/secret_key.rs
+++ b/elliptic-curve/tests/secret_key.rs
@@ -1,0 +1,10 @@
+//! Secret key tests
+
+#![cfg(feature = "dev")]
+
+use elliptic_curve::dev::SecretKey;
+
+#[test]
+fn undersize_secret_key() {
+    assert!(SecretKey::from_bytes(&[]).is_err());
+}


### PR DESCRIPTION
Closes #588

`SecretKey::from_bytes` was previously attempting to use `TryFrom<&[u8]>` on `GenericArray`, however `GenericArray` actually has a panicking `From` impl, and was therefore receiving panicking `TryFrom` via the blanket impl of `TryFrom` for `From`.

This commit adds a regression test which captures the bug, and fixes the implementation to test that the slice is correctly sized.