### PR TITLE
password-hash: add helper methods to `InvalidValue`

### DIFF
--- a/password-hash/src/errors.rs
+++ b/password-hash/src/errors.rs
@@ -114,6 +114,18 @@ pub enum InvalidValue {
     TooShort,
 }
 
+impl InvalidValue {
+    /// Create an [`Error::ParamValueInvalid`] which warps this error.
+    pub fn param_error(self) -> Error {
+        Error::ParamValueInvalid(self)
+    }
+
+    /// Create an [`Error::SaltInvalid`] which wraps this error.
+    pub fn salt_error(self) -> Error {
+        Error::SaltInvalid(self)
+    }
+}
+
 impl fmt::Display for InvalidValue {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> core::result::Result<(), fmt::Error> {
         match self {


### PR DESCRIPTION
Simplifies constructing an appropriate `password_hash::Error` from an `InvalidValue` enum.