### PR TITLE
signature v1.3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -511,7 +511,7 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "digest 0.9.0",
  "hex-literal 0.2.1",

--- a/signature/CHANGELOG.md
+++ b/signature/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.3.1 (2021-06-29)
+### Added
+- `Result` alias ([#676])
+
+[#676]: https://github.com/RustCrypto/traits/pull/676
+
 ## 1.3.0 (2021-01-06)
 ### Changed
 - Bump `rand_core` to v0.6 ([#457])

--- a/signature/Cargo.toml
+++ b/signature/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name          = "signature"
 description   = "Traits for cryptographic signature algorithms (e.g. ECDSA, Ed25519)"
-version       = "1.3.0" # Also update html_root_url in lib.rs when bumping this
+version       = "1.3.1" # Also update html_root_url in lib.rs when bumping this
 authors       = ["RustCrypto Developers"]
 license       = "Apache-2.0 OR MIT"
 documentation = "https://docs.rs/signature"

--- a/signature/src/lib.rs
+++ b/signature/src/lib.rs
@@ -160,7 +160,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
-    html_root_url = "https://docs.rs/signature/1.3.0"
+    html_root_url = "https://docs.rs/signature/1.3.1"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]


### PR DESCRIPTION
### Added
- `Result` alias ([#676])

[#676]: https://github.com/RustCrypto/traits/pull/676