### PR TITLE
aead: re-export `rand_core`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -305,6 +305,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
 name = "group"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -424,6 +435,9 @@ name = "rand_core"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+dependencies = [
+ "getrandom",
+]
 
 [[package]]
 name = "rustc_version"
@@ -602,6 +616,12 @@ checksum = "0d67cb4616d99b940db1d6bd28844ff97108b498a6ca850e5b6191a532063286"
 dependencies = [
  "vcell",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.10.2+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wyz"

--- a/aead/Cargo.toml
+++ b/aead/Cargo.toml
@@ -17,13 +17,15 @@ categories = ["cryptography", "no-std"]
 [dependencies]
 generic-array = { version = "0.14", default-features = false }
 
+# optional dependencies
 blobby = { version = "0.3", optional = true }
 heapless = { version = "0.7", optional = true, default-features = false }
 rand_core = { version = "0.6", optional = true }
 
 [features]
-std = ["alloc"]
+default = ["rand_core"]
 alloc = []
+std = ["alloc", "rand_core/std"]
 dev = ["blobby"]
 stream = []
 

--- a/aead/Cargo.toml
+++ b/aead/Cargo.toml
@@ -23,7 +23,6 @@ heapless = { version = "0.7", optional = true, default-features = false }
 rand_core = { version = "0.6", optional = true }
 
 [features]
-default = ["rand_core"]
 alloc = []
 std = ["alloc", "rand_core/std"]
 dev = ["blobby"]

--- a/aead/src/lib.rs
+++ b/aead/src/lib.rs
@@ -40,16 +40,21 @@ pub mod stream;
 pub use generic_array::{self, typenum::consts};
 
 #[cfg(feature = "heapless")]
+#[cfg_attr(docsrs, doc(cfg(feature = "heapless")))]
 pub use heapless;
 
 #[cfg(feature = "rand_core")]
-use rand_core::{CryptoRng, RngCore};
+#[cfg_attr(docsrs, doc(cfg(feature = "rand_core")))]
+pub use rand_core;
 
 use core::fmt;
 use generic_array::{typenum::Unsigned, ArrayLength, GenericArray};
 
 #[cfg(feature = "alloc")]
 use alloc::vec::Vec;
+
+#[cfg(feature = "rand_core")]
+use rand_core::{CryptoRng, RngCore};
 
 /// Error type.
 ///


### PR DESCRIPTION
This PR implements the changes proposed in #681 to simplify access to the `rand_core` traits and `OsRng`.

`rand_core` is conditionally re-exported when the eponymous crate feature is enabled.

Additionally, the `std` crate feature enables `rand_core/std`, which permits access to `OsRng` as `aead::rand_core::OsRng`.