### PR TITLE
password-hash: refactor `PasswordHasher`

### DIFF
--- a/password-hash/src/lib.rs
+++ b/password-hash/src/lib.rs
@@ -227,7 +227,7 @@ impl<'a> PasswordHash<'a> {
         password: impl AsRef<[u8]>,
         salt: &'a str,
     ) -> Result<Self> {
-        phf.hash_password_simple(password.as_ref(), salt)
+        phf.hash_password(password.as_ref(), salt)
     }
 
     /// Verify this password hash using the specified set of supported

--- a/password-hash/tests/hashing.rs
+++ b/password-hash/tests/hashing.rs
@@ -13,7 +13,7 @@ pub struct StubPasswordHasher;
 impl PasswordHasher for StubPasswordHasher {
     type Params = StubParams;
 
-    fn hash_password<'a>(
+    fn hash_password_customized<'a>(
         &self,
         password: &[u8],
         algorithm: Option<Ident<'a>>,


### PR DESCRIPTION
- Renames `hash_password` => `hash_password_customized`
- Renames `hash_password_simple` => `hash_password`
- Adds a `version` param to `hash_password_customized`

A main goal of this commit is to make the method with the shortest name the recommended a simplest to use.