### PR TITLE
elliptic-curve: use `AlgorithmIdentifier::assert_oids` helper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,7 +56,7 @@ checksum = "d0d27fb6b6f1e43147af148af49d49329413ba781aa0d5e10979831c210173b5"
 [[package]]
 name = "base64ct"
 version = "1.0.0"
-source = "git+https://github.com/rustcrypto/utils.git#c1f7fd345e112b2f363a5b8a3ab3d321df4fed7c"
+source = "git+https://github.com/rustcrypto/utils.git#3fc828a86a31b2b5016dd64e4f3b38a858f9d070"
 
 [[package]]
 name = "bitfield"
@@ -145,7 +145,7 @@ dependencies = [
 [[package]]
 name = "const-oid"
 version = "0.6.0"
-source = "git+https://github.com/rustcrypto/utils.git#c1f7fd345e112b2f363a5b8a3ab3d321df4fed7c"
+source = "git+https://github.com/rustcrypto/utils.git#3fc828a86a31b2b5016dd64e4f3b38a858f9d070"
 
 [[package]]
 name = "cortex-m"
@@ -185,7 +185,7 @@ dependencies = [
 [[package]]
 name = "crypto-bigint"
 version = "0.1.0"
-source = "git+https://github.com/rustcrypto/utils.git#c1f7fd345e112b2f363a5b8a3ab3d321df4fed7c"
+source = "git+https://github.com/rustcrypto/utils.git#3fc828a86a31b2b5016dd64e4f3b38a858f9d070"
 dependencies = [
  "generic-array",
  "subtle",
@@ -224,7 +224,7 @@ dependencies = [
 [[package]]
 name = "der"
 version = "0.4.0-pre"
-source = "git+https://github.com/rustcrypto/utils.git#c1f7fd345e112b2f363a5b8a3ab3d321df4fed7c"
+source = "git+https://github.com/rustcrypto/utils.git#3fc828a86a31b2b5016dd64e4f3b38a858f9d070"
 dependencies = [
  "const-oid",
 ]
@@ -366,9 +366,9 @@ checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
 name = "libc"
-version = "0.2.94"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18794a8ad5b29321f790b55d93dfba91e125cb1a9edbd4f8e3150acc771c1a5e"
+checksum = "789da6d93f1b866ffe175afc5322a4d76c038605a1c3319bb57b06967ca98a36"
 
 [[package]]
 name = "nb"
@@ -403,7 +403,7 @@ dependencies = [
 [[package]]
 name = "pkcs8"
 version = "0.7.0-pre"
-source = "git+https://github.com/rustcrypto/utils.git#c1f7fd345e112b2f363a5b8a3ab3d321df4fed7c"
+source = "git+https://github.com/rustcrypto/utils.git#3fc828a86a31b2b5016dd64e4f3b38a858f9d070"
 dependencies = [
  "base64ct 1.0.0 (git+https://github.com/rustcrypto/utils.git)",
  "der",
@@ -531,7 +531,7 @@ dependencies = [
 [[package]]
 name = "spki"
 version = "0.4.0-pre"
-source = "git+https://github.com/rustcrypto/utils.git#c1f7fd345e112b2f363a5b8a3ab3d321df4fed7c"
+source = "git+https://github.com/rustcrypto/utils.git#3fc828a86a31b2b5016dd64e4f3b38a858f9d070"
 dependencies = [
  "der",
 ]

--- a/elliptic-curve/src/secret_key/pkcs8.rs
+++ b/elliptic-curve/src/secret_key/pkcs8.rs
@@ -54,18 +54,9 @@ where
     fn from_pkcs8_private_key_info(
         private_key_info: pkcs8::PrivateKeyInfo<'_>,
     ) -> pkcs8::Result<Self> {
-        if private_key_info.algorithm.oid != ALGORITHM_OID {
-            return Err(pkcs8::der::ErrorKind::UnknownOid {
-                oid: private_key_info.algorithm.oid,
-            }
-            .into());
-        }
-
-        let params_oid = private_key_info.algorithm.parameters_oid()?;
-
-        if params_oid != C::OID {
-            return Err(pkcs8::der::ErrorKind::UnknownOid { oid: params_oid }.into());
-        }
+        private_key_info
+            .algorithm
+            .assert_oids(ALGORITHM_OID, C::OID)?;
 
         let mut decoder = der::Decoder::new(private_key_info.private_key);
 


### PR DESCRIPTION
Simplifies checking of SPKI OIDs