### PR TITLE
aead: require `heapless` v0.6.1

### DIFF
--- a/aead/Cargo.toml
+++ b/aead/Cargo.toml
@@ -18,7 +18,7 @@ categories = ["cryptography", "no-std"]
 generic-array = { version = "0.14", default-features = false }
 
 blobby = { version = "0.3", optional = true }
-heapless = { version = "0.6", optional = true, default-features = false }
+heapless = { version = "0.6.1", optional = true, default-features = false }
 rand_core = { version = "0.6", optional = true }
 
 [features]


### PR DESCRIPTION
This is mostly to clear the https://deps.rs "insecure" warning from the repo.