### PR TITLE
password-hash: fix broken `b64` links

### DIFF
--- a/password-hash/src/output.rs
+++ b/password-hash/src/output.rs
@@ -87,7 +87,7 @@ impl Output {
         MAX_LENGTH
     }
 
-    /// Maximum length of [`Output`] when encoded as [`b64`] string: 86-bytes
+    /// Maximum length of [`Output`] when encoded as B64 string: 86-bytes
     /// (i.e. 86 ASCII characters)
     pub const fn b64_max_len() -> usize {
         ((MAX_LENGTH * 4) / 3) + 1
@@ -153,13 +153,13 @@ impl Output {
         usize::from(self.length)
     }
 
-    /// Parse [`b64`]-encoded [`Output`], i.e. using the PHC string
+    /// Parse B64-encoded [`Output`], i.e. using the PHC string
     /// specification's restricted interpretation of Base64.
     pub fn b64_decode(input: &str) -> Result<Self, OutputError> {
         Self::decode(input, Encoding::B64)
     }
 
-    /// Write [`b64`]-encoded [`Output`] to the provided buffer, returning
+    /// Write B64-encoded [`Output`] to the provided buffer, returning
     /// a sub-slice containing the encoded data.
     ///
     /// Returns an error if the buffer is too short to contain the output.
@@ -185,7 +185,7 @@ impl Output {
         Ok(encoding.encode(self.as_ref(), out)?)
     }
 
-    /// Get the length of this [`Output`] when encoded as [`b64`].
+    /// Get the length of this [`Output`] when encoded as B64.
     pub fn b64_len(&self) -> usize {
         Encoding::B64.encoded_len(self.as_ref())
     }

--- a/password-hash/src/salt.rs
+++ b/password-hash/src/salt.rs
@@ -117,9 +117,9 @@ impl<'a> Salt<'a> {
         Ok(Self(input.try_into()?))
     }
 
-    /// Attempt to decode a [`b64`][`crate::b64`]-encoded [`Salt`], writing the
-    /// decoded result into the provided buffer, and returning a slice of the
-    /// buffer containing the decoded result on success.
+    /// Attempt to decode a B64-encoded [`Salt`], writing the decoded result
+    /// into the provided buffer, and returning a slice of the buffer
+    /// containing the decoded result on success.
     ///
     /// [1]: https://github.com/P-H-C/phc-string-format/blob/master/phc-sf-spec.md#argon2-encoding
     pub fn b64_decode<'b>(&self, buf: &'b mut [u8]) -> Result<&'b [u8], B64Error> {

--- a/password-hash/src/value.rs
+++ b/password-hash/src/value.rs
@@ -69,7 +69,7 @@ impl<'a> Value<'a> {
         Ok(Self(input))
     }
 
-    /// Attempt to decode a [`b64`]-encoded [`Value`], writing the decoded
+    /// Attempt to decode a B64-encoded [`Value`], writing the decoded
     /// result into the provided buffer, and returning a slice of the buffer
     /// containing the decoded result on success.
     ///


### PR DESCRIPTION
This module no-longer exists as it was replaced by the `base64ct` crate