### PR TITLE
Pin subtle to v2.4 for crypto-mac v0.11

### DIFF
--- a/crypto-mac/CHANGELOG.md
+++ b/crypto-mac/CHANGELOG.md
@@ -5,11 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.11.1 (2021-07-20)
+### Changed
+- Pin `subtle` dependency to v2.4 ([#691])
+
+[#691]: https://github.com/RustCrypto/traits/pull/691
+
 ## 0.11.0 (2021-04-28)
 ### Changed
 - Bump `cipher` dependency to v0.3 ([#621])
 
 [#621]: https://github.com/RustCrypto/traits/pull/621
+
+## 0.10.1 (2021-07-20)
+### Changed
+- Pin `subtle` dependency to v2.4 ([#690])
+
+[#690]: https://github.com/RustCrypto/traits/pull/690
 
 ## 0.10.0 (2020-10-15)
 ### Changed

--- a/crypto-mac/Cargo.toml
+++ b/crypto-mac/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "crypto-mac"
 description = "Trait for Message Authentication Code (MAC) algorithms"
-version = "0.11.0"
+version = "0.11.1" # Also update html_root_url in lib.rs when bumping this
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
@@ -14,7 +14,7 @@ categories = ["cryptography", "no-std"]
 [dependencies]
 generic-array = "0.14"
 cipher = { version = "0.3", optional = true, path = "../cipher" }
-subtle = { version = "2", default-features = false }
+subtle = { version = "=2.4", default-features = false }
 blobby = { version = "0.3", optional = true }
 
 [features]

--- a/crypto-mac/src/lib.rs
+++ b/crypto-mac/src/lib.rs
@@ -4,7 +4,8 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg"
+    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
+    html_root_url = "https://docs.rs/crypto-mac/0.11.1"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]


### PR DESCRIPTION
#690 has pinned `subtle` for `crtypto-mac` v0.10.