### PR TITLE
elliptic-curve: make ScalarBytes<C> the SecretKey<C> internal repr

### DIFF
--- a/elliptic-curve/src/jwk.rs
+++ b/elliptic-curve/src/jwk.rs
@@ -7,7 +7,7 @@ use crate::{
     sec1::{
         Coordinates, EncodedPoint, UncompressedPointSize, UntaggedPointSize, ValidatePublicKey,
     },
-    secret_key::{SecretKey, SecretValue},
+    secret_key::SecretKey,
     weierstrass::Curve,
     Error, FieldBytes,
 };
@@ -135,9 +135,7 @@ impl JwkEcKey {
     #[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
     pub fn to_secret_key<C>(&self) -> Result<SecretKey<C>, Error>
     where
-        C: Curve + JwkParameters + ValidatePublicKey + SecretValue,
-        C::Secret: Clone + Zeroize,
-        FieldBytes<C>: From<C::Secret>,
+        C: Curve + JwkParameters + ValidatePublicKey,
         UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
         UncompressedPointSize<C>: ArrayLength<u8>,
     {
@@ -232,9 +230,7 @@ where
 #[cfg_attr(docsrs, doc(cfg(feature = "jwk")))]
 impl<C> TryFrom<JwkEcKey> for SecretKey<C>
 where
-    C: Curve + JwkParameters + ValidatePublicKey + SecretValue,
-    C::Secret: Clone + Zeroize,
-    FieldBytes<C>: From<C::Secret>,
+    C: Curve + JwkParameters + ValidatePublicKey,
     UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
     UncompressedPointSize<C>: ArrayLength<u8>,
 {
@@ -248,9 +244,7 @@ where
 #[cfg_attr(docsrs, doc(cfg(feature = "jwk")))]
 impl<C> TryFrom<&JwkEcKey> for SecretKey<C>
 where
-    C: Curve + JwkParameters + ValidatePublicKey + SecretValue,
-    C::Secret: Clone + Zeroize,
-    FieldBytes<C>: From<C::Secret>,
+    C: Curve + JwkParameters + ValidatePublicKey,
     UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
     UncompressedPointSize<C>: ArrayLength<u8>,
 {

--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -74,9 +74,6 @@ pub use {
 #[cfg(feature = "bits")]
 pub use crate::scalar::ScalarBits;
 
-#[cfg(all(feature = "hazmat", feature = "zeroize"))]
-pub use secret_key::{SecretBytes, SecretValue};
-
 #[cfg(feature = "jwk")]
 pub use crate::jwk::{JwkEcKey, JwkParameters};
 

--- a/elliptic-curve/src/scalar/non_zero.rs
+++ b/elliptic-curve/src/scalar/non_zero.rs
@@ -12,7 +12,7 @@ use generic_array::GenericArray;
 use subtle::{Choice, ConditionallySelectable, CtOption};
 
 #[cfg(feature = "zeroize")]
-use zeroize::Zeroize;
+use {crate::SecretKey, zeroize::Zeroize};
 
 /// Non-zero scalar type.
 ///
@@ -111,6 +111,20 @@ where
 {
     fn from(scalar: NonZeroScalar<C>) -> FieldBytes<C> {
         scalar.scalar.to_repr()
+    }
+}
+
+#[cfg(feature = "zeroize")]
+#[cfg_attr(docsrs, doc(cfg(feature = "zeroize")))]
+impl<C> From<&SecretKey<C>> for NonZeroScalar<C>
+where
+    C: Curve + ProjectiveArithmetic,
+    Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
+{
+    fn from(sk: &SecretKey<C>) -> NonZeroScalar<C> {
+        let scalar = sk.as_scalar_bytes().to_scalar();
+        debug_assert!(!scalar.is_zero());
+        Self { scalar }
     }
 }
 

--- a/elliptic-curve/src/sec1.rs
+++ b/elliptic-curve/src/sec1.rs
@@ -28,10 +28,7 @@ use crate::{
 };
 
 #[cfg(feature = "zeroize")]
-use crate::{
-    secret_key::{SecretKey, SecretValue},
-    zeroize::Zeroize,
-};
+use crate::{secret_key::SecretKey, zeroize::Zeroize};
 
 /// Size of a compressed point for the given elliptic curve when encoded
 /// using the SEC1 `Elliptic-Curve-Point-to-Octet-String` algorithm
@@ -134,7 +131,7 @@ where
         AffinePoint<C>: ToEncodedPoint<C>,
         Scalar<C>: PrimeField<Repr = FieldBytes<C>> + Zeroize,
     {
-        (C::ProjectivePoint::generator() * secret_key.secret_scalar().as_ref())
+        (C::ProjectivePoint::generator() * secret_key.to_secret_scalar().as_ref())
             .to_affine()
             .to_encoded_point(compress)
     }
@@ -496,7 +493,7 @@ where
 #[cfg_attr(docsrs, doc(cfg(feature = "zeroize")))]
 pub trait ValidatePublicKey
 where
-    Self: Curve + SecretValue,
+    Self: Curve,
     UntaggedPointSize<Self>: Add<U1> + ArrayLength<u8>,
     UncompressedPointSize<Self>: ArrayLength<u8>,
 {

--- a/elliptic-curve/src/secret_key/pkcs8.rs
+++ b/elliptic-curve/src/secret_key/pkcs8.rs
@@ -1,6 +1,6 @@
 //! PKCS#8 encoding/decoding support
 
-use super::{SecretKey, SecretValue};
+use super::SecretKey;
 use crate::{
     sec1::{self, UncompressedPointSize, UntaggedPointSize, ValidatePublicKey},
     weierstrass, AlgorithmParameters, FieldBytes, ALGORITHM_OID,
@@ -43,9 +43,7 @@ const ENCODING_ERROR_MSG: &str = "DER encoding error";
 #[cfg_attr(docsrs, doc(cfg(feature = "pkcs8")))]
 impl<C> FromPrivateKey for SecretKey<C>
 where
-    C: weierstrass::Curve + AlgorithmParameters + ValidatePublicKey + SecretValue,
-    C::Secret: Clone + Zeroize,
-    FieldBytes<C>: From<C::Secret>,
+    C: weierstrass::Curve + AlgorithmParameters + ValidatePublicKey,
     UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
     UncompressedPointSize<C>: ArrayLength<u8>,
 {
@@ -157,9 +155,7 @@ where
 #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
 impl<C> FromStr for SecretKey<C>
 where
-    C: weierstrass::Curve + AlgorithmParameters + ValidatePublicKey + SecretValue,
-    C::Secret: Clone + Zeroize,
-    FieldBytes<C>: From<C::Secret>,
+    C: weierstrass::Curve + AlgorithmParameters + ValidatePublicKey,
     UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
     UncompressedPointSize<C>: ArrayLength<u8>,
 {


### PR DESCRIPTION
Previously SecretKey<C> had a generic internal value, depending on whether or not the `arithmetic` feature was activated. This was mostly trying to work around the fact that there wasn't a baseline arithmetic impl available to validate secret keys.

Now there is! SecretBytes<C> uses C::UInt and its may features as a `crypto-bigint` to always validate the internal bytes.

This means we can simply use `SecretBytes<C>` as the inner value of a `SecretKey<C>`, and still provide infallible conversions to `NonZeroScalar<C>`.