### PR TITLE
elliptic-curve: bump `crypto-bigint` dependency to v0.2.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,9 +146,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-bigint"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09910f0830248af4499907177608b81d640c8c404526f8770b87b765fbd8c9a5"
+checksum = "cc209804a22c34a98fe26a32d997ac64d4284816f65cf1a529c4e31a256218a0"
 dependencies = [
  "generic-array",
  "rand_core",

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["cryptography", "no-std"]
 keywords   = ["crypto", "ecc", "elliptic", "weierstrass"]
 
 [dependencies]
-crypto-bigint = { version = "0.2.3", features = ["generic-array"] }
+crypto-bigint = { version = "0.2.4", features = ["generic-array"] }
 generic-array = { version = "0.14", default-features = false }
 rand_core = { version = "0.6", default-features = false }
 subtle = { version = "=2.4", default-features = false }


### PR DESCRIPTION
This release includes some new features which can be used to calculate various constants from an elliptic curve's order using `const fn`s.

Bumping the minimum release allows for elliptic curve libs to pin to a release of the `elliptic-curve` crate which includes this new version, allowing them to ensure the transitive dependency is up-to-date without explicitly pinning to it.