### PR TITLE
elliptic-curve v0.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -247,7 +247,7 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.10.0-pre"
+version = "0.10.0"
 dependencies = [
  "base64ct",
  "crypto-bigint",

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -17,7 +17,7 @@ edition = "2018"
 aead = { version = "0.4", optional = true, path = "../aead" }
 cipher = { version = "0.3", optional = true }
 digest = { version = "0.9", optional = true }
-elliptic-curve = { version = "=0.10.0-pre", optional = true, path = "../elliptic-curve" }
+elliptic-curve = { version = "0.10", optional = true, path = "../elliptic-curve" }
 mac = { version = "0.11", package = "crypto-mac", optional = true }
 password-hash = { version = "0.2", optional = true, path = "../password-hash" }
 signature = { version = "1.2.0", optional = true, default-features = false, path = "../signature" }

--- a/elliptic-curve/CHANGELOG.md
+++ b/elliptic-curve/CHANGELOG.md
@@ -4,6 +4,41 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.10.0 (2021-06-07)
+### Added
+- `ScalarBytes::from_uint` ([#651])
+- `dev::ScalarBytes` ([#652])
+- `ScalarArithmetic` trait ([#654])
+- `AffineArithmetic` trait ([#658])
+- `PointCompaction` trait and SEC1 tag support ([#659])
+
+### Changed
+- Bump `ff` and `group` to v0.10; MSRV 1.51+ ([#643])
+- Merge `Curve` and `Order` traits ([#644])
+- Use `crypto-bigint` to represent `Curve::ORDER` ([#645])
+- Source `FieldSize<C>` from `C::UInt` type ([#646])
+- Impl `ScalarBytes<C>` using `C::UInt` ([#647])
+- Make `ScalarBytes<C>` the `SecretKey<C>` internal repr ([#649])
+- Bump `crypto-bigint` to v0.2 ([#662])
+- Bump `pkcs8` to v0.7 ([#662])
+
+### Removed
+- `util` module ([#648])
+
+[#643]: https://github.com/RustCrypto/traits/pull/643
+[#644]: https://github.com/RustCrypto/traits/pull/644
+[#645]: https://github.com/RustCrypto/traits/pull/645
+[#646]: https://github.com/RustCrypto/traits/pull/646
+[#647]: https://github.com/RustCrypto/traits/pull/647
+[#648]: https://github.com/RustCrypto/traits/pull/648
+[#649]: https://github.com/RustCrypto/traits/pull/649
+[#651]: https://github.com/RustCrypto/traits/pull/651
+[#652]: https://github.com/RustCrypto/traits/pull/652
+[#654]: https://github.com/RustCrypto/traits/pull/654
+[#658]: https://github.com/RustCrypto/traits/pull/658
+[#659]: https://github.com/RustCrypto/traits/pull/659
+[#662]: https://github.com/RustCrypto/traits/pull/662
+
 ## 0.9.12 (2021-05-18)
 ### Added
 - `Ord` and `PartialOrd` impls on `PublicKey` ([#637])

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -5,7 +5,7 @@ General purpose Elliptic Curve Cryptography (ECC) support, including types
 and traits for representing various elliptic curve forms, scalars, points,
 and public/secret keys composed thereof.
 """
-version    = "0.10.0-pre" # Also update html_root_url in lib.rs when bumping this
+version    = "0.10.0" # Also update html_root_url in lib.rs when bumping this
 authors    = ["RustCrypto Developers"]
 license    = "Apache-2.0 OR MIT"
 repository = "https://github.com/RustCrypto/traits/tree/master/elliptic-curve"

--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -16,7 +16,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
-    html_root_url = "https://docs.rs/elliptic-curve/0.9.12"
+    html_root_url = "https://docs.rs/elliptic-curve/0.10.0"
 )]
 
 #[cfg(feature = "alloc")]


### PR DESCRIPTION
### Added
- `ScalarBytes::from_uint` ([#651])
- `dev::ScalarBytes` ([#652])
- `ScalarArithmetic` trait ([#654])
- `AffineArithmetic` trait ([#658])
- `PointCompaction` trait and SEC1 tag support ([#659])

### Changed
- Bump `ff` and `group` to v0.10; MSRV 1.51+ ([#643])
- Merge `Curve` and `Order` traits ([#644])
- Use `crypto-bigint` to represent `Curve::ORDER` ([#645])
- Source `FieldSize<C>` from `C::UInt` type ([#646])
- Impl `ScalarBytes<C>` using `C::UInt` ([#647])
- Make `ScalarBytes<C>` the `SecretKey<C>` internal repr ([#649])
- Bump `crypto-bigint` to v0.2 ([#662])
- Bump `pkcs8` to v0.7 ([#662])

### Removed
- `util` module ([#648])

[#643]: https://github.com/RustCrypto/traits/pull/643
[#644]: https://github.com/RustCrypto/traits/pull/644
[#645]: https://github.com/RustCrypto/traits/pull/645
[#646]: https://github.com/RustCrypto/traits/pull/646
[#647]: https://github.com/RustCrypto/traits/pull/647
[#648]: https://github.com/RustCrypto/traits/pull/648
[#649]: https://github.com/RustCrypto/traits/pull/649
[#651]: https://github.com/RustCrypto/traits/pull/651
[#652]: https://github.com/RustCrypto/traits/pull/652
[#654]: https://github.com/RustCrypto/traits/pull/654
[#658]: https://github.com/RustCrypto/traits/pull/658
[#659]: https://github.com/RustCrypto/traits/pull/659
[#662]: https://github.com/RustCrypto/traits/pull/662