### PR TITLE
elliptic-curve: add TODO for replacing UInt with an associated constant

### DIFF
--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -110,6 +110,8 @@ pub const ALGORITHM_OID: pkcs8::ObjectIdentifier =
 /// curves (e.g. [`SecretKey`]).
 pub trait Curve: Clone + Debug + Default + Eq + Ord + Send + Sync {
     /// Integer type used to represent field elements of this elliptic curve.
+    // TODO(tarcieri): replace this with an e.g. `const Curve::MODULUS: uint`.
+    // Requires rust-lang/rust#60551, i.e. `const_evaluatable_checked`
     type UInt: AsRef<[bigint::Limb]>
         + ArrayEncoding
         + Copy


### PR DESCRIPTION
Ideally instead of specifying a `Curve::UInt` associated type, we could instead specify a constant, and then pass that as a const generic parameter to `crypto_bigint::UInt`.

Unfortunately that requires a lot more functionality than is implemented in `min_const_generics`:

https://github.com/rust-lang/rust/issues/60551

This commit makes a note of as much in the comments, calling it out as future work.