### PR TITLE
password-hash: v0.2 breaking changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -323,7 +323,7 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "password-hash"
-version = "0.1.4"
+version = "0.2.0-pre"
 dependencies = [
  "base64ct",
  "rand_core",

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -17,7 +17,7 @@ cipher = { version = "=0.3.0-pre.4", optional = true, path = "../cipher" }
 digest = { version = "0.10.0-pre", optional = true, path = "../digest" }
 elliptic-curve = { version = "0.9", optional = true, path = "../elliptic-curve" }
 mac = { version = "=0.11.0-pre", package = "crypto-mac", optional = true, path = "../crypto-mac" }
-password-hash = { version = "0.1", optional = true, path = "../password-hash" }
+password-hash = { version = "=0.2.0-pre", optional = true, path = "../password-hash" }
 signature = { version = "1.3.0", optional = true, default-features = false, path = "../signature" }
 universal-hash = { version = "0.4", optional = true, path = "../universal-hash" }
 

--- a/password-hash/Cargo.toml
+++ b/password-hash/Cargo.toml
@@ -5,7 +5,7 @@ Traits which describe the functionality of password hashing algorithms,
 as well as a `no_std`-friendly implementation of the PHC string format
 (a well-defined subset of the Modular Crypt Format a.k.a. MCF)
 """
-version = "0.1.4"
+version = "0.2.0-pre"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
This commit contains a set of breaking changes intended to be released as part of `password-hash` v0.2, addressing a number of currently open issues about the crate discovered when integrating it into the crates in the https://github.com/RustCrypto/password-hashes repo.

This fixes the following issues:

- Allow specifying output length and version with params (#505)
- Allow passing `&str`, `&Salt`, or `&SaltString` as salt (#529)
- Simplify error handling (#547)