### PR TITLE
password-hash: `error::InvalidValue` improvements

### DIFF
--- a/password-hash/src/errors.rs
+++ b/password-hash/src/errors.rs
@@ -98,31 +98,30 @@ impl From<base64ct::InvalidLengthError> for Error {
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum InvalidValue {
+    /// Character is not in the allowed set.
+    InvalidChar(char),
+
+    /// Format is invalid.
+    InvalidFormat,
+
+    /// Value is malformed.
+    Malformed,
+
     /// Value exceeds the maximum allowed length.
     TooLong,
 
     /// Value does not satisfy the minimum length.
     TooShort,
-
-    /// Unspecified error.
-    // TODO(tarcieri): specify all error cases
-    NotProvided,
-
-    /// Character is not in the allowed set.
-    InvalidChar,
-
-    /// Format is invalid.
-    InvalidFormat,
 }
 
 impl fmt::Display for InvalidValue {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> core::result::Result<(), fmt::Error> {
         match self {
+            Self::InvalidChar(c) => write!(f, "contains invalid character: '{}'", c),
+            Self::InvalidFormat => f.write_str("value format is invalid"),
+            Self::Malformed => f.write_str("value malformed"),
             Self::TooLong => f.write_str("value to long"),
             Self::TooShort => f.write_str("value to short"),
-            Self::NotProvided => f.write_str("required value not provided"),
-            Self::InvalidChar => f.write_str("contains invalid character"),
-            Self::InvalidFormat => f.write_str("value format is invalid"),
         }
     }
 }

--- a/password-hash/src/params.rs
+++ b/password-hash/src/params.rs
@@ -165,11 +165,11 @@ impl FromStr for ParamsString {
             // Validate value
             param
                 .next()
-                .ok_or(Error::ParamValueInvalid(InvalidValue::NotProvided))
+                .ok_or(Error::ParamValueInvalid(InvalidValue::Malformed))
                 .and_then(Value::try_from)?;
 
             if param.next().is_some() {
-                return Err(Error::ParamValueInvalid(InvalidValue::NotProvided));
+                return Err(Error::ParamValueInvalid(InvalidValue::Malformed));
             }
         }
 

--- a/password-hash/src/salt.rs
+++ b/password-hash/src/salt.rs
@@ -296,6 +296,6 @@ mod tests {
     fn reject_new_invalid_char() {
         let s = "01234_abcd";
         let err = Salt::new(s).err().unwrap();
-        assert_eq!(err, Error::SaltInvalid(InvalidValue::InvalidChar));
+        assert_eq!(err, Error::SaltInvalid(InvalidValue::InvalidChar('_')));
     }
 }

--- a/password-hash/src/value.rs
+++ b/password-hash/src/value.rs
@@ -125,13 +125,13 @@ impl<'a> Value<'a> {
 
         // Empty strings aren't decimals
         if value.is_empty() {
-            return Err(Error::ParamValueInvalid(InvalidValue::NotProvided));
+            return Err(Error::ParamValueInvalid(InvalidValue::Malformed));
         }
 
         // Ensure all characters are digits
         for c in value.chars() {
             if !matches!(c, '0'..='9') {
-                return Err(Error::ParamValueInvalid(InvalidValue::InvalidChar));
+                return Err(Error::ParamValueInvalid(InvalidValue::InvalidChar(c)));
             }
         }
 
@@ -194,7 +194,7 @@ impl<'a> fmt::Display for Value<'a> {
 fn assert_valid_value(input: &str) -> Result<()> {
     for c in input.chars() {
         if !is_char_valid(c) {
-            return Err(Error::ParamValueInvalid(InvalidValue::InvalidChar));
+            return Err(Error::ParamValueInvalid(InvalidValue::InvalidChar(c)));
         }
     }
 
@@ -256,7 +256,7 @@ mod tests {
         let err = u32::try_from(value).err().unwrap();
         assert!(matches!(
             err,
-            Error::ParamValueInvalid(InvalidValue::InvalidChar)
+            Error::ParamValueInvalid(InvalidValue::InvalidChar(_))
         ));
     }
 
@@ -287,7 +287,7 @@ mod tests {
         let err = Value::new(INVALID_CHAR).err().unwrap();
         assert!(matches!(
             err,
-            Error::ParamValueInvalid(InvalidValue::InvalidChar)
+            Error::ParamValueInvalid(InvalidValue::InvalidChar(_))
         ));
     }
 


### PR DESCRIPTION
- Rename `NotProvided` variant to `Malformed`
- Have `InvalidChar` include the character which was considered invalid