### PR TITLE
password-hash v0.1.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -323,7 +323,7 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "password-hash"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "base64ct",
  "rand_core",

--- a/password-hash/CHANGELOG.md
+++ b/password-hash/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.3 (2021-04-17)
+### Changed
+- Update docs for PHC string <version> field ([#593])
+
+### Fixed
+- Broken `b64` links in rustdoc ([#594])
+
+[#593]: https://github.com/RustCrypto/traits/pull/593
+[#594]: https://github.com/RustCrypto/traits/pull/594
+
 ## 0.1.2 (2021-03-17)
 ### Changed
 - Bump `base64ct` dependency to v1.0 ([#579])

--- a/password-hash/Cargo.toml
+++ b/password-hash/Cargo.toml
@@ -5,7 +5,7 @@ Traits which describe the functionality of password hashing algorithms,
 as well as a `no_std`-friendly implementation of the PHC string format
 (a well-defined subset of the Modular Crypt Format a.k.a. MCF)
 """
-version = "0.1.2"
+version = "0.1.3"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/password-hash/src/lib.rs
+++ b/password-hash/src/lib.rs
@@ -39,7 +39,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
-    html_root_url = "https://docs.rs/password-hash/0.1.2"
+    html_root_url = "https://docs.rs/password-hash/0.1.3"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]


### PR DESCRIPTION
### Changed
- Update docs for PHC string <version> field ([#593])

### Fixed
- Broken `b64` links in rustdoc ([#594])

[#593]: https://github.com/RustCrypto/traits/pull/593
[#594]: https://github.com/RustCrypto/traits/pull/594