### PR TITLE
aead v0.4.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "aead"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "blobby",
  "generic-array",

--- a/aead/CHANGELOG.md
+++ b/aead/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.3 (2021-08-29)
+### Added
+- `Result` type alias ([#725])
+
+[#725]: https://github.com/RustCrypto/traits/pull/725
+
 ## 0.4.2 (2021-07-12)
 ### Added
 - Re-export `rand_core` ([#682])

--- a/aead/Cargo.toml
+++ b/aead/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aead"
-version = "0.4.2" # Also update html_root_url in lib.rs when bumping this
+version = "0.4.3" # Also update html_root_url in lib.rs when bumping this
 description = """
 Traits for Authenticated Encryption with Associated Data (AEAD) algorithms,
 such as AES-GCM as ChaCha20Poly1305, which provide a high-level API

--- a/aead/src/lib.rs
+++ b/aead/src/lib.rs
@@ -19,7 +19,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
-    html_root_url = "https://docs.rs/aead/0.4.2"
+    html_root_url = "https://docs.rs/aead/0.4.3"
 )]
 #![warn(missing_docs, rust_2018_idioms)]
 


### PR DESCRIPTION
### Added
- `Result` type alias ([#725])

[#725]: https://github.com/RustCrypto/traits/pull/725