### PR TITLE
elliptic-curve v0.10.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "aead"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "blobby",
  "generic-array",
@@ -251,7 +251,7 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "base64ct",
  "crypto-bigint",

--- a/aead/CHANGELOG.md
+++ b/aead/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## v0.4.2 (2021-07-12)
+## 0.4.2 (2021-07-12)
 ### Added
 - Re-export `rand_core` ([#682])
 

--- a/elliptic-curve/CHANGELOG.md
+++ b/elliptic-curve/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## 0.10.4 (2021-07-12)
 ### Added
 - Re-export `rand_core` ([#683])
 

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -5,7 +5,7 @@ General purpose Elliptic Curve Cryptography (ECC) support, including types
 and traits for representing various elliptic curve forms, scalars, points,
 and public/secret keys composed thereof.
 """
-version    = "0.10.3" # Also update html_root_url in lib.rs when bumping this
+version    = "0.10.4" # Also update html_root_url in lib.rs when bumping this
 authors    = ["RustCrypto Developers"]
 license    = "Apache-2.0 OR MIT"
 repository = "https://github.com/RustCrypto/traits/tree/master/elliptic-curve"

--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -16,7 +16,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
-    html_root_url = "https://docs.rs/elliptic-curve/0.10.3"
+    html_root_url = "https://docs.rs/elliptic-curve/0.10.4"
 )]
 
 #[cfg(feature = "alloc")]


### PR DESCRIPTION
### Added
- Re-export `rand_core` ([#683])

[#683]: https://github.com/RustCrypto/traits/pull/683