### PR TITLE
cipher + crypto-mac: CHANGELOG fixups

### DIFF
--- a/cipher/CHANGELOG.md
+++ b/cipher/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Encrypt/decrypt-only block cipher traits ([#352])
 - Re-export `blobby` from root ([#435])
 - Block cipher trait blanket impls for refs ([#441])
+- `generate_key` method to `New*` trait ([#513])
 
 ### Changed
 - Consolidate error types ([#373])
@@ -22,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#435]: https://github.com/RustCrypto/traits/pull/435
 [#441]: https://github.com/RustCrypto/traits/pull/441
 [#442]: https://github.com/RustCrypto/traits/pull/442
+[#513]: https://github.com/RustCrypto/traits/pull/513
 
 ## 0.2.5 (2020-11-01)
 ### Fixed

--- a/crypto-mac/CHANGELOG.md
+++ b/crypto-mac/CHANGELOG.md
@@ -6,9 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## 0.11.0 (2021-04-28)
+### Added
+- `generate_key` method to `New*` trait ([#513])
+
 ### Changed
+- Renamed `new_var` to `new_from_slice` ([#442])
 - Bump `cipher` dependency to v0.3 ([#621])
 
+[#442]: https://github.com/RustCrypto/traits/pull/442
+[#513]: https://github.com/RustCrypto/traits/pull/513
 [#621]: https://github.com/RustCrypto/traits/pull/621
 
 ## 0.10.0 (2020-10-15)


### PR DESCRIPTION
- Document `generate_key`
- Add `new_from_slice` docs to `crypto-mac` (closes #626)