### PR TITLE
password-hash: add `version` param to `PasswordHasher`

### DIFF
--- a/password-hash/src/traits.rs
+++ b/password-hash/src/traits.rs
@@ -1,6 +1,6 @@
 //! Trait definitions.
 
-use crate::{Error, Ident, ParamsString, PasswordHash, Result, Salt};
+use crate::{Decimal, Error, Ident, ParamsString, PasswordHash, Result, Salt};
 use core::{
     convert::{TryFrom, TryInto},
     fmt::Debug,
@@ -26,6 +26,7 @@ pub trait PasswordHasher {
         self.hash_password(
             password,
             None,
+            None,
             Self::Params::default(),
             Salt::try_from(salt.as_ref())?,
         )
@@ -38,6 +39,7 @@ pub trait PasswordHasher {
         &self,
         password: &[u8],
         algorithm: Option<Ident<'a>>,
+        version: Option<Decimal>,
         params: Self::Params,
         salt: impl Into<Salt<'a>>,
     ) -> Result<PasswordHash<'a>>;
@@ -63,6 +65,7 @@ impl<T: PasswordHasher> PasswordVerifier for T {
             let computed_hash = self.hash_password(
                 password,
                 Some(hash.algorithm),
+                hash.version,
                 T::Params::try_from(&hash)?,
                 *salt,
             )?;

--- a/password-hash/tests/hashing.rs
+++ b/password-hash/tests/hashing.rs
@@ -17,6 +17,7 @@ impl PasswordHasher for StubPasswordHasher {
         &self,
         password: &[u8],
         algorithm: Option<Ident<'a>>,
+        version: Option<Decimal>,
         params: StubParams,
         salt: impl Into<Salt<'a>>,
     ) -> Result<PasswordHash<'a>> {
@@ -37,7 +38,7 @@ impl PasswordHasher for StubPasswordHasher {
 
         Ok(PasswordHash {
             algorithm: ALG,
-            version: None,
+            version,
             params: params.try_into()?,
             salt: Some(salt),
             hash: Some(hash),


### PR DESCRIPTION
This makes the `hash_password` method reflect all of the potential parameters to a `PasswordHash`.