### PR TITLE
password-hash: use `subtle` crate for comparing hash `Output`

### DIFF
--- a/.github/workflows/password-hash.yml
+++ b/.github/workflows/password-hash.yml
@@ -54,5 +54,6 @@ jobs:
         profile: minimal
         override: true
     - run: cargo check --all-features
+    - run: cargo test --release --no-default-features
     - run: cargo test --release
     - run: cargo test --release --all-features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -376,6 +376,7 @@ version = "0.2.0"
 dependencies = [
  "base64ct",
  "rand_core",
+ "subtle",
 ]
 
 [[package]]

--- a/password-hash/Cargo.toml
+++ b/password-hash/Cargo.toml
@@ -17,9 +17,13 @@ keywords = ["crypt", "mcf", "password", "pbkdf", "phc"]
 
 [dependencies]
 base64ct = "1"
+subtle = { version = "2", default-features = false }
+
+# optional features
 rand_core = { version = "0.6", optional = true, default-features = false }
 
 [features]
+default = ["rand_core"]
 alloc = ["base64ct/alloc"]
 std = ["alloc", "base64ct/std"]
 

--- a/password-hash/src/salt.rs
+++ b/password-hash/src/salt.rs
@@ -94,7 +94,7 @@ impl<'a> Salt<'a> {
     pub const RECOMMENDED_LENGTH: usize = 16;
 
     /// Create a [`Salt`] from the given `str`, validating it according to
-    /// [`Salt::min_len`] and [`Salt::max_len`] length restrictions.
+    /// [`Salt::MIN_LENGTH`] and [`Salt::MAX_LENGTH`] length restrictions.
     pub fn new(input: &'a str) -> Result<Self> {
         if input.len() < Self::MIN_LENGTH {
             return Err(Error::SaltTooShort);

--- a/password-hash/src/value.rs
+++ b/password-hash/src/value.rs
@@ -32,7 +32,7 @@ pub type Decimal = u32;
 /// # Additional Notes
 /// The PHC spec allows for algorithm-defined maximum lengths for parameter
 /// values, however in the interest of interoperability this library defines a
-/// [`Value::max_len`] of 48 ASCII characters.
+/// [`Value::MAX_LENGTH`] of 48 ASCII characters.
 ///
 /// [1]: https://github.com/P-H-C/phc-string-format/blob/master/phc-sf-spec.md
 /// [2]: https://github.com/P-H-C/phc-string-format/blob/master/phc-sf-spec.md#argon2-encoding


### PR DESCRIPTION
Previously a non-short-circuiting comparison was used, however the `subtle` crate provides a more robust option in this regard with the `ConstantTimeEq` trait and its associated impls on byte slices.

This commit also includes an updated rationale for why password hashes benefit from constant time comparisons, including a description of a timing attack on password hash verification.