### PR TITLE
elliptic-curve: bump PKCS#8 to v0.7.0-pre

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,6 +54,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0d27fb6b6f1e43147af148af49d49329413ba781aa0d5e10979831c210173b5"
 
 [[package]]
+name = "base64ct"
+version = "1.0.0"
+source = "git+https://github.com/rustcrypto/utils.git#fa026e3850abedd70371107d1f78e8034e49b742"
+
+[[package]]
 name = "bitfield"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -139,9 +144,8 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "279bc8fc53f788a75c7804af68237d1fce02cde1e275a886a4b320604dc2aeda"
+version = "0.6.0"
+source = "git+https://github.com/rustcrypto/utils.git#fa026e3850abedd70371107d1f78e8034e49b742"
 
 [[package]]
 name = "cortex-m"
@@ -181,7 +185,7 @@ dependencies = [
 [[package]]
 name = "crypto-bigint"
 version = "0.1.0"
-source = "git+https://github.com/rustcrypto/utils.git#4ff54f79d5c478720d5e6297e53208365aabbf07"
+source = "git+https://github.com/rustcrypto/utils.git#fa026e3850abedd70371107d1f78e8034e49b742"
 dependencies = [
  "generic-array",
  "subtle",
@@ -219,9 +223,8 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eeb9d92785d1facb50567852ce75d0858630630e7eabea59cf7eb7474051087"
+version = "0.4.0-pre"
+source = "git+https://github.com/rustcrypto/utils.git#fa026e3850abedd70371107d1f78e8034e49b742"
 dependencies = [
  "const-oid",
 ]
@@ -248,7 +251,7 @@ dependencies = [
 name = "elliptic-curve"
 version = "0.10.0-pre"
 dependencies = [
- "base64ct",
+ "base64ct 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "crypto-bigint",
  "ff",
  "generic-array",
@@ -392,18 +395,17 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 name = "password-hash"
 version = "0.2.1"
 dependencies = [
- "base64ct",
+ "base64ct 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core",
  "subtle",
 ]
 
 [[package]]
 name = "pkcs8"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9c2f795bc591cb3384cb64082a578b89207ac92bb89c9d98c1ea2ace7cd8110"
+version = "0.7.0-pre"
+source = "git+https://github.com/rustcrypto/utils.git#fa026e3850abedd70371107d1f78e8034e49b742"
 dependencies = [
- "base64ct",
+ "base64ct 1.0.0 (git+https://github.com/rustcrypto/utils.git)",
  "der",
  "spki",
  "zeroize",
@@ -528,9 +530,8 @@ dependencies = [
 
 [[package]]
 name = "spki"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dae7e047abc519c96350e9484a96c6bf1492348af912fd3446dd2dc323f6268"
+version = "0.4.0-pre"
+source = "git+https://github.com/rustcrypto/utils.git#fa026e3850abedd70371107d1f78e8034e49b742"
 dependencies = [
  "der",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,4 @@ members = [
 
 [patch.crates-io]
 crypto-bigint = { git = "https://github.com/rustcrypto/utils.git" }
+pkcs8 = { git = "https://github.com/rustcrypto/utils.git" }

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -15,17 +15,19 @@ categories = ["cryptography", "no-std"]
 keywords   = ["crypto", "ecc", "elliptic", "weierstrass"]
 
 [dependencies]
-base64ct = { version = "1", optional = true, default-features = false }
 crypto-bigint = { version = "0.1", features = ["generic-array"] }
+generic-array = { version = "0.14", default-features = false }
+rand_core = { version = "0.6", default-features = false }
+subtle = { version = "2.4", default-features = false }
+
+# optional dependencies
+base64ct = { version = "1", optional = true, default-features = false }
 ff = { version = "0.10", optional = true, default-features = false }
 group = { version = "0.10", optional = true, default-features = false }
 hex-literal = { version = "0.3", optional = true }
-generic-array = { version = "0.14", default-features = false }
-pkcs8 = { version = "0.6", optional = true }
-rand_core = { version = "0.6", default-features = false }
+pkcs8 = { version = "=0.7.0-pre", optional = true }
 serde = { version = "1", optional = true, default-features = false }
 serde_json = { version = "1", optional = true, default-features = false, features = ["alloc"] }
-subtle = { version = "2.4", default-features = false }
 zeroize = { version = "1", optional = true,  default-features = false }
 
 [dev-dependencies]

--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -20,6 +20,8 @@
 )]
 
 #[cfg(feature = "alloc")]
+#[allow(unused_imports)]
+#[macro_use]
 extern crate alloc;
 
 #[cfg(feature = "std")]

--- a/elliptic-curve/tests/pkcs8.rs
+++ b/elliptic-curve/tests/pkcs8.rs
@@ -25,6 +25,7 @@ fn example_private_key() -> PrivateKeyDocument {
     SecretKey::from_bytes(&EXAMPLE_SCALAR)
         .unwrap()
         .to_pkcs8_der()
+        .unwrap()
 }
 
 #[test]


### PR DESCRIPTION
Patched in via git.

This version includes the merger of `PublicKeyInfo` and `OneAsymmetricKey` into a single type.

Additionally, it bumps the `der` crate, which simplifies handling of context-sensitive fields.

It also makes encoding fallible, which eliminates a lot of previous usages of `expect`.