### PR TITLE
Re-export rand_core

### DIFF
--- a/aead/CHANGELOG.md
+++ b/aead/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- Re-export `rand_core` ([#682])
+
+[#682]: https://github.com/RustCrypto/traits/pull/682
+
 ## 0.4.1 (2021-05-03)
 ### Changed
 - Bump `heapless` dependency to v0.7 ([#628])

--- a/cipher/CHANGELOG.md
+++ b/cipher/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- Re-export `rand_core` ([#683])
+
+[#683]: https://github.com/RustCrypto/traits/pull/683
+
 ## 0.3.0 (2021-04-28)
 ### Added
 - Encrypt/decrypt-only block cipher traits ([#352])

--- a/cipher/Cargo.toml
+++ b/cipher/Cargo.toml
@@ -15,13 +15,14 @@ categories = ["cryptography", "no-std"]
 generic-array = "0.14"
 crypto-common = { version = "=0.1.0-pre", path = "../crypto-common" }
 
+# optional dependencies
 block-buffer = { version = "=0.10.0-pre.4", features = ["block-padding"], optional = true }
 blobby = { version = "0.3", optional = true }
 rand_core = { version = "0.6", optional = true }
 
 [features]
 default = ["mode_wrapper"]
-std = ["crypto-common/std"]
+std = ["crypto-common/std", "rand_core/std"]
 mode_wrapper = ["block-buffer"]
 dev = ["blobby"]
 

--- a/cipher/src/lib.rs
+++ b/cipher/src/lib.rs
@@ -16,6 +16,10 @@
 #[cfg(feature = "std")]
 extern crate std;
 
+#[cfg(feature = "rand_core")]
+#[cfg_attr(docsrs, doc(cfg(feature = "rand_core")))]
+pub use rand_core;
+
 #[cfg(feature = "dev")]
 pub use blobby;
 

--- a/crypto-mac/CHANGELOG.md
+++ b/crypto-mac/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- Re-export `rand_core` ([#683])
+
+[#683]: https://github.com/RustCrypto/traits/pull/683
+
 ## 0.11.0 (2021-04-28)
 ### Added
 - `generate_key` method to `New*` trait ([#513])

--- a/crypto-mac/Cargo.toml
+++ b/crypto-mac/Cargo.toml
@@ -23,7 +23,7 @@ rand_core = { version = "0.6", optional = true }
 [features]
 dev = ["blobby"]
 core-api = ["crypto-common/core-api"]
-std = ["crypto-common/std"]
+std = ["crypto-common/std", "rand_core/std"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crypto-mac/src/lib.rs
+++ b/crypto-mac/src/lib.rs
@@ -12,6 +12,10 @@
 #[cfg(feature = "std")]
 extern crate std;
 
+#[cfg(feature = "rand_core")]
+#[cfg_attr(docsrs, doc(cfg(feature = "rand_core")))]
+pub use rand_core;
+
 #[cfg(feature = "cipher")]
 pub use cipher;
 #[cfg(feature = "cipher")]

--- a/elliptic-curve/CHANGELOG.md
+++ b/elliptic-curve/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- Re-export `rand_core` ([#683])
+
+[#683]: https://github.com/RustCrypto/traits/pull/683
+
 ## 0.10.3 (2021-06-21)
 ### Changed
 - Bump `crypto-bigint` to v0.2.1 ([#673])

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -43,7 +43,7 @@ ecdh = ["arithmetic", "zeroize"]
 hazmat = []
 jwk = ["alloc", "base64ct/alloc", "serde", "serde_json", "zeroize/alloc"]
 pem = ["alloc", "pkcs8/pem"]
-std = ["alloc"]
+std = ["alloc", "rand_core/std"]
 
 [package.metadata.docs.rs]
 features = ["arithmetic", "ecdh", "jwk", "pem", "std"]

--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -27,6 +27,10 @@ extern crate alloc;
 #[cfg(feature = "std")]
 extern crate std;
 
+#[cfg(feature = "rand_core")]
+#[cfg_attr(docsrs, doc(cfg(feature = "rand_core")))]
+pub use rand_core;
+
 pub mod ops;
 pub mod sec1;
 pub mod weierstrass;

--- a/password-hash/CHANGELOG.md
+++ b/password-hash/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- Re-export `rand_core` ([#683])
+
+[#683]: https://github.com/RustCrypto/traits/pull/683
+
 ## 0.2.1 (2021-05-05)
 ### Changed
 - Use `subtle` crate for comparing hash `Output` ([#631])

--- a/password-hash/Cargo.toml
+++ b/password-hash/Cargo.toml
@@ -25,7 +25,7 @@ rand_core = { version = "0.6", optional = true, default-features = false }
 [features]
 default = ["rand_core"]
 alloc = ["base64ct/alloc"]
-std = ["alloc", "base64ct/std"]
+std = ["alloc", "base64ct/std", "rand_core/std"]
 
 [package.metadata.docs.rs]
 rustc-args = ["--cfg", "docsrs"]

--- a/password-hash/src/lib.rs
+++ b/password-hash/src/lib.rs
@@ -50,6 +50,10 @@ extern crate alloc;
 #[cfg(feature = "std")]
 extern crate std;
 
+#[cfg(feature = "rand_core")]
+#[cfg_attr(docsrs, doc(cfg(feature = "rand_core")))]
+pub use rand_core;
+
 mod encoding;
 mod errors;
 mod ident;

--- a/signature/CHANGELOG.md
+++ b/signature/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- Re-export `rand_core`. Emit compilation error if unstable functionality
+is enabled by bypassing the preview features. ([#683])
+
+[#683]: https://github.com/RustCrypto/traits/pull/683
+
 ## 1.3.1 (2021-06-29)
 ### Added
 - `Result` alias ([#676])

--- a/signature/src/lib.rs
+++ b/signature/src/lib.rs
@@ -168,6 +168,24 @@
 #[cfg(feature = "std")]
 extern crate std;
 
+#[cfg(all(feature = "signature_derive", not(feature = "derive-preview")))]
+compile_error!(
+    "The `signature_derive` feature should not be enabled directly. \
+    Use the `derive-preview` feature instead."
+);
+
+#[cfg(all(feature = "digest", not(feature = "digest-preview")))]
+compile_error!(
+    "The `digest` feature should not be enabled directly. \
+    Use the `digest-preview` feature instead."
+);
+
+#[cfg(all(feature = "rand_core", not(feature = "rand-preview")))]
+compile_error!(
+    "The `rand_core` feature should not be enabled directly. \
+    Use the `rand-preview` feature instead."
+);
+
 #[cfg(feature = "derive-preview")]
 #[cfg_attr(docsrs, doc(cfg(feature = "derive-preview")))]
 pub use signature_derive::{Signer, Verifier};
@@ -175,7 +193,8 @@ pub use signature_derive::{Signer, Verifier};
 #[cfg(feature = "digest-preview")]
 pub use digest;
 
-#[cfg(feature = "rand-preview")]
+#[cfg(feature = "rand_core")]
+#[cfg_attr(docsrs, doc(cfg(feature = "rand-preview")))]
 pub use rand_core;
 
 mod error;


### PR DESCRIPTION
Closes #681

Also issue compilation errors if unstable functionality in the `signature` crate is enabled by toggling features introduced by optional dependencies. In theory it may break build for some people, but it would've happened eventually either way. Also I do not forward `std` to `rand_core` in this case since doing it correctly requires weak feature activation.