### PR TITLE
elliptic-curve v0.10.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -215,7 +215,7 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.10.5"
+version = "0.10.6"
 dependencies = [
  "base64ct",
  "crypto-bigint",

--- a/elliptic-curve/CHANGELOG.md
+++ b/elliptic-curve/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.10.6 (2021-08-23)
+### Changed
+- Bump `crypto-bigint` dependency to v0.2.4 ([#710])
+
+[#710]: https://github.com/RustCrypto/traits/pull/710
+
 ## 0.10.5 (2021-07-20)
 ### Changed
 - Pin `zeroize` dependency to v1.4 and `subtle` to v2.4 ([#349])

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -5,7 +5,7 @@ General purpose Elliptic Curve Cryptography (ECC) support, including types
 and traits for representing various elliptic curve forms, scalars, points,
 and public/secret keys composed thereof.
 """
-version    = "0.10.5" # Also update html_root_url in lib.rs when bumping this
+version    = "0.10.6" # Also update html_root_url in lib.rs when bumping this
 authors    = ["RustCrypto Developers"]
 license    = "Apache-2.0 OR MIT"
 repository = "https://github.com/RustCrypto/traits/tree/master/elliptic-curve"
@@ -28,7 +28,7 @@ hex-literal = { version = "0.3", optional = true }
 pkcs8 = { version = "0.7", optional = true }
 serde = { version = "1", optional = true, default-features = false }
 serde_json = { version = "1", optional = true, default-features = false, features = ["alloc"] }
-zeroize = { version = "=1.4", optional = true,  default-features = false }
+zeroize = { version = ">=1, <1.5", optional = true,  default-features = false }
 
 [dev-dependencies]
 hex-literal = "0.3"

--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -16,7 +16,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
-    html_root_url = "https://docs.rs/elliptic-curve/0.10.5"
+    html_root_url = "https://docs.rs/elliptic-curve/0.10.6"
 )]
 
 #[cfg(feature = "alloc")]


### PR DESCRIPTION
### Changed
- Bump `crypto-bigint` dependency to v0.2.4 ([#710])

[#710]: https://github.com/RustCrypto/traits/pull/710