### PR TITLE
elliptic-curve: add Order trait

### DIFF
--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -25,11 +25,13 @@ extern crate alloc;
 #[cfg(feature = "std")]
 extern crate std;
 
-mod error;
 pub mod ops;
 pub mod sec1;
 pub mod util;
 pub mod weierstrass;
+
+mod error;
+mod order;
 
 #[cfg(feature = "arithmetic")]
 mod point;
@@ -52,7 +54,10 @@ mod jwk;
 #[cfg(feature = "zeroize")]
 mod secret_key;
 
-pub use self::error::{Error, Result};
+pub use self::{
+    error::{Error, Result},
+    order::Order,
+};
 
 pub use generic_array::{self, typenum::consts};
 pub use rand_core;

--- a/elliptic-curve/src/order.rs
+++ b/elliptic-curve/src/order.rs
@@ -1,0 +1,31 @@
+//! Low-level elliptic curve parameters.
+
+use crate::Curve;
+use core::fmt::Debug;
+
+/// Order of an elliptic curve group.
+///
+/// This trait is available even when the `arithmetic` feature of the crate
+/// is disabled and does not require any additional crate dependencies.
+///
+/// This trait is useful for supporting a baseline level of functionality
+/// across curve implementations, even ones which do not provide a field
+/// arithmetic backend.
+// TODO(tarcieri): merge this with the `Curve` type in the next release?
+pub trait Order: Curve {
+    /// Type representing the "limbs" of the curves group's order on
+    /// 32-bit platforms.
+    #[cfg(target_pointer_width = "32")]
+    type Limbs: AsRef<[u32]> + Copy + Debug;
+
+    /// Type representing the "limbs" of the curves group's order on
+    /// 64-bit platforms.
+    #[cfg(target_pointer_width = "64")]
+    type Limbs: AsRef<[u64]> + Copy + Debug;
+
+    /// Order constant (a.k.a. `N`).
+    ///
+    /// Subdivided into either 32-bit or 64-bit "limbs" (depending on the
+    /// target CPU's word size), specified from least to most significant.
+    const ORDER: Self::Limbs;
+}


### PR DESCRIPTION
Adds a trait which notably does *not* depend on the `arithmetic` feature which allows associating a constant for the curve's order with a particular curve type.

Since it stores the curve type as a constant, it's not possible to use `GenericArray`, so instead it has each curve specify a `Limbs` type which is used as the type for an `ORDER` constant.

The longer-term goal will be to merge this with the `Curve` trait, ensuring that every curve implementation has a known order regardless of whether it provides an arithmetic backend or not.

This can be used as the foundation for making certain functionality generic across curve implementations at a baseline, such as checking if scalars are in-range, and as such can simplify things which are presently conditionally defined based on the presence or absence of an arithmetic backend.