### PR TITLE
password-hash v0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -325,7 +325,7 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "password-hash"
-version = "0.3.0-pre.1"
+version = "0.3.0"
 dependencies = [
  "base64ct",
  "rand_core",

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -19,7 +19,7 @@ cipher = { version = "0.3", optional = true }
 digest = { version = "0.9", optional = true }
 elliptic-curve = { version = "0.10", optional = true, path = "../elliptic-curve" }
 mac = { version = "0.11", package = "crypto-mac", optional = true }
-password-hash = { version = "=0.3.0-pre.1", optional = true, path = "../password-hash" }
+password-hash = { version = "0.3", optional = true, path = "../password-hash" }
 signature = { version = "1.3.0", optional = true, default-features = false, path = "../signature" }
 universal-hash = { version = "0.4", optional = true, path = "../universal-hash" }
 

--- a/password-hash/CHANGELOG.md
+++ b/password-hash/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.3.0 (2021-08-27)
+### Added
+- More details to `ParamValueInvalid` ([#713])
+- `SaltInvalid` error ([#713])
+- `version` param to `PasswordHasher` ([#719])
+- `ParamsString::add_b64_bytes` method ([#722])
+
+### Changed
+- Rename `PasswordHash::hash_password_simple` => `PasswordHash::hash_password` ([#720])
+- Rename `PasswordHash::hash_password` => `PasswordHash::hash_password_customized` ([#720])
+- Rename `Error::B64` => `Error::B64Encoding` ([#721])
+
+[#713]: https://github.com/RustCrypto/traits/pull/713
+[#719]: https://github.com/RustCrypto/traits/pull/719
+[#720]: https://github.com/RustCrypto/traits/pull/720
+[#721]: https://github.com/RustCrypto/traits/pull/721
+[#722]: https://github.com/RustCrypto/traits/pull/722
+
 ## 0.2.3 (2021-08-23)
 ### Changed
 - Make max lengths of `Value` and `Salt` both 64 ([#707])

--- a/password-hash/Cargo.toml
+++ b/password-hash/Cargo.toml
@@ -5,7 +5,7 @@ Traits which describe the functionality of password hashing algorithms,
 as well as a `no_std`-friendly implementation of the PHC string format
 (a well-defined subset of the Modular Crypt Format a.k.a. MCF)
 """
-version = "0.3.0-pre.1" # Also update html_root_url in lib.rs when bumping this
+version = "0.3.0" # Also update html_root_url in lib.rs when bumping this
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/password-hash/src/lib.rs
+++ b/password-hash/src/lib.rs
@@ -39,7 +39,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
-    html_root_url = "https://docs.rs/password-hash/0.3.0-pre.1"
+    html_root_url = "https://docs.rs/password-hash/0.3.0"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]


### PR DESCRIPTION
### Added
- More details to `ParamValueInvalid` ([#713])
- `SaltInvalid` error ([#713])
- `version` param to `PasswordHasher` ([#719])
- `ParamsString::add_b64_bytes` method ([#722])

### Changed
- Rename `PasswordHash::hash_password_simple` => `PasswordHash::hash_password` ([#720])
- Rename `PasswordHash::hash_password` => `PasswordHash::hash_password_customized` ([#720])
- Rename `Error::B64` => `Error::B64Encoding` ([#721])

[#713]: https://github.com/RustCrypto/traits/pull/713
[#719]: https://github.com/RustCrypto/traits/pull/719
[#720]: https://github.com/RustCrypto/traits/pull/720
[#721]: https://github.com/RustCrypto/traits/pull/721
[#722]: https://github.com/RustCrypto/traits/pull/722