### PR TITLE
password-hash v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -342,7 +342,7 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "password-hash"
-version = "0.2.0-pre"
+version = "0.2.0"
 dependencies = [
  "base64ct",
  "rand_core",

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -17,7 +17,7 @@ cipher = { version = "0.3", optional = true }
 digest = { version = "0.9", optional = true }
 elliptic-curve = { version = "0.9", optional = true, path = "../elliptic-curve" }
 mac = { version = "0.11", package = "crypto-mac", optional = true }
-password-hash = { version = "=0.2.0-pre", optional = true, path = "../password-hash" }
+password-hash = { version = "0.2", optional = true, path = "../password-hash" }
 signature = { version = "1.2.0", optional = true, default-features = false, path = "../signature" }
 universal-hash = { version = "0.4", optional = true, path = "../universal-hash" }
 

--- a/password-hash/CHANGELOG.md
+++ b/password-hash/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.0 (2021-04-29)
+### Changed
+- Allow specifying output length and version with params ([#615])
+- Allow passing `&str`, `&Salt`, or `&SaltString` as salt ([#615])
+- Simplify error handling ([#615])
+
+[#615]: https://github.com/RustCrypto/traits/pull/615
+
 ## 0.1.4 (2021-04-19)
 ### Added
 - Length constants ([#600])

--- a/password-hash/Cargo.toml
+++ b/password-hash/Cargo.toml
@@ -5,7 +5,7 @@ Traits which describe the functionality of password hashing algorithms,
 as well as a `no_std`-friendly implementation of the PHC string format
 (a well-defined subset of the Modular Crypt Format a.k.a. MCF)
 """
-version = "0.2.0-pre"
+version = "0.2.0" # Also update html_root_url in lib.rs when bumping this
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
@@ -25,4 +25,4 @@ std = ["alloc", "base64ct/std"]
 
 [package.metadata.docs.rs]
 rustc-args = ["--cfg", "docsrs"]
-features = ["rand_core"]
+all-features = true

--- a/password-hash/src/lib.rs
+++ b/password-hash/src/lib.rs
@@ -39,7 +39,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
-    html_root_url = "https://docs.rs/password-hash/0.2.0-pre"
+    html_root_url = "https://docs.rs/password-hash/0.2.0"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]


### PR DESCRIPTION
### Changed
- Allow specifying output length and version with params ([#615])
- Allow passing `&str`, `&Salt`, or `&SaltString` as salt ([#615])
- Simplify error handling ([#615])

[#615]: https://github.com/RustCrypto/traits/pull/615