### PR TITLE
elliptic-curve: use `crypto-bigint` to represent `Curve::Order`

### DIFF
--- a/.github/workflows/crypto.yml
+++ b/.github/workflows/crypto.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.44.0 # MSRV
+          - 1.51.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -43,7 +43,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.44.0 # MSRV
+          - 1.51.0 # MSRV
           - stable
     steps:
     - uses: actions/checkout@v1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -179,6 +179,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-bigint"
+version = "0.1.0"
+source = "git+https://github.com/rustcrypto/utils.git#01c945e05d86cd36b7222f0a8628cf51410eebc7"
+dependencies = [
+ "generic-array",
+ "subtle",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.0-pre"
 dependencies = [
@@ -240,6 +249,7 @@ name = "elliptic-curve"
 version = "0.10.0-pre"
 dependencies = [
  "base64ct",
+ "crypto-bigint",
  "ff",
  "generic-array",
  "group",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,6 @@ members = [
     "signature/async",
     "universal-hash",
 ]
+
+[patch.crates-io]
+crypto-bigint = { git = "https://github.com/rustcrypto/utils.git" }

--- a/crypto/README.md
+++ b/crypto/README.md
@@ -14,7 +14,7 @@ access compatible versions of all traits from the Rust Crypto project.
 
 ## Minimum Supported Rust Version
 
-Rust **1.44** or higher.
+Rust **1.51** or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be
 done with a minor version bump.
@@ -46,7 +46,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/crypto/badge.svg
 [docs-link]: https://docs.rs/crypto/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.44+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.51+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260050-Traits
 [build-image]: https://github.com/RustCrypto/traits/workflows/crypto/badge.svg?branch=master&event=push

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -16,6 +16,7 @@ keywords   = ["crypto", "ecc", "elliptic", "weierstrass"]
 
 [dependencies]
 base64ct = { version = "1", optional = true, default-features = false }
+crypto-bigint = { version = "0.1", features = ["generic-array"] }
 ff = { version = "0.10", optional = true, default-features = false }
 group = { version = "0.10", optional = true, default-features = false }
 hex-literal = { version = "0.3", optional = true }

--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -56,7 +56,7 @@ pub use self::{
     error::{Error, Result},
     scalar::bytes::ScalarBytes,
 };
-
+pub use crypto_bigint::{self as bigint, ArrayEncoding, NumBits, NumBytes};
 pub use generic_array::{self, typenum::consts};
 pub use rand_core;
 pub use subtle;
@@ -110,21 +110,14 @@ pub const ALGORITHM_OID: pkcs8::ObjectIdentifier =
 /// be impl'd by these ZSTs, facilitating types which are generic over elliptic
 /// curves (e.g. [`SecretKey`]).
 pub trait Curve: Clone + Debug + Default + Eq + Ord + Send + Sync {
-    /// Type representing the "limbs" of the curves group's order on
-    /// 32-bit platforms.
-    #[cfg(target_pointer_width = "32")]
-    type Limbs: AsRef<[u32]> + Copy + Debug;
-
-    /// Type representing the "limbs" of the curves group's order on
-    /// 64-bit platforms.
-    #[cfg(target_pointer_width = "64")]
-    type Limbs: AsRef<[u64]> + Copy + Debug;
+    /// Integer type used to represent field elements of this elliptic curve.
+    type UInt: AsRef<[bigint::Limb]> + ArrayEncoding + Copy + Debug + NumBits + NumBytes;
 
     /// Order constant.
     ///
     /// Subdivided into either 32-bit or 64-bit "limbs" (depending on the
     /// target CPU's word size), specified from least to most significant.
-    const ORDER: Self::Limbs;
+    const ORDER: Self::UInt;
 
     /// Size of this curve's field in *bytes*, i.e. the number of bytes needed
     /// to serialize a field element.

--- a/elliptic-curve/src/scalar/bytes.rs
+++ b/elliptic-curve/src/scalar/bytes.rs
@@ -36,7 +36,7 @@ where
     #[cfg(target_pointer_width = "32")]
     pub fn new(bytes: FieldBytes<C>) -> CtOption<Self> {
         assert_eq!(
-            mem::size_of::<C::Limbs>(),
+            mem::size_of::<C::UInt>(),
             mem::size_of::<FieldBytes<C>>(),
             "malformed curve order"
         );
@@ -57,7 +57,7 @@ where
     #[cfg(target_pointer_width = "64")]
     pub fn new(bytes: FieldBytes<C>) -> CtOption<Self> {
         assert_eq!(
-            mem::size_of::<C::Limbs>(),
+            mem::size_of::<C::UInt>(),
             mem::size_of::<FieldBytes<C>>(),
             "malformed curve order"
         );


### PR DESCRIPTION
The `crypto_bigint::UInt` type has const-friendly initializers that can parse the curve order from e.g. hexadecimal.

This commit changes the `Order` to be represented as a `UInt` type. This also permits things like simplified (and constant time, if needed) comparisons to ensure a given value is in range.

Additionally, this commit reimplements the `dev` module's `Scalar` type for `MockCurve` to use a `crypto_bigint::U256` internally.