### PR TITLE
crypto v0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,7 +166,7 @@ dependencies = [
 
 [[package]]
 name = "crypto"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "aead",
  "cipher 0.3.0",

--- a/crypto/CHANGELOG.md
+++ b/crypto/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.3.0 (2021-06-08)
+### Changed
+- Bump `elliptic-curve` crate dependency to v0.10 ([#663])
+- Bump `signature` crate dependency to v1.3.0 ([#664])
+
+[#663]: https://github.com/RustCrypto/traits/pull/663
+[#664]: https://github.com/RustCrypto/traits/pull/664
+
 ## 0.2.0 (2021-04-29)
 - Initial (re-)release of the `cryptography` crate as `crypto`
 

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crypto"
-version = "0.2.0" # Also update html_root_url in lib.rs when bumping this
+version = "0.3.0" # Also update html_root_url in lib.rs when bumping this
 description = """
 Resources for building cryptosystems in Rust using the RustCrypto project's ecosystem.
 """

--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -39,7 +39,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
-    html_root_url = "https://docs.rs/crypto/0.2.0"
+    html_root_url = "https://docs.rs/crypto/0.3.0"
 )]
 #![forbid(unsafe_code)]
 #![warn(rust_2018_idioms)]


### PR DESCRIPTION
### Changed
- Bump `elliptic-curve` crate dependency to v0.10 ([#663])
- Bump `signature` crate dependency to v1.3.0 ([#664])

[#663]: https://github.com/RustCrypto/traits/pull/663
[#664]: https://github.com/RustCrypto/traits/pull/664