### PR TITLE
password-hash: minor fixes for `InvalidValue`

### DIFF
--- a/password-hash/src/encoding.rs
+++ b/password-hash/src/encoding.rs
@@ -1,7 +1,8 @@
 //! Base64 encoding variants.
 
-use crate::B64Error;
-use base64ct::{Base64Bcrypt, Base64Crypt, Base64Unpadded as B64, Encoding as _};
+use base64ct::{
+    Base64Bcrypt, Base64Crypt, Base64Unpadded as B64, Encoding as _, Error as B64Error,
+};
 
 /// Base64 encoding variants.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]

--- a/password-hash/src/errors.rs
+++ b/password-hash/src/errors.rs
@@ -9,7 +9,7 @@ pub type Result<T> = core::result::Result<T, Error>;
 
 /// Password hashing errors.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
-// #[non_exhaustive] TODO(tarcieri): make non-exhaustive in next breaking release
+#[non_exhaustive]
 pub enum Error {
     /// Unsupported algorithm.
     Algorithm,
@@ -94,21 +94,32 @@ impl From<base64ct::InvalidLengthError> for Error {
     }
 }
 
+/// Parse errors relating to invalid parameter values or salts.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum InvalidValue {
-    ToLong,
-    ToShort,
+    /// Value exceeds the maximum allowed length.
+    TooLong,
+
+    /// Value does not satisfy the minimum length.
+    TooShort,
+
+    /// Unspecified error.
+    // TODO(tarcieri): specify all error cases
     NotProvided,
+
+    /// Character is not in the allowed set.
     InvalidChar,
+
+    /// Format is invalid.
     InvalidFormat,
 }
 
 impl fmt::Display for InvalidValue {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> core::result::Result<(), fmt::Error> {
         match self {
-            Self::ToLong => f.write_str("value to long"),
-            Self::ToShort => f.write_str("value to short"),
+            Self::TooLong => f.write_str("value to long"),
+            Self::TooShort => f.write_str("value to short"),
             Self::NotProvided => f.write_str("required value not provided"),
             Self::InvalidChar => f.write_str("contains invalid character"),
             Self::InvalidFormat => f.write_str("value format is invalid"),

--- a/password-hash/src/lib.rs
+++ b/password-hash/src/lib.rs
@@ -54,8 +54,9 @@ extern crate std;
 #[cfg_attr(docsrs, doc(cfg(feature = "rand_core")))]
 pub use rand_core;
 
+pub mod errors;
+
 mod encoding;
-mod errors;
 mod ident;
 mod output;
 mod params;
@@ -64,7 +65,7 @@ mod value;
 
 pub use crate::{
     encoding::Encoding,
-    errors::{B64Error, Error, Result},
+    errors::{Error, Result},
     ident::Ident,
     output::Output,
     params::ParamsString,

--- a/password-hash/src/salt.rs
+++ b/password-hash/src/salt.rs
@@ -100,11 +100,11 @@ impl<'a> Salt<'a> {
         let length = input.as_bytes().len();
 
         if length < Self::MIN_LENGTH {
-            return Err(Error::SaltInvalid(InvalidValue::ToShort));
+            return Err(Error::SaltInvalid(InvalidValue::TooShort));
         }
 
         if length > Self::MAX_LENGTH {
-            return Err(Error::SaltInvalid(InvalidValue::ToLong));
+            return Err(Error::SaltInvalid(InvalidValue::TooLong));
         }
 
         input.try_into().map(Self).map_err(|e| match e {
@@ -200,7 +200,7 @@ impl SaltString {
                 length: length as u8,
             })
         } else {
-            Err(Error::SaltInvalid(InvalidValue::ToLong))
+            Err(Error::SaltInvalid(InvalidValue::TooLong))
         }
     }
 
@@ -281,7 +281,7 @@ mod tests {
     fn reject_new_too_short() {
         for &too_short in &["", "a", "ab", "abc"] {
             let err = Salt::new(too_short).err().unwrap();
-            assert_eq!(err, Error::SaltInvalid(InvalidValue::ToShort));
+            assert_eq!(err, Error::SaltInvalid(InvalidValue::TooShort));
         }
     }
 
@@ -289,7 +289,7 @@ mod tests {
     fn reject_new_too_long() {
         let s = "01234567891123456789212345678931234567894123456785234567896234567";
         let err = Salt::new(s).err().unwrap();
-        assert_eq!(err, Error::SaltInvalid(InvalidValue::ToLong));
+        assert_eq!(err, Error::SaltInvalid(InvalidValue::TooLong));
     }
 
     #[test]

--- a/password-hash/src/value.rs
+++ b/password-hash/src/value.rs
@@ -43,15 +43,15 @@ pub struct Value<'a>(&'a str);
 impl<'a> Value<'a> {
     /// Maximum length of an [`Value`] - 64 ASCII characters (i.e. 64-bytes).
     ///
-    /// This value is selected to match the maximum length of a [`Salt`], as this
-    /// library internally uses this type to represent salts.
+    /// This value is selected to match the maximum length of a [`Salt`][`crate::Salt`]
+    /// as this library internally uses this type to represent salts.
     pub const MAX_LENGTH: usize = 64;
 
     /// Parse a [`Value`] from the provided `str`, validating it according to
     /// the PHC string format's rules.
     pub fn new(input: &'a str) -> Result<Self> {
         if input.as_bytes().len() > Self::MAX_LENGTH {
-            return Err(Error::ParamValueInvalid(InvalidValue::ToLong));
+            return Err(Error::ParamValueInvalid(InvalidValue::TooLong));
         }
 
         // Check that the characters are permitted in a PHC parameter value.
@@ -294,12 +294,12 @@ mod tests {
     #[test]
     fn reject_too_long() {
         let err = Value::new(INVALID_TOO_LONG).err().unwrap();
-        assert_eq!(err, Error::ParamValueInvalid(InvalidValue::ToLong));
+        assert_eq!(err, Error::ParamValueInvalid(InvalidValue::TooLong));
     }
 
     #[test]
     fn reject_invalid_char_and_too_long() {
         let err = Value::new(INVALID_CHAR_AND_TOO_LONG).err().unwrap();
-        assert_eq!(err, Error::ParamValueInvalid(InvalidValue::ToLong));
+        assert_eq!(err, Error::ParamValueInvalid(InvalidValue::TooLong));
     }
 }


### PR DESCRIPTION
- Make `errors` module public, allowing access to `InvalidValue`
- Add rustdoc documentation for `InvalidValue`
- Don't re-export `B64Error` at the toplevel now that `errors` is pub
- Fix a few typos