### PR TITLE
crypto: fix `password_hash` module name in rustdoc

### DIFF
--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -28,7 +28,7 @@
 //! | [`digest`](https://docs.rs/digest) | `digest` | Cryptographic hash functions |
 //! | [`elliptic_curve`](https://docs.rs/elliptic-curve) | `elliptic-curve` | Elliptic curve cryptography |
 //! | [`mac`](https://docs.rs/crypto-mac) | `mac` | Message Authentication Codes (i.e. symmetric message authentication) |
-//! | [`password-hash`](https://docs.rs/password-hash) | `password-hash` | Password hashing functions |
+//! | [`password_hash`](https://docs.rs/password-hash) | `password-hash` | Password hashing functions |
 //! | [`signature`](https://docs.rs/signature) | `signature` | Digital signatures (i.e. public key-based message authentication) |
 //! | [`universal_hash`](https://docs.rs/universal-hash) | `universal‑hash` | Universal Hash Functions (used to build MACs) |
 //!


### PR DESCRIPTION
It previously had a hyphen (i.e. crate name, not module name)