### PR TITLE
Add `PointCompaction` trait

### DIFF
--- a/elliptic-curve/src/weierstrass.rs
+++ b/elliptic-curve/src/weierstrass.rs
@@ -12,9 +12,21 @@ pub trait PointCompression {
     const COMPRESS_POINTS: bool;
 }
 
+/// Point compaction settings
+pub trait PointCompaction {
+    /// Should point compaction be applied by default?
+    const COMPACT_POINTS: bool;
+}
+
 /// Attempt to decompress an elliptic curve point from its x-coordinate and
 /// a boolean flag indicating whether or not the y-coordinate is odd.
 pub trait DecompressPoint<C: Curve>: Sized {
     /// Attempt to decompress an elliptic curve point.
     fn decompress(x: &FieldBytes<C>, y_is_odd: Choice) -> CtOption<Self>;
+}
+
+/// Attempt to decompact an elliptic curve point from an x-coordinate
+pub trait DecompactPoint<C: Curve>: Sized {
+    /// Attempt to decompact an elliptic curve point
+    fn decompact(x: &FieldBytes<C>) -> CtOption<Self>;
 }


### PR DESCRIPTION
This PR contains @vihu's work from #590, rebased against the latest version of the code, and modified so as not to introduce new trait bounds on existing types, thus making support by any particular curve implementation optional.

I'm a bit hesitant to support a draft, especially one where I would like to propose changes but from an IETF process perspective it otherwise seems dead. Nevertheless the functionality it provides does seem interesting, and in that regard worth supporting.

Closes #590.