### PR TITLE
elliptic-curve: add `ScalarBytes` type

### DIFF
--- a/elliptic-curve/src/dev.rs
+++ b/elliptic-curve/src/dev.rs
@@ -7,13 +7,12 @@ use crate::{
     ff::{Field, PrimeField},
     group,
     rand_core::RngCore,
-    scalar::ScalarBits,
     sec1::{FromEncodedPoint, ToEncodedPoint},
     subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption},
     util::sbb64,
     weierstrass,
     zeroize::Zeroize,
-    AlgorithmParameters, Curve, Order, ProjectiveArithmetic,
+    AlgorithmParameters, Curve, Order, ProjectiveArithmetic, ScalarBits,
 };
 use core::{
     convert::{TryFrom, TryInto},
@@ -93,7 +92,7 @@ pub type EncodedPoint = crate::sec1::EncodedPoint<MockCurve>;
 pub type FieldBytes = crate::FieldBytes<MockCurve>;
 
 /// Non-zero scalar value.
-pub type NonZeroScalar = crate::scalar::NonZeroScalar<MockCurve>;
+pub type NonZeroScalar = crate::NonZeroScalar<MockCurve>;
 
 /// Public key.
 pub type PublicKey = crate::PublicKey<MockCurve>;

--- a/elliptic-curve/src/ecdh.rs
+++ b/elliptic-curve/src/ecdh.rs
@@ -27,8 +27,8 @@
 //! [SIGMA]: https://webee.technion.ac.il/~hugo/sigma-pdf.pdf
 
 use crate::{
-    public_key::PublicKey, scalar::NonZeroScalar, weierstrass::Curve, AffinePoint, FieldBytes,
-    ProjectiveArithmetic, ProjectivePoint, Scalar,
+    weierstrass::Curve, AffinePoint, FieldBytes, NonZeroScalar, ProjectiveArithmetic,
+    ProjectivePoint, PublicKey, Scalar,
 };
 use core::{borrow::Borrow, fmt::Debug};
 use ff::PrimeField;

--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -32,13 +32,12 @@ pub mod weierstrass;
 
 mod error;
 mod order;
+mod scalar;
 
 #[cfg(feature = "arithmetic")]
 mod point;
 #[cfg(feature = "arithmetic")]
 mod public_key;
-#[cfg(feature = "arithmetic")]
-mod scalar;
 
 #[cfg(feature = "dev")]
 #[cfg_attr(docsrs, doc(cfg(feature = "dev")))]
@@ -68,7 +67,7 @@ pub use {
     crate::{
         point::{AffinePoint, ProjectiveArithmetic, ProjectivePoint},
         public_key::PublicKey,
-        scalar::{NonZeroScalar, Scalar, ScalarBits},
+        scalar::{bytes::ScalarBytes, non_zero::NonZeroScalar, Scalar, ScalarBits},
     },
     ff::{self, Field},
     group::{self, Group},

--- a/elliptic-curve/src/order.rs
+++ b/elliptic-curve/src/order.rs
@@ -1,14 +1,7 @@
 //! Low-level elliptic curve parameters.
 
-use crate::{Curve, FieldBytes};
-use core::{convert::TryInto, fmt::Debug, mem};
-use subtle::Choice;
-
-// TODO(tarcieri): unify these into a target-width gated `sbb`
-#[cfg(target_pointer_width = "32")]
-use crate::util::sbb32;
-#[cfg(target_pointer_width = "64")]
-use crate::util::sbb64;
+use crate::Curve;
+use core::fmt::Debug;
 
 /// Order of an elliptic curve group.
 ///
@@ -35,78 +28,4 @@ pub trait Order: Curve {
     /// Subdivided into either 32-bit or 64-bit "limbs" (depending on the
     /// target CPU's word size), specified from least to most significant.
     const ORDER: Self::Limbs;
-
-    /// Check that the given serialized scalar field element is in range.
-    ///
-    /// Field element must be serialized as a big endian integer.
-    #[cfg(target_pointer_width = "32")]
-    fn is_scalar_repr_in_range(fe_bytes: &FieldBytes<Self>) -> Choice {
-        assert_eq!(
-            mem::size_of::<Self::Limbs>(),
-            mem::size_of::<FieldBytes<Self>>()
-        );
-
-        let mut borrow = 0;
-
-        for (i, chunk) in fe_bytes.as_ref().chunks(4).rev().enumerate() {
-            let limb = u32::from_be_bytes(chunk.try_into().unwrap());
-            borrow = sbb32(limb, Self::ORDER.as_ref()[i], borrow).1;
-        }
-
-        Choice::from((borrow as u8) & 1)
-    }
-
-    /// Check that the given scalar field repr is in range.
-    ///
-    /// Field element must be serialized as a big endian integer.
-    #[cfg(target_pointer_width = "64")]
-    fn is_scalar_repr_in_range(fe_bytes: &FieldBytes<Self>) -> Choice {
-        assert_eq!(
-            mem::size_of::<Self::Limbs>(),
-            mem::size_of::<FieldBytes<Self>>()
-        );
-
-        let mut borrow = 0;
-
-        for (i, chunk) in fe_bytes.as_ref().chunks(8).rev().enumerate() {
-            let limb = u64::from_be_bytes(chunk.try_into().unwrap());
-            borrow = sbb64(limb, Self::ORDER.as_ref()[i], borrow).1;
-        }
-
-        Choice::from((borrow as u8) & 1)
-    }
-}
-
-#[cfg(all(test, feature = "dev"))]
-mod tests {
-    use super::Order;
-    use crate::dev::MockCurve;
-    use hex_literal::hex;
-
-    const SCALAR_REPR_IN_RANGE: [u8; 32] =
-        hex!("FFFFFFFF 00000000 FFFFFFFF FFFFFFFF BCE6FAAD A7179E84 F3B9CAC2 FC632550");
-
-    const SCALAR_REPR_ORDER: [u8; 32] =
-        hex!("FFFFFFFF 00000000 FFFFFFFF FFFFFFFF BCE6FAAD A7179E84 F3B9CAC2 FC632551");
-
-    const SCALAR_REPR_MAX: [u8; 32] =
-        hex!("FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF");
-
-    #[test]
-    fn scalar_in_range() {
-        let zero_in_range = MockCurve::is_scalar_repr_in_range(&Default::default());
-        assert!(bool::from(zero_in_range));
-
-        let below_order_in_range = MockCurve::is_scalar_repr_in_range(&SCALAR_REPR_IN_RANGE.into());
-        assert!(bool::from(below_order_in_range));
-    }
-
-    #[test]
-    fn scalar_with_overflow() {
-        let order_overflows = !MockCurve::is_scalar_repr_in_range(&SCALAR_REPR_ORDER.into());
-        assert!(bool::from(order_overflows));
-
-        let max_overflows = !MockCurve::is_scalar_repr_in_range(&SCALAR_REPR_MAX.into());
-        assert!(bool::from(max_overflows));
-    }
 }

--- a/elliptic-curve/src/public_key.rs
+++ b/elliptic-curve/src/public_key.rs
@@ -2,12 +2,12 @@
 
 use crate::{
     consts::U1,
-    scalar::NonZeroScalar,
     sec1::{
         EncodedPoint, FromEncodedPoint, ToEncodedPoint, UncompressedPointSize, UntaggedPointSize,
     },
     weierstrass::{Curve, PointCompression},
-    AffinePoint, Error, FieldBytes, ProjectiveArithmetic, ProjectivePoint, Result, Scalar,
+    AffinePoint, Error, FieldBytes, NonZeroScalar, ProjectiveArithmetic, ProjectivePoint, Result,
+    Scalar,
 };
 use core::{
     convert::{TryFrom, TryInto},

--- a/elliptic-curve/src/scalar.rs
+++ b/elliptic-curve/src/scalar.rs
@@ -1,163 +1,23 @@
 //! Scalar types.
 
-use crate::{
-    ops::Invert,
-    rand_core::{CryptoRng, RngCore},
-    Curve, Error, FieldBytes, ProjectiveArithmetic, Result,
-};
-use core::{convert::TryFrom, ops::Deref};
-use ff::{Field, FieldBits, PrimeField};
-use generic_array::{typenum::Unsigned, GenericArray};
-use group::Group;
-use subtle::{Choice, ConditionallySelectable, CtOption};
+pub(crate) mod bytes;
 
-#[cfg(feature = "zeroize")]
-use zeroize::Zeroize;
+#[cfg(feature = "arithmetic")]
+pub(crate) mod non_zero;
+
+#[cfg(feature = "arithmetic")]
+use {
+    crate::ProjectiveArithmetic,
+    ff::{FieldBits, PrimeField},
+    group::Group,
+};
 
 /// Scalar field element for a particular elliptic curve.
+#[cfg(feature = "arithmetic")]
 #[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
 pub type Scalar<C> = <<C as ProjectiveArithmetic>::ProjectivePoint as Group>::Scalar;
 
 /// Bit representation of a scalar field element of a given curve.
+#[cfg(feature = "arithmetic")]
 #[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
 pub type ScalarBits<C> = FieldBits<<Scalar<C> as PrimeField>::ReprBits>;
-
-/// Non-zero scalar type.
-///
-/// This type ensures that its value is not zero, ala `core::num::NonZero*`.
-/// To do this, the generic `S` type must impl both `Default` and
-/// `ConstantTimeEq`, with the requirement that `S::default()` returns 0.
-///
-/// In the context of ECC, it's useful for ensuring that scalar multiplication
-/// cannot result in the point at infinity.
-#[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
-#[derive(Clone)]
-pub struct NonZeroScalar<C>
-where
-    C: Curve + ProjectiveArithmetic,
-    Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
-{
-    scalar: Scalar<C>,
-}
-
-impl<C> NonZeroScalar<C>
-where
-    C: Curve + ProjectiveArithmetic,
-    Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
-{
-    /// Generate a random `NonZeroScalar`
-    pub fn random(mut rng: impl CryptoRng + RngCore) -> Self {
-        // Use rejection sampling to eliminate zero values
-        loop {
-            if let Some(result) = Self::new(Field::random(&mut rng)) {
-                break result;
-            }
-        }
-    }
-
-    /// Decode a [`NonZeroScalar] from a serialized field element
-    pub fn from_repr(repr: FieldBytes<C>) -> Option<Self> {
-        Scalar::<C>::from_repr(repr).and_then(Self::new)
-    }
-
-    /// Create a [`NonZeroScalar`] from a scalar.
-    // TODO(tarcieri): make this constant time?
-    pub fn new(scalar: Scalar<C>) -> Option<Self> {
-        if scalar.is_zero() {
-            None
-        } else {
-            Some(Self { scalar })
-        }
-    }
-}
-
-impl<C> AsRef<Scalar<C>> for NonZeroScalar<C>
-where
-    C: Curve + ProjectiveArithmetic,
-    Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
-{
-    fn as_ref(&self) -> &Scalar<C> {
-        &self.scalar
-    }
-}
-
-impl<C> ConditionallySelectable for NonZeroScalar<C>
-where
-    C: Curve + ProjectiveArithmetic,
-    Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
-{
-    fn conditional_select(a: &Self, b: &Self, choice: Choice) -> Self {
-        Self {
-            scalar: Scalar::<C>::conditional_select(&a.scalar, &b.scalar, choice),
-        }
-    }
-}
-
-impl<C> Copy for NonZeroScalar<C>
-where
-    C: Curve + ProjectiveArithmetic,
-    Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
-{
-}
-
-impl<C> Deref for NonZeroScalar<C>
-where
-    C: Curve + ProjectiveArithmetic,
-    Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
-{
-    type Target = Scalar<C>;
-
-    fn deref(&self) -> &Scalar<C> {
-        &self.scalar
-    }
-}
-
-impl<C> From<NonZeroScalar<C>> for FieldBytes<C>
-where
-    C: Curve + ProjectiveArithmetic,
-    Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
-{
-    fn from(scalar: NonZeroScalar<C>) -> FieldBytes<C> {
-        scalar.scalar.to_repr()
-    }
-}
-
-impl<C> Invert for NonZeroScalar<C>
-where
-    C: Curve + ProjectiveArithmetic,
-    Scalar<C>: PrimeField<Repr = FieldBytes<C>> + Invert,
-{
-    type Output = Scalar<C>;
-
-    /// Perform a scalar inversion
-    fn invert(&self) -> CtOption<Self::Output> {
-        ff::Field::invert(&self.scalar)
-    }
-}
-
-impl<C> TryFrom<&[u8]> for NonZeroScalar<C>
-where
-    C: Curve + ProjectiveArithmetic,
-    Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
-{
-    type Error = Error;
-
-    fn try_from(bytes: &[u8]) -> Result<Self> {
-        if bytes.len() == C::FieldSize::to_usize() {
-            NonZeroScalar::from_repr(GenericArray::clone_from_slice(bytes)).ok_or(Error)
-        } else {
-            Err(Error)
-        }
-    }
-}
-
-#[cfg(feature = "zeroize")]
-impl<C> Zeroize for NonZeroScalar<C>
-where
-    C: Curve + ProjectiveArithmetic,
-    Scalar<C>: PrimeField<Repr = FieldBytes<C>> + Zeroize,
-{
-    fn zeroize(&mut self) {
-        self.scalar.zeroize();
-    }
-}

--- a/elliptic-curve/src/scalar/bytes.rs
+++ b/elliptic-curve/src/scalar/bytes.rs
@@ -1,0 +1,201 @@
+//! Scalar bytes.
+
+use crate::{Curve, Error, FieldBytes, Order, Result};
+use core::{
+    convert::{TryFrom, TryInto},
+    mem,
+};
+use generic_array::{typenum::Unsigned, GenericArray};
+use subtle::{Choice, CtOption};
+
+#[cfg(feature = "arithmetic")]
+use crate::{ff::PrimeField, ProjectiveArithmetic, Scalar};
+
+// TODO(tarcieri): unify these into a target-width gated `sbb`
+#[cfg(target_pointer_width = "32")]
+use crate::util::sbb32;
+#[cfg(target_pointer_width = "64")]
+use crate::util::sbb64;
+
+/// Scalar bytes: wrapper for [`FieldBytes`] which guarantees that the the
+/// inner byte value is within range of the curve's [`Order`].
+///
+/// Does not require an arithmetic implementation.
+#[derive(Clone, Debug)]
+pub struct ScalarBytes<C: Curve + Order> {
+    /// Inner byte value; guaranteed to be in range of the curve's order.
+    inner: FieldBytes<C>,
+}
+
+impl<C> ScalarBytes<C>
+where
+    C: Curve + Order,
+{
+    /// Create new [`ScalarBytes`], checking that the given input is within
+    /// range of the curve's [`Order`].
+    #[cfg(target_pointer_width = "32")]
+    pub fn new(bytes: FieldBytes<C>) -> CtOption<Self> {
+        assert_eq!(
+            mem::size_of::<C::Limbs>(),
+            mem::size_of::<FieldBytes<C>>(),
+            "malformed curve order"
+        );
+
+        let mut borrow = 0;
+
+        for (i, chunk) in bytes.as_ref().chunks(4).rev().enumerate() {
+            let limb = u32::from_be_bytes(chunk.try_into().unwrap());
+            borrow = sbb32(limb, C::ORDER.as_ref()[i], borrow).1;
+        }
+
+        let is_some = Choice::from((borrow as u8) & 1);
+        CtOption::new(Self { inner: bytes }, is_some)
+    }
+
+    /// Create new [`ScalarBytes`], checking that the given input is within
+    /// range of the curve's [`Order`].
+    #[cfg(target_pointer_width = "64")]
+    pub fn new(bytes: FieldBytes<C>) -> CtOption<Self> {
+        assert_eq!(
+            mem::size_of::<C::Limbs>(),
+            mem::size_of::<FieldBytes<C>>(),
+            "malformed curve order"
+        );
+
+        let mut borrow = 0;
+
+        for (i, chunk) in bytes.as_ref().chunks(8).rev().enumerate() {
+            let limb = u64::from_be_bytes(chunk.try_into().unwrap());
+            borrow = sbb64(limb, C::ORDER.as_ref()[i], borrow).1;
+        }
+
+        let is_some = Choice::from((borrow as u8) & 1);
+        CtOption::new(Self { inner: bytes }, is_some)
+    }
+
+    /// Convert from a [`Scalar`] type for this curve.
+    #[cfg(feature = "arithmetic")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
+    pub fn from_scalar(scalar: &Scalar<C>) -> Self
+    where
+        C: ProjectiveArithmetic,
+        Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
+    {
+        Self {
+            inner: scalar.to_repr(),
+        }
+    }
+
+    /// Convert to a [`Scalar`] type for this curve.
+    #[cfg(feature = "arithmetic")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
+    pub fn to_scalar(&self) -> Scalar<C>
+    where
+        C: ProjectiveArithmetic,
+        Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
+    {
+        self.clone().into_scalar()
+    }
+
+    /// Convert into a [`Scalar`] type for this curve.
+    #[cfg(feature = "arithmetic")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
+    pub fn into_scalar(self) -> Scalar<C>
+    where
+        C: ProjectiveArithmetic,
+        Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
+    {
+        Scalar::<C>::from_repr(self.inner).expect("ScalarBytes order invariant violated")
+    }
+
+    /// Borrow the inner [`FieldBytes`]
+    pub fn as_bytes(&self) -> &FieldBytes<C> {
+        &self.inner
+    }
+
+    /// Convert into [`FieldBytes`]
+    pub fn into_bytes(self) -> FieldBytes<C> {
+        self.inner
+    }
+}
+
+impl<C> AsRef<FieldBytes<C>> for ScalarBytes<C>
+where
+    C: Curve + Order,
+{
+    fn as_ref(&self) -> &FieldBytes<C> {
+        &self.inner
+    }
+}
+
+impl<C> AsRef<[u8]> for ScalarBytes<C>
+where
+    C: Curve + Order,
+{
+    fn as_ref(&self) -> &[u8] {
+        self.inner.as_slice()
+    }
+}
+
+impl<C> Copy for ScalarBytes<C>
+where
+    C: Curve + Order,
+    FieldBytes<C>: Copy,
+{
+}
+
+impl<C> From<ScalarBytes<C>> for FieldBytes<C>
+where
+    C: Curve + Order,
+{
+    fn from(scalar_bytes: ScalarBytes<C>) -> FieldBytes<C> {
+        scalar_bytes.inner
+    }
+}
+
+impl<C> TryFrom<&[u8]> for ScalarBytes<C>
+where
+    C: Curve + Order,
+{
+    type Error = Error;
+
+    fn try_from(bytes: &[u8]) -> Result<Self> {
+        if bytes.len() == C::FieldSize::to_usize() {
+            Option::from(ScalarBytes::new(GenericArray::clone_from_slice(bytes))).ok_or(Error)
+        } else {
+            Err(Error)
+        }
+    }
+}
+
+#[cfg(all(test, feature = "dev"))]
+mod tests {
+    use crate::dev::MockCurve;
+    use core::convert::TryFrom;
+    use hex_literal::hex;
+
+    type ScalarBytes = super::ScalarBytes<MockCurve>;
+
+    const SCALAR_REPR_ZERO: [u8; 32] = [0u8; 32];
+
+    const SCALAR_REPR_IN_RANGE: [u8; 32] =
+        hex!("FFFFFFFF 00000000 FFFFFFFF FFFFFFFF BCE6FAAD A7179E84 F3B9CAC2 FC632550");
+
+    const SCALAR_REPR_ORDER: [u8; 32] =
+        hex!("FFFFFFFF 00000000 FFFFFFFF FFFFFFFF BCE6FAAD A7179E84 F3B9CAC2 FC632551");
+
+    const SCALAR_REPR_MAX: [u8; 32] =
+        hex!("FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF");
+
+    #[test]
+    fn scalar_in_range() {
+        assert!(ScalarBytes::try_from(SCALAR_REPR_ZERO.as_ref()).is_ok());
+        assert!(ScalarBytes::try_from(SCALAR_REPR_IN_RANGE.as_ref()).is_ok());
+    }
+
+    #[test]
+    fn scalar_with_overflow() {
+        assert!(ScalarBytes::try_from(SCALAR_REPR_ORDER.as_ref()).is_err());
+        assert!(ScalarBytes::try_from(SCALAR_REPR_MAX.as_ref()).is_err());
+    }
+}

--- a/elliptic-curve/src/scalar/non_zero.rs
+++ b/elliptic-curve/src/scalar/non_zero.rs
@@ -1,0 +1,154 @@
+//! Non-zero scalar type.
+
+use crate::{
+    ops::Invert,
+    rand_core::{CryptoRng, RngCore},
+    Curve, Error, FieldBytes, ProjectiveArithmetic, Result, Scalar,
+};
+use core::{convert::TryFrom, ops::Deref};
+use ff::{Field, PrimeField};
+use generic_array::{typenum::Unsigned, GenericArray};
+use subtle::{Choice, ConditionallySelectable, CtOption};
+
+#[cfg(feature = "zeroize")]
+use zeroize::Zeroize;
+
+/// Non-zero scalar type.
+///
+/// This type ensures that its value is not zero, ala `core::num::NonZero*`.
+/// To do this, the generic `S` type must impl both `Default` and
+/// `ConstantTimeEq`, with the requirement that `S::default()` returns 0.
+///
+/// In the context of ECC, it's useful for ensuring that scalar multiplication
+/// cannot result in the point at infinity.
+#[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
+#[derive(Clone)]
+pub struct NonZeroScalar<C>
+where
+    C: Curve + ProjectiveArithmetic,
+    Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
+{
+    scalar: Scalar<C>,
+}
+
+impl<C> NonZeroScalar<C>
+where
+    C: Curve + ProjectiveArithmetic,
+    Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
+{
+    /// Generate a random `NonZeroScalar`
+    pub fn random(mut rng: impl CryptoRng + RngCore) -> Self {
+        // Use rejection sampling to eliminate zero values
+        loop {
+            if let Some(result) = Self::new(Field::random(&mut rng)) {
+                break result;
+            }
+        }
+    }
+
+    /// Decode a [`NonZeroScalar] from a serialized field element
+    pub fn from_repr(repr: FieldBytes<C>) -> Option<Self> {
+        Scalar::<C>::from_repr(repr).and_then(Self::new)
+    }
+
+    /// Create a [`NonZeroScalar`] from a scalar.
+    // TODO(tarcieri): make this constant time?
+    pub fn new(scalar: Scalar<C>) -> Option<Self> {
+        if scalar.is_zero() {
+            None
+        } else {
+            Some(Self { scalar })
+        }
+    }
+}
+
+impl<C> AsRef<Scalar<C>> for NonZeroScalar<C>
+where
+    C: Curve + ProjectiveArithmetic,
+    Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
+{
+    fn as_ref(&self) -> &Scalar<C> {
+        &self.scalar
+    }
+}
+
+impl<C> ConditionallySelectable for NonZeroScalar<C>
+where
+    C: Curve + ProjectiveArithmetic,
+    Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
+{
+    fn conditional_select(a: &Self, b: &Self, choice: Choice) -> Self {
+        Self {
+            scalar: Scalar::<C>::conditional_select(&a.scalar, &b.scalar, choice),
+        }
+    }
+}
+
+impl<C> Copy for NonZeroScalar<C>
+where
+    C: Curve + ProjectiveArithmetic,
+    Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
+{
+}
+
+impl<C> Deref for NonZeroScalar<C>
+where
+    C: Curve + ProjectiveArithmetic,
+    Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
+{
+    type Target = Scalar<C>;
+
+    fn deref(&self) -> &Scalar<C> {
+        &self.scalar
+    }
+}
+
+impl<C> From<NonZeroScalar<C>> for FieldBytes<C>
+where
+    C: Curve + ProjectiveArithmetic,
+    Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
+{
+    fn from(scalar: NonZeroScalar<C>) -> FieldBytes<C> {
+        scalar.scalar.to_repr()
+    }
+}
+
+impl<C> Invert for NonZeroScalar<C>
+where
+    C: Curve + ProjectiveArithmetic,
+    Scalar<C>: PrimeField<Repr = FieldBytes<C>> + Invert,
+{
+    type Output = Scalar<C>;
+
+    /// Perform a scalar inversion
+    fn invert(&self) -> CtOption<Self::Output> {
+        ff::Field::invert(&self.scalar)
+    }
+}
+
+impl<C> TryFrom<&[u8]> for NonZeroScalar<C>
+where
+    C: Curve + ProjectiveArithmetic,
+    Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
+{
+    type Error = Error;
+
+    fn try_from(bytes: &[u8]) -> Result<Self> {
+        if bytes.len() == C::FieldSize::to_usize() {
+            NonZeroScalar::from_repr(GenericArray::clone_from_slice(bytes)).ok_or(Error)
+        } else {
+            Err(Error)
+        }
+    }
+}
+
+#[cfg(feature = "zeroize")]
+impl<C> Zeroize for NonZeroScalar<C>
+where
+    C: Curve + ProjectiveArithmetic,
+    Scalar<C>: PrimeField<Repr = FieldBytes<C>> + Zeroize,
+{
+    fn zeroize(&mut self) {
+        self.scalar.zeroize();
+    }
+}

--- a/elliptic-curve/src/secret_key.rs
+++ b/elliptic-curve/src/secret_key.rs
@@ -22,10 +22,9 @@ use zeroize::Zeroize;
 #[cfg(feature = "arithmetic")]
 use crate::{
     ff::PrimeField,
-    public_key::PublicKey,
     rand_core::{CryptoRng, RngCore},
-    scalar::{NonZeroScalar, Scalar},
-    weierstrass, AffinePoint, ProjectiveArithmetic, ProjectivePoint,
+    weierstrass, AffinePoint, NonZeroScalar, ProjectiveArithmetic, ProjectivePoint, PublicKey,
+    Scalar,
 };
 
 #[cfg(feature = "jwk")]


### PR DESCRIPTION
Adds a type for representing `FieldBytes` which is always in range of the curve's `Order`.

Does not require the `arithmetic` feature or a `ProjectiveArithmetic` implementation, however when those are enabled it supports infallible conversions to/from `Scalar<C>`.