### PR TITLE
elliptic-curve: always re-export ScalarBytes

### DIFF
--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -56,6 +56,7 @@ mod secret_key;
 pub use self::{
     error::{Error, Result},
     order::Order,
+    scalar::bytes::ScalarBytes,
 };
 
 pub use generic_array::{self, typenum::consts};
@@ -67,7 +68,7 @@ pub use {
     crate::{
         point::{AffinePoint, ProjectiveArithmetic, ProjectivePoint},
         public_key::PublicKey,
-        scalar::{bytes::ScalarBytes, non_zero::NonZeroScalar, Scalar, ScalarBits},
+        scalar::{non_zero::NonZeroScalar, Scalar, ScalarBits},
     },
     ff::{self, Field},
     group::{self, Group},


### PR DESCRIPTION
It was previously needlessly conditionally gated on the `arithmetic` feature by accident.