### PR TITLE
elliptic-curve v0.10.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -247,7 +247,7 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "base64ct",
  "crypto-bigint",

--- a/elliptic-curve/CHANGELOG.md
+++ b/elliptic-curve/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.10.1 (2021-06-09)
+### Added
+- Explicit `Copy` bounds on `PublicKey` ([#667])
+
+[#667]: https://github.com/RustCrypto/traits/pull/667
+
 ## 0.10.0 (2021-06-07)
 ### Added
 - `ScalarBytes::from_uint` ([#651])

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -5,7 +5,7 @@ General purpose Elliptic Curve Cryptography (ECC) support, including types
 and traits for representing various elliptic curve forms, scalars, points,
 and public/secret keys composed thereof.
 """
-version    = "0.10.0" # Also update html_root_url in lib.rs when bumping this
+version    = "0.10.1" # Also update html_root_url in lib.rs when bumping this
 authors    = ["RustCrypto Developers"]
 license    = "Apache-2.0 OR MIT"
 repository = "https://github.com/RustCrypto/traits/tree/master/elliptic-curve"

--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -16,7 +16,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
-    html_root_url = "https://docs.rs/elliptic-curve/0.10.0"
+    html_root_url = "https://docs.rs/elliptic-curve/0.10.1"
 )]
 
 #[cfg(feature = "alloc")]


### PR DESCRIPTION
### Added
- Explicit `Copy` bounds on `PublicKey` ([#667])

[#667]: https://github.com/RustCrypto/traits/pull/667