### PR TITLE
feat: Add more details to `ParamValueInvalid` and introduce `SaltInvalid` error

### DIFF
--- a/password-hash/src/errors.rs
+++ b/password-hash/src/errors.rs
@@ -33,7 +33,7 @@ pub enum Error {
     ParamNameInvalid,
 
     /// Invalid parameter value.
-    ParamValueInvalid,
+    ParamValueInvalid(ParamValueError),
 
     /// Maximum number of parameters exceeded.
     ParamsMaxExceeded,
@@ -56,8 +56,21 @@ pub enum Error {
     /// Salt too long.
     SaltTooLong,
 
+    /// Salt invalid.
+    SaltInvalid,
+
     /// Invalid algorithm version.
     Version,
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum ParamValueError {
+    ToLong,
+    ToShort,
+    NotProvided,
+    InvalidChar,
+    InvalidFormat,
 }
 
 impl fmt::Display for Error {
@@ -70,7 +83,19 @@ impl fmt::Display for Error {
             Self::OutputTooLong => f.write_str("PHF output too long (max 64-bytes)"),
             Self::ParamNameDuplicated => f.write_str("duplicate parameter"),
             Self::ParamNameInvalid => f.write_str("invalid parameter name"),
-            Self::ParamValueInvalid => f.write_str("invalid parameter value"),
+            Self::ParamValueInvalid(param_err) => match param_err {
+                ParamValueError::ToLong => f.write_str("invalid parameter value: value to long"),
+                ParamValueError::ToShort => f.write_str("invalid parameter value: value to short"),
+                ParamValueError::NotProvided => {
+                    f.write_str("invalid parameter value: required value not provided")
+                }
+                ParamValueError::InvalidChar => {
+                    f.write_str("invalid parameter value: contains invalid character")
+                }
+                ParamValueError::InvalidFormat => {
+                    f.write_str("invalid parameter value: value format is invalid")
+                }
+            },
             Self::ParamsMaxExceeded => f.write_str("maximum number of parameters reached"),
             Self::Password => write!(f, "invalid password"),
             Self::PhcStringInvalid => write!(f, "password hash string invalid"),
@@ -78,6 +103,7 @@ impl fmt::Display for Error {
             Self::PhcStringTooLong => write!(f, "password hash string too long"),
             Self::SaltTooShort => write!(f, "salt too short"),
             Self::SaltTooLong => write!(f, "salt too long"),
+            Self::SaltInvalid => write!(f, "salt invalid"),
             Self::Version => write!(f, "invalid algorithm version"),
         }
     }

--- a/password-hash/src/params.rs
+++ b/password-hash/src/params.rs
@@ -1,5 +1,6 @@
 //! Algorithm parameters.
 
+use crate::errors::ParamValueError;
 use crate::{
     value::{Decimal, Value},
     Error, Ident, Result,
@@ -56,7 +57,9 @@ impl ParamsString {
         value: impl TryInto<Value<'a>>,
     ) -> Result<()> {
         let name = name.try_into().map_err(|_| Error::ParamNameInvalid)?;
-        let value = value.try_into().map_err(|_| Error::ParamValueInvalid)?;
+        let value = value
+            .try_into()
+            .map_err(|_| Error::ParamValueInvalid(ParamValueError::InvalidFormat))?;
         self.add(name, value)
     }
 
@@ -162,11 +165,11 @@ impl FromStr for ParamsString {
             // Validate value
             param
                 .next()
-                .ok_or(Error::ParamValueInvalid)
+                .ok_or(Error::ParamValueInvalid(ParamValueError::NotProvided))
                 .and_then(Value::try_from)?;
 
             if param.next().is_some() {
-                return Err(Error::ParamValueInvalid);
+                return Err(Error::ParamValueInvalid(ParamValueError::NotProvided));
             }
         }
 


### PR DESCRIPTION
### Overview

As briefly discussed in #706 this PR:
- Adds more context to `Error::ParamValueInvalid` in from of `ParamValueError` enum.
- Introduces `Error::SaltInvalid`.
- Maps `Error::ParamValueInvalid` to proper salt error.

Also as discussed in the issue **this is a breaking change.**

### Notes

`ParamValueError` could be an an `Option` in `ParamValueInvalid`: `ParamValueInvalid(Option<ParamValueError>)` if in some cases we do not want to specify a more detailed error but it might be more cumbersome to handle and I am not sure if there is such need, therefore, I went for implementation without it. Just wanted to highlight it as my knowledge here is limited.

Fixes: #706 