### PR TITLE
elliptic-curve: bump `ff` and `group` to v0.10; MSRV 1.51+

### DIFF
--- a/.github/workflows/elliptic-curve.yml
+++ b/.github/workflows/elliptic-curve.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.47.0 # MSRV
+          - 1.51.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -37,6 +37,7 @@ jobs:
           override: true
       - run: cargo build --no-default-features --release --target ${{ matrix.target }}
       - run: cargo build --no-default-features --release --target ${{ matrix.target }} --features arithmetic
+      - run: cargo build --no-default-features --release --target ${{ matrix.target }} --features bits
       - run: cargo build --no-default-features --release --target ${{ matrix.target }} --features dev
       - run: cargo build --no-default-features --release --target ${{ matrix.target }} --features ecdh
       - run: cargo build --no-default-features --release --target ${{ matrix.target }} --features hazmat
@@ -50,7 +51,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.47.0 # MSRV
+          - 1.51.0 # MSRV
           - stable
           - nightly
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,9 +61,9 @@ checksum = "46afbd2983a5d5a7bd740ccb198caf5b82f45c40c09c0eed36052d91cb92e719"
 
 [[package]]
 name = "bitvec"
-version = "0.20.4"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7774144344a4faa177370406a7ff5f1da24303817368584c6206c8303eb07848"
+checksum = "5237f00a8c86130a0cc317830e558b966dd7850d48a953d998c813f01a41b527"
 dependencies = [
  "funty",
  "radium",
@@ -237,10 +237,9 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.9.12"
+version = "0.10.0-pre"
 dependencies = [
  "base64ct",
- "bitvec",
  "ff",
  "generic-array",
  "group",
@@ -265,9 +264,9 @@ dependencies = [
 
 [[package]]
 name = "ff"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a4d941a5b7c2a75222e2d44fcdf634a67133d9db31e177ae5ff6ecda852bfe"
+checksum = "63eec06c61e487eecf0f7e6e6372e596a81922c28d33e645d6983ca6493a1af0"
 dependencies = [
  "bitvec",
  "rand_core",
@@ -276,9 +275,9 @@ dependencies = [
 
 [[package]]
 name = "funty"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
+checksum = "1847abb9cb65d566acd5942e94aea9c8f547ad02c98e1649326fc0e8910b8b1e"
 
 [[package]]
 name = "generic-array"
@@ -292,9 +291,9 @@ dependencies = [
 
 [[package]]
 name = "group"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61b3c1e8b4f1ca07e6605ea1be903a5f6956aec5c8a67fd44d56076631675ed8"
+checksum = "1c363a5301b8f153d80747126a04b3c82073b9fe3130571a9d170cacdeaf7912"
 dependencies = [
  "ff",
  "rand_core",
@@ -616,9 +615,12 @@ dependencies = [
 
 [[package]]
 name = "wyz"
-version = "0.2.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
+checksum = "129e027ad65ce1453680623c3fb5163cbf7107bfe1aa32257e7d0e63f9ced188"
+dependencies = [
+ "tap",
+]
 
 [[package]]
 name = "zeroize"

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -17,7 +17,7 @@ edition = "2018"
 aead = { version = "0.4", optional = true, path = "../aead" }
 cipher = { version = "0.3", optional = true }
 digest = { version = "0.9", optional = true }
-elliptic-curve = { version = "0.9", optional = true, path = "../elliptic-curve" }
+elliptic-curve = { version = "=0.10.0-pre", optional = true, path = "../elliptic-curve" }
 mac = { version = "0.11", package = "crypto-mac", optional = true }
 password-hash = { version = "0.2", optional = true, path = "../password-hash" }
 signature = { version = "1.2.0", optional = true, default-features = false, path = "../signature" }

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -5,7 +5,7 @@ General purpose Elliptic Curve Cryptography (ECC) support, including types
 and traits for representing various elliptic curve forms, scalars, points,
 and public/secret keys composed thereof.
 """
-version    = "0.9.12" # Also update html_root_url in lib.rs when bumping this
+version    = "0.10.0-pre" # Also update html_root_url in lib.rs when bumping this
 authors    = ["RustCrypto Developers"]
 license    = "Apache-2.0 OR MIT"
 repository = "https://github.com/RustCrypto/traits/tree/master/elliptic-curve"
@@ -16,9 +16,8 @@ keywords   = ["crypto", "ecc", "elliptic", "weierstrass"]
 
 [dependencies]
 base64ct = { version = "1", optional = true, default-features = false }
-bitvec = { version = "0.20.2", optional = true, default-features = false }
-ff = { version = "0.9", optional = true, default-features = false }
-group = { version = "0.9", optional = true, default-features = false }
+ff = { version = "0.10", optional = true, default-features = false }
+group = { version = "0.10", optional = true, default-features = false }
 hex-literal = { version = "0.3", optional = true }
 generic-array = { version = "0.14", default-features = false }
 pkcs8 = { version = "0.6", optional = true }
@@ -34,7 +33,8 @@ hex-literal = "0.3"
 [features]
 default = ["arithmetic"]
 alloc = []
-arithmetic = ["bitvec", "ff", "group"]
+arithmetic = ["ff", "group"]
+bits = ["arithmetic", "ff/bits"]
 dev = ["arithmetic", "hex-literal", "pem", "zeroize"]
 ecdh = ["arithmetic", "zeroize"]
 hazmat = []

--- a/elliptic-curve/README.md
+++ b/elliptic-curve/README.md
@@ -15,7 +15,7 @@ and public/secret keys composed thereof.
 
 ## Minimum Supported Rust Version
 
-Requires Rust **1.47** or higher.
+Requires Rust **1.51** or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be
 done with a minor version bump.
@@ -47,7 +47,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/elliptic-curve/badge.svg
 [docs-link]: https://docs.rs/elliptic-curve/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.47+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.51+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260040-elliptic-curves
 [build-image]: https://github.com/RustCrypto/elliptic-curves/workflows/elliptic-curve%20crate/badge.svg?branch=master&event=push

--- a/elliptic-curve/src/jwk.rs
+++ b/elliptic-curve/src/jwk.rs
@@ -30,7 +30,7 @@ use zeroize::Zeroize;
 
 #[cfg(feature = "arithmetic")]
 use crate::{
-    ff::PrimeField,
+    group::ff::PrimeField,
     public_key::PublicKey,
     sec1::{FromEncodedPoint, ToEncodedPoint},
     AffinePoint, ProjectiveArithmetic, ProjectivePoint, Scalar,

--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -4,7 +4,7 @@
 //!
 //! ## Minimum Supported Rust Version
 //!
-//! Rust **1.47** or higher.
+//! Rust **1.51** or higher.
 //!
 //! Minimum supported Rust version can be changed in the future, but it will be
 //! done with a minor version bump.
@@ -68,11 +68,14 @@ pub use {
     crate::{
         point::{AffinePoint, ProjectiveArithmetic, ProjectivePoint},
         public_key::PublicKey,
-        scalar::{non_zero::NonZeroScalar, Scalar, ScalarBits},
+        scalar::{non_zero::NonZeroScalar, Scalar},
     },
-    ff::{self, Field},
+    ff::Field,
     group::{self, Group},
 };
+
+#[cfg(feature = "bits")]
+pub use crate::scalar::ScalarBits;
 
 #[cfg(all(feature = "hazmat", feature = "zeroize"))]
 pub use secret_key::{SecretBytes, SecretValue};

--- a/elliptic-curve/src/scalar.rs
+++ b/elliptic-curve/src/scalar.rs
@@ -6,11 +6,7 @@ pub(crate) mod bytes;
 pub(crate) mod non_zero;
 
 #[cfg(feature = "arithmetic")]
-use {
-    crate::ProjectiveArithmetic,
-    ff::{FieldBits, PrimeField},
-    group::Group,
-};
+use {crate::ProjectiveArithmetic, group::Group};
 
 /// Scalar field element for a particular elliptic curve.
 #[cfg(feature = "arithmetic")]
@@ -18,6 +14,6 @@ use {
 pub type Scalar<C> = <<C as ProjectiveArithmetic>::ProjectivePoint as Group>::Scalar;
 
 /// Bit representation of a scalar field element of a given curve.
-#[cfg(feature = "arithmetic")]
-#[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
-pub type ScalarBits<C> = FieldBits<<Scalar<C> as PrimeField>::ReprBits>;
+#[cfg(feature = "bits")]
+#[cfg_attr(docsrs, doc(cfg(feature = "bits")))]
+pub type ScalarBits<C> = ff::FieldBits<<Scalar<C> as ff::PrimeFieldBits>::ReprBits>;

--- a/elliptic-curve/src/scalar/bytes.rs
+++ b/elliptic-curve/src/scalar/bytes.rs
@@ -9,7 +9,7 @@ use generic_array::{typenum::Unsigned, GenericArray};
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 
 #[cfg(feature = "arithmetic")]
-use crate::{ff::PrimeField, ProjectiveArithmetic, Scalar};
+use crate::{group::ff::PrimeField, ProjectiveArithmetic, Scalar};
 
 // TODO(tarcieri): unify these into a target-width gated `sbb`
 #[cfg(target_pointer_width = "32")]

--- a/elliptic-curve/src/sec1.rs
+++ b/elliptic-curve/src/sec1.rs
@@ -21,7 +21,7 @@ use alloc::boxed::Box;
 
 #[cfg(feature = "arithmetic")]
 use crate::{
-    ff::PrimeField, weierstrass::DecompressPoint, AffinePoint, ProjectiveArithmetic, Scalar,
+    group::ff::PrimeField, weierstrass::DecompressPoint, AffinePoint, ProjectiveArithmetic, Scalar,
 };
 
 #[cfg(all(feature = "arithmetic", feature = "zeroize"))]

--- a/elliptic-curve/src/secret_key.rs
+++ b/elliptic-curve/src/secret_key.rs
@@ -21,7 +21,7 @@ use zeroize::Zeroize;
 
 #[cfg(feature = "arithmetic")]
 use crate::{
-    ff::PrimeField,
+    group::ff::PrimeField,
     rand_core::{CryptoRng, RngCore},
     weierstrass, AffinePoint, NonZeroScalar, ProjectiveArithmetic, ProjectivePoint, PublicKey,
     Scalar,

--- a/elliptic-curve/src/secret_key/pkcs8.rs
+++ b/elliptic-curve/src/secret_key/pkcs8.rs
@@ -15,13 +15,13 @@ use zeroize::Zeroize;
 #[cfg(all(feature = "arithmetic", feature = "pem"))]
 use {
     crate::{
-        ff::PrimeField,
         scalar::Scalar,
         sec1::{FromEncodedPoint, ToEncodedPoint},
         AffinePoint, ProjectiveArithmetic, ProjectivePoint,
     },
     alloc::vec::Vec,
     core::{convert::TryInto, fmt::Debug, iter},
+    ff::PrimeField,
     pkcs8::{der::Encodable, ToPrivateKey},
     zeroize::Zeroizing,
 };


### PR DESCRIPTION
Bumps the `ff` and `group` crate dependencies to the latest releases.

Additionally, this commit removes the re-export of the `ff` crate, with the expectation it be accessed as `elliptic_curve::group::ff` instead.

## Changelogs
- `ff`: https://github.com/zkcrypto/ff/blob/main/CHANGELOG.md#0100---2021-06-01
- `group`: https://github.com/zkcrypto/group/blob/main/CHANGELOG.md#0100---2021-06-01