### PR TITLE
Pin zeroize dependency to v1.4 and subtle to v2.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,9 +147,9 @@ checksum = "44c32f031ea41b4291d695026c023b95d59db2d8a2c7640800ed56bc8f510f22"
 
 [[package]]
 name = "cortex-m"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "643a210c1bdc23d0db511e2a576082f4ff4dcae9d0c37f50b431b8f8439d6d6b"
+checksum = "2ac919ef424449ec8c08d515590ce15d9262c0ca5f0da5b0c901e971a3b783b3"
 dependencies = [
  "bare-metal",
  "bitfield",
@@ -159,9 +159,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed00c67cb5d0a7d64a44f6ad2668db7e7530311dd53ea79bcd4fb022c64911c8"
+checksum = "66c99696f6c9dd7f35d486b9d04d7e6e202aa3e8c40d553f2fdf5e7e0c6a71ef"
 dependencies = [
  "libc",
 ]
@@ -360,9 +360,9 @@ checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
 name = "libc"
-version = "0.2.95"
+version = "0.2.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "789da6d93f1b866ffe175afc5322a4d76c038605a1c3319bb57b06967ca98a36"
+checksum = "320cfe77175da3a483efed4bc0adc1968ca050b098ce4f2f1c13a56626128790"
 
 [[package]]
 name = "nb"
@@ -543,9 +543,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.72"
+version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1e8cdbefb79a9a5a65e0db8b47b723ee907b7c7f8496c76a1770b5c310bab82"
+checksum = "f71489ff30030d2ae598524f61326b902466f72a0fb1a8564c001cc63425bcc7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -554,9 +554,9 @@ dependencies = [
 
 [[package]]
 name = "synstructure"
-version = "0.12.4"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b834f2d66f734cb897113e34aaff2f1ab4719ca946f9a7358dba8f8064148701"
+checksum = "474aaa926faa1603c40b7885a9eaea29b444d1cb2850cb7c0e37bb1a4182f4fa"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -251,7 +251,7 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "base64ct",
  "crypto-bigint",
@@ -387,7 +387,7 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "password-hash"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "base64ct",
  "rand_core",
@@ -584,7 +584,7 @@ checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
 name = "universal-hash"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "generic-array",
  "subtle",

--- a/crypto-mac/CHANGELOG.md
+++ b/crypto-mac/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [#683]: https://github.com/RustCrypto/traits/pull/683
 
+## 0.11.1 (2021-07-20)
+### Changed
+- Pin `subtle` dependency to v2.4 ([#691])
+
+[#691]: https://github.com/RustCrypto/traits/pull/691
+
 ## 0.11.0 (2021-04-28)
 ### Added
 - `generate_key` method to `New*` trait ([#513])
@@ -22,6 +28,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#442]: https://github.com/RustCrypto/traits/pull/442
 [#513]: https://github.com/RustCrypto/traits/pull/513
 [#621]: https://github.com/RustCrypto/traits/pull/621
+
+## 0.10.1 (2021-07-20)
+### Changed
+- Pin `subtle` dependency to v2.4 ([#690])
+
+[#690]: https://github.com/RustCrypto/traits/pull/690
 
 ## 0.10.0 (2020-10-15)
 ### Changed

--- a/crypto-mac/Cargo.toml
+++ b/crypto-mac/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "crypto-mac"
 description = "Trait for Message Authentication Code (MAC) algorithms"
-version = "0.12.0-pre"
+version = "0.12.0-pre" # Also update html_root_url in lib.rs when bumping this
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
@@ -15,7 +15,7 @@ categories = ["cryptography", "no-std"]
 generic-array = "0.14"
 crypto-common = { version = "=0.1.0-pre", path = "../crypto-common" }
 cipher = { version = "=0.4.0-pre", path = "../cipher" }
-subtle = { version = "2", default-features = false }
+subtle = { version = "=2.4", default-features = false }
 
 blobby = { version = "0.3", optional = true }
 rand_core = { version = "0.6", optional = true }

--- a/crypto-mac/src/lib.rs
+++ b/crypto-mac/src/lib.rs
@@ -4,7 +4,8 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
-    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg"
+    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
+    html_root_url = "https://docs.rs/crypto-mac/0.12.0-pre"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]

--- a/elliptic-curve/CHANGELOG.md
+++ b/elliptic-curve/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.10.5 (2021-07-20)
+### Changed
+- Pin `zeroize` dependency to v1.4 and `subtle` to v2.4 ([#349])
+
+[#689]: https://github.com/RustCrypto/traits/pull/689
+
 ## 0.10.4 (2021-07-12)
 ### Added
 - Re-export `rand_core` ([#683])

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -5,7 +5,7 @@ General purpose Elliptic Curve Cryptography (ECC) support, including types
 and traits for representing various elliptic curve forms, scalars, points,
 and public/secret keys composed thereof.
 """
-version    = "0.10.4" # Also update html_root_url in lib.rs when bumping this
+version    = "0.10.5" # Also update html_root_url in lib.rs when bumping this
 authors    = ["RustCrypto Developers"]
 license    = "Apache-2.0 OR MIT"
 repository = "https://github.com/RustCrypto/traits/tree/master/elliptic-curve"
@@ -18,7 +18,7 @@ keywords   = ["crypto", "ecc", "elliptic", "weierstrass"]
 crypto-bigint = { version = "0.2.2", features = ["generic-array"] }
 generic-array = { version = "0.14", default-features = false }
 rand_core = { version = "0.6", default-features = false }
-subtle = { version = "2.4", default-features = false }
+subtle = { version = "=2.4", default-features = false }
 
 # optional dependencies
 base64ct = { version = "1", optional = true, default-features = false }
@@ -28,7 +28,7 @@ hex-literal = { version = "0.3", optional = true }
 pkcs8 = { version = "0.7", optional = true }
 serde = { version = "1", optional = true, default-features = false }
 serde_json = { version = "1", optional = true, default-features = false, features = ["alloc"] }
-zeroize = { version = "1", optional = true,  default-features = false }
+zeroize = { version = "=1.4", optional = true,  default-features = false }
 
 [dev-dependencies]
 hex-literal = "0.3"

--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -16,7 +16,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
-    html_root_url = "https://docs.rs/elliptic-curve/0.10.4"
+    html_root_url = "https://docs.rs/elliptic-curve/0.10.5"
 )]
 
 #[cfg(feature = "alloc")]

--- a/password-hash/CHANGELOG.md
+++ b/password-hash/CHANGELOG.md
@@ -5,11 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## 0.2.2 (2021-07-20)
+### Changed
+- Pin `subtle` dependency to v2.4 ([#689])
+
 ### Added
 - Re-export `rand_core` ([#683])
 
 [#683]: https://github.com/RustCrypto/traits/pull/683
+[#689]: https://github.com/RustCrypto/traits/pull/689
 
 ## 0.2.1 (2021-05-05)
 ### Changed

--- a/password-hash/Cargo.toml
+++ b/password-hash/Cargo.toml
@@ -5,7 +5,7 @@ Traits which describe the functionality of password hashing algorithms,
 as well as a `no_std`-friendly implementation of the PHC string format
 (a well-defined subset of the Modular Crypt Format a.k.a. MCF)
 """
-version = "0.2.1" # Also update html_root_url in lib.rs when bumping this
+version = "0.2.2" # Also update html_root_url in lib.rs when bumping this
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
@@ -17,7 +17,7 @@ keywords = ["crypt", "mcf", "password", "pbkdf", "phc"]
 
 [dependencies]
 base64ct = "1"
-subtle = { version = "2", default-features = false }
+subtle = { version = "=2.4", default-features = false }
 
 # optional features
 rand_core = { version = "0.6", optional = true, default-features = false }

--- a/password-hash/src/lib.rs
+++ b/password-hash/src/lib.rs
@@ -39,7 +39,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
-    html_root_url = "https://docs.rs/password-hash/0.2.1"
+    html_root_url = "https://docs.rs/password-hash/0.2.2"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]

--- a/universal-hash/CHANGELOG.md
+++ b/universal-hash/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.1 (2021-07-20)
+### Changed
+- Pin `subtle` dependency to v2.4 ([#689])
+
+[#689]: https://github.com/RustCrypto/traits/pull/689
+
 ## 0.4.0 (2020-06-04)
 ### Added
 - `Key` and `Block` type aliases ([#128])

--- a/universal-hash/Cargo.toml
+++ b/universal-hash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "universal-hash"
-version = "0.4.0"
+version = "0.4.1" # Also update html_root_url in lib.rs when bumping this
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 description = "Trait for universal hash functions"
@@ -13,7 +13,7 @@ edition = "2018"
 
 [dependencies]
 generic-array = "0.14"
-subtle = { version = "2", default-features = false }
+subtle = { version = "=2.4", default-features = false }
 
 [features]
 std = []

--- a/universal-hash/src/lib.rs
+++ b/universal-hash/src/lib.rs
@@ -21,7 +21,8 @@
 #![forbid(unsafe_code)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
-    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg"
+    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
+    html_root_url = "https://docs.rs/universal-hash/0.4.1"
 )]
 #![warn(missing_docs, rust_2018_idioms)]
 


### PR DESCRIPTION
`crypto-mac` will be updated in a separate PR since current `master` contains the pre-release version.

Also updates Cargo.lock.