### PR TITLE
elliptic-curve: source FieldSize from Curve::UInt type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -181,7 +181,7 @@ dependencies = [
 [[package]]
 name = "crypto-bigint"
 version = "0.1.0"
-source = "git+https://github.com/rustcrypto/utils.git#01c945e05d86cd36b7222f0a8628cf51410eebc7"
+source = "git+https://github.com/rustcrypto/utils.git#4ff54f79d5c478720d5e6297e53208365aabbf07"
 dependencies = [
  "generic-array",
  "subtle",

--- a/elliptic-curve/src/dev.rs
+++ b/elliptic-curve/src/dev.rs
@@ -3,7 +3,6 @@
 
 use crate::{
     bigint::{ArrayEncoding, U256},
-    consts::U32,
     error::{Error, Result},
     rand_core::RngCore,
     sec1::{FromEncodedPoint, ToEncodedPoint},
@@ -39,7 +38,6 @@ pub const PSEUDO_COORDINATE_FIXED_BASE_MUL: [u8; 32] =
 pub struct MockCurve;
 
 impl Curve for MockCurve {
-    type FieldSize = U32;
     type UInt = U256;
 
     const ORDER: U256 =

--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -89,8 +89,8 @@ pub use secret_key::SecretKey;
 #[cfg(feature = "zeroize")]
 pub use zeroize;
 
-use core::{fmt::Debug, ops::Add};
-use generic_array::{typenum::Unsigned, ArrayLength, GenericArray};
+use core::fmt::Debug;
+use generic_array::GenericArray;
 
 /// Algorithm [`ObjectIdentifier`][`pkcs8::ObjectIdentifier`] for elliptic
 /// curve public key cryptography.
@@ -118,17 +118,13 @@ pub trait Curve: Clone + Debug + Default + Eq + Ord + Send + Sync {
     /// Subdivided into either 32-bit or 64-bit "limbs" (depending on the
     /// target CPU's word size), specified from least to most significant.
     const ORDER: Self::UInt;
-
-    /// Size of this curve's field in *bytes*, i.e. the number of bytes needed
-    /// to serialize a field element.
-    ///
-    /// This is used for computing the sizes of field element types related to
-    /// this curve and other types composed from them (e.g. signatures).
-    type FieldSize: ArrayLength<u8> + Add + Eq + Ord + Unsigned;
 }
 
+/// Size of field elements of this elliptic curve.
+pub type FieldSize<C> = <<C as Curve>::UInt as ArrayEncoding>::ByteSize;
+
 /// Byte representation of a base/scalar field element of a given curve.
-pub type FieldBytes<C> = GenericArray<u8, <C as Curve>::FieldSize>;
+pub type FieldBytes<C> = GenericArray<u8, FieldSize<C>>;
 
 /// Associate an [`ObjectIdentifier`][`pkcs8::ObjectIdentifier`] (OID) with an
 /// elliptic curve algorithm implementation.

--- a/elliptic-curve/src/scalar/bytes.rs
+++ b/elliptic-curve/src/scalar/bytes.rs
@@ -1,11 +1,11 @@
 //! Scalar bytes.
 
-use crate::{Curve, Error, FieldBytes, Result};
+use crate::{bigint::NumBytes, Curve, Error, FieldBytes, Result};
 use core::{
     convert::{TryFrom, TryInto},
     mem,
 };
-use generic_array::{typenum::Unsigned, GenericArray};
+use generic_array::GenericArray;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 
 #[cfg(feature = "arithmetic")]
@@ -218,7 +218,7 @@ where
     type Error = Error;
 
     fn try_from(bytes: &[u8]) -> Result<Self> {
-        if bytes.len() == C::FieldSize::to_usize() {
+        if bytes.len() == C::UInt::NUM_BYTES {
             Option::from(ScalarBytes::new(GenericArray::clone_from_slice(bytes))).ok_or(Error)
         } else {
             Err(Error)

--- a/elliptic-curve/src/scalar/non_zero.rs
+++ b/elliptic-curve/src/scalar/non_zero.rs
@@ -1,13 +1,14 @@
 //! Non-zero scalar type.
 
 use crate::{
+    bigint::NumBytes,
     ops::Invert,
     rand_core::{CryptoRng, RngCore},
     Curve, Error, FieldBytes, ProjectiveArithmetic, Result, Scalar,
 };
 use core::{convert::TryFrom, ops::Deref};
 use ff::{Field, PrimeField};
-use generic_array::{typenum::Unsigned, GenericArray};
+use generic_array::GenericArray;
 use subtle::{Choice, ConditionallySelectable, CtOption};
 
 #[cfg(feature = "zeroize")]
@@ -134,7 +135,7 @@ where
     type Error = Error;
 
     fn try_from(bytes: &[u8]) -> Result<Self> {
-        if bytes.len() == C::FieldSize::to_usize() {
+        if bytes.len() == C::UInt::NUM_BYTES {
             NonZeroScalar::from_repr(GenericArray::clone_from_slice(bytes)).ok_or(Error)
         } else {
             Err(Error)

--- a/elliptic-curve/src/secret_key.rs
+++ b/elliptic-curve/src/secret_key.rs
@@ -10,13 +10,12 @@
 #[cfg(feature = "pkcs8")]
 mod pkcs8;
 
-use crate::{Curve, Error, FieldBytes, Result};
+use crate::{bigint::NumBytes, Curve, Error, FieldBytes, Result};
 use core::{
     convert::TryFrom,
     fmt::{self, Debug},
     ops::Deref,
 };
-use generic_array::typenum::Unsigned;
 use zeroize::Zeroize;
 
 #[cfg(feature = "arithmetic")]
@@ -105,7 +104,7 @@ where
     pub fn from_bytes(bytes: impl AsRef<[u8]>) -> Result<Self> {
         let bytes = bytes.as_ref();
 
-        if bytes.len() != C::FieldSize::to_usize() {
+        if bytes.len() != C::UInt::NUM_BYTES {
             return Err(Error);
         }
 


### PR DESCRIPTION
The `crypto-bigint` library defines an associated `ArrayLength<u8>` for every `UInt` type as part of the `ArrayEncoding` trait.

This means we don't need to define both: we can now source what was previously `C::FieldSize` via `C::UInt::ByteSize`.

This commit performs that replacement, adding a `FieldSize<C>` type alias which can be used anywhere `C::FieldSize` was previously used which sources the `ArrayLength<u8>` from `C::UInt` instead.