### PR TITLE
cipher v0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,7 +85,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cipher"
-version = "0.3.0-pre.4"
+version = "0.3.0"
 dependencies = [
  "blobby 0.3.0",
  "generic-array 0.14.4",

--- a/cipher/CHANGELOG.md
+++ b/cipher/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.3.0 (2021-04-29)
+### Added
+- Encrypt/decrypt-only block cipher traits ([#352])
+- Re-export `blobby` from root ([#435])
+- Block cipher trait blanket impls for refs ([#441])
+
+### Changed
+- Consolidate error types ([#373])
+- Change `SeekNum` impls to fit with the new `BlockBuffer` ([#435])
+- Reorganize modules ([#435])
+- Renamed `new_var` to `new_from_slice(s)` ([#442])
+
+[#352]: https://github.com/RustCrypto/traits/pull/352
+[#373]: https://github.com/RustCrypto/traits/pull/373
+[#435]: https://github.com/RustCrypto/traits/pull/435
+[#441]: https://github.com/RustCrypto/traits/pull/441
+[#442]: https://github.com/RustCrypto/traits/pull/442
+
 ## 0.2.5 (2020-11-01)
 ### Fixed
 - Nested macros used old deprecated names ([#360])

--- a/cipher/Cargo.toml
+++ b/cipher/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cipher"
 description = "Traits for describing block ciphers and stream ciphers"
-version = "0.3.0-pre.4"
+version = "0.3.0"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/crypto-mac/Cargo.toml
+++ b/crypto-mac/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["cryptography", "no-std"]
 
 [dependencies]
 generic-array = "0.14"
-cipher = { version = "=0.3.0-pre.4", optional = true, path = "../cipher" }
+cipher = { version = "0.3", optional = true, path = "../cipher" }
 subtle = { version = "2", default-features = false }
 blobby = { version = "0.3", optional = true }
 

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 
 [dependencies]
 aead = { version = "0.3", optional = true, path = "../aead" }
-cipher = { version = "=0.3.0-pre.4", optional = true, path = "../cipher" }
+cipher = { version = "0.3", optional = true, path = "../cipher" }
 digest = { version = "0.9", optional = true, path = "../digest" }
 elliptic-curve = { version = "0.8", optional = true, path = "../elliptic-curve" }
 mac = { version = "=0.11.0-pre", package = "crypto-mac", optional = true, path = "../crypto-mac" }


### PR DESCRIPTION
### Added
- Encrypt/decrypt-only block cipher traits ([#352])
- Re-export `blobby` from root ([#435])
- Block cipher trait blanket impls for refs ([#441])

### Changed
- Consolidate error types ([#373])
- Change `SeekNum` impls to fit with the new `BlockBuffer` ([#435])
- Reorganize modules ([#435])
- Renamed `new_var` to `new_from_slice(s)` ([#442])

[#352]: https://github.com/RustCrypto/traits/pull/352
[#373]: https://github.com/RustCrypto/traits/pull/373
[#435]: https://github.com/RustCrypto/traits/pull/435
[#441]: https://github.com/RustCrypto/traits/pull/441
[#442]: https://github.com/RustCrypto/traits/pull/442