### PR TITLE
elliptic-curve: bump `crypto-bigint` to v0.2.0-pre

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,7 +56,7 @@ checksum = "d0d27fb6b6f1e43147af148af49d49329413ba781aa0d5e10979831c210173b5"
 [[package]]
 name = "base64ct"
 version = "1.0.0"
-source = "git+https://github.com/rustcrypto/utils.git#3fc828a86a31b2b5016dd64e4f3b38a858f9d070"
+source = "git+https://github.com/rustcrypto/utils.git#dd17922cba2798f9a002850acf455cf2d6215483"
 
 [[package]]
 name = "bitfield"
@@ -145,7 +145,7 @@ dependencies = [
 [[package]]
 name = "const-oid"
 version = "0.6.0"
-source = "git+https://github.com/rustcrypto/utils.git#3fc828a86a31b2b5016dd64e4f3b38a858f9d070"
+source = "git+https://github.com/rustcrypto/utils.git#dd17922cba2798f9a002850acf455cf2d6215483"
 
 [[package]]
 name = "cortex-m"
@@ -184,8 +184,8 @@ dependencies = [
 
 [[package]]
 name = "crypto-bigint"
-version = "0.1.0"
-source = "git+https://github.com/rustcrypto/utils.git#3fc828a86a31b2b5016dd64e4f3b38a858f9d070"
+version = "0.2.0-pre"
+source = "git+https://github.com/rustcrypto/utils.git#dd17922cba2798f9a002850acf455cf2d6215483"
 dependencies = [
  "generic-array",
  "subtle",
@@ -224,7 +224,7 @@ dependencies = [
 [[package]]
 name = "der"
 version = "0.4.0-pre"
-source = "git+https://github.com/rustcrypto/utils.git#3fc828a86a31b2b5016dd64e4f3b38a858f9d070"
+source = "git+https://github.com/rustcrypto/utils.git#dd17922cba2798f9a002850acf455cf2d6215483"
 dependencies = [
  "const-oid",
 ]
@@ -403,7 +403,7 @@ dependencies = [
 [[package]]
 name = "pkcs8"
 version = "0.7.0-pre"
-source = "git+https://github.com/rustcrypto/utils.git#3fc828a86a31b2b5016dd64e4f3b38a858f9d070"
+source = "git+https://github.com/rustcrypto/utils.git#dd17922cba2798f9a002850acf455cf2d6215483"
 dependencies = [
  "base64ct 1.0.0 (git+https://github.com/rustcrypto/utils.git)",
  "der",
@@ -531,7 +531,7 @@ dependencies = [
 [[package]]
 name = "spki"
 version = "0.4.0-pre"
-source = "git+https://github.com/rustcrypto/utils.git#3fc828a86a31b2b5016dd64e4f3b38a858f9d070"
+source = "git+https://github.com/rustcrypto/utils.git#dd17922cba2798f9a002850acf455cf2d6215483"
 dependencies = [
  "der",
 ]

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["cryptography", "no-std"]
 keywords   = ["crypto", "ecc", "elliptic", "weierstrass"]
 
 [dependencies]
-crypto-bigint = { version = "0.1", features = ["generic-array"] }
+crypto-bigint = { version = "=0.2.0-pre", features = ["generic-array"] }
 generic-array = { version = "0.14", default-features = false }
 rand_core = { version = "0.6", default-features = false }
 subtle = { version = "2.4", default-features = false }

--- a/elliptic-curve/src/dev.rs
+++ b/elliptic-curve/src/dev.rs
@@ -2,7 +2,7 @@
 //! against concrete implementations of the traits in this crate.
 
 use crate::{
-    bigint::{ArrayEncoding, U256},
+    bigint::{ArrayEncoding as _, U256},
     error::{Error, Result},
     rand_core::RngCore,
     sec1::{FromEncodedPoint, ToEncodedPoint},
@@ -135,7 +135,7 @@ impl PrimeField for Scalar {
     const S: u32 = 4;
 
     fn from_repr(bytes: FieldBytes) -> Option<Self> {
-        U256::from_be_bytes(&bytes).try_into().ok()
+        U256::from_be_byte_array(bytes).try_into().ok()
     }
 
     fn to_repr(&self) -> FieldBytes {

--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -57,7 +57,7 @@ pub use self::{
     error::{Error, Result},
     scalar::bytes::ScalarBytes,
 };
-pub use crypto_bigint::{self as bigint, ArrayEncoding, NumBits, NumBytes};
+pub use crypto_bigint as bigint;
 pub use generic_array::{self, typenum::consts};
 pub use rand_core;
 pub use subtle;
@@ -111,12 +111,11 @@ pub const ALGORITHM_OID: pkcs8::ObjectIdentifier =
 pub trait Curve: Clone + Debug + Default + Eq + Ord + Send + Sync {
     /// Integer type used to represent field elements of this elliptic curve.
     type UInt: AsRef<[bigint::Limb]>
-        + ArrayEncoding
+        + bigint::ArrayEncoding
+        + bigint::Encoding
         + Copy
         + Debug
         + Default
-        + NumBits
-        + NumBytes
         + ConstantTimeEq
         + ConstantTimeGreater
         + ConstantTimeLess;
@@ -129,7 +128,7 @@ pub trait Curve: Clone + Debug + Default + Eq + Ord + Send + Sync {
 }
 
 /// Size of field elements of this elliptic curve.
-pub type FieldSize<C> = <<C as Curve>::UInt as ArrayEncoding>::ByteSize;
+pub type FieldSize<C> = <<C as Curve>::UInt as bigint::ArrayEncoding>::ByteSize;
 
 /// Byte representation of a base/scalar field element of a given curve.
 pub type FieldBytes<C> = GenericArray<u8, FieldSize<C>>;

--- a/elliptic-curve/src/scalar/bytes.rs
+++ b/elliptic-curve/src/scalar/bytes.rs
@@ -1,7 +1,7 @@
 //! Scalar bytes.
 
 use crate::{
-    bigint::{ArrayEncoding, NumBytes},
+    bigint::{ArrayEncoding as _, Encoding as _},
     Curve, Error, FieldBytes, Result,
 };
 use core::convert::TryFrom;
@@ -31,7 +31,7 @@ where
     /// Create new [`ScalarBytes`], checking that the given input is within
     /// range of the [`Curve::ORDER`].
     pub fn new(bytes: FieldBytes<C>) -> CtOption<Self> {
-        Self::from_uint(&C::UInt::from_be_byte_array(&bytes))
+        Self::from_uint(&C::UInt::from_be_byte_array(bytes))
     }
 
     /// Create [`ScalarBytes`] from the provided `C::UInt`.
@@ -226,7 +226,7 @@ where
     type Error = Error;
 
     fn try_from(bytes: &[u8]) -> Result<Self> {
-        if bytes.len() == C::UInt::NUM_BYTES {
+        if bytes.len() == C::UInt::BYTE_SIZE {
             Option::from(ScalarBytes::new(GenericArray::clone_from_slice(bytes))).ok_or(Error)
         } else {
             Err(Error)

--- a/elliptic-curve/src/scalar/non_zero.rs
+++ b/elliptic-curve/src/scalar/non_zero.rs
@@ -1,7 +1,7 @@
 //! Non-zero scalar type.
 
 use crate::{
-    bigint::NumBytes,
+    bigint::Encoding as _,
     ops::Invert,
     rand_core::{CryptoRng, RngCore},
     Curve, Error, FieldBytes, ProjectiveArithmetic, Result, Scalar,
@@ -155,7 +155,7 @@ where
     type Error = Error;
 
     fn try_from(bytes: &[u8]) -> Result<Self> {
-        if bytes.len() == C::UInt::NUM_BYTES {
+        if bytes.len() == C::UInt::BYTE_SIZE {
             NonZeroScalar::from_repr(GenericArray::clone_from_slice(bytes)).ok_or(Error)
         } else {
             Err(Error)


### PR DESCRIPTION
Sourced from git.

Incorporates this `Encoding` trait refactor: https://github.com/RustCrypto/utils/pull/488