### PR TITLE
elliptic-curve: bump `ff` + `group` to v0.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -215,7 +215,7 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.10.6"
+version = "0.11.0-pre"
 dependencies = [
  "base64ct",
  "crypto-bigint",
@@ -233,9 +233,9 @@ dependencies = [
 
 [[package]]
 name = "ff"
-version = "0.10.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0f40b2dcd8bc322217a5f6559ae5f9e9d1de202a2ecee2e9eafcbece7562a4f"
+checksum = "b2958d04124b9f27f175eaeb9a9f383d026098aa837eadd8ba22c11f13a05b9e"
 dependencies = [
  "bitvec",
  "rand_core",
@@ -271,9 +271,9 @@ dependencies = [
 
 [[package]]
 name = "group"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c363a5301b8f153d80747126a04b3c82073b9fe3130571a9d170cacdeaf7912"
+checksum = "bc5ac374b108929de78460075f3dc439fa66df9d8fc77e8f12caa5165fcf0c89"
 dependencies = [
  "ff",
  "rand_core",

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -17,7 +17,7 @@ edition = "2018"
 aead = { version = "0.4", optional = true, path = "../aead" }
 cipher = { version = "0.3", optional = true }
 digest = { version = "0.9", optional = true }
-elliptic-curve = { version = "0.10", optional = true, path = "../elliptic-curve" }
+elliptic-curve = { version = "=0.11.0-pre", optional = true, path = "../elliptic-curve" }
 mac = { version = "0.11", package = "crypto-mac", optional = true }
 password-hash = { version = "0.3", optional = true, path = "../password-hash" }
 signature = { version = "1.3.0", optional = true, default-features = false, path = "../signature" }

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -5,7 +5,7 @@ General purpose Elliptic Curve Cryptography (ECC) support, including types
 and traits for representing various elliptic curve forms, scalars, points,
 and public/secret keys composed thereof.
 """
-version    = "0.10.6" # Also update html_root_url in lib.rs when bumping this
+version    = "0.11.0-pre" # Also update html_root_url in lib.rs when bumping this
 authors    = ["RustCrypto Developers"]
 license    = "Apache-2.0 OR MIT"
 repository = "https://github.com/RustCrypto/traits/tree/master/elliptic-curve"
@@ -22,8 +22,8 @@ subtle = { version = "=2.4", default-features = false }
 
 # optional dependencies
 base64ct = { version = "1", optional = true, default-features = false }
-ff = { version = "0.10", optional = true, default-features = false }
-group = { version = "0.10", optional = true, default-features = false }
+ff = { version = "0.11", optional = true, default-features = false }
+group = { version = "0.11", optional = true, default-features = false }
 hex-literal = { version = "0.3", optional = true }
 pkcs8 = { version = "0.7", optional = true }
 serde = { version = "1", optional = true, default-features = false }

--- a/elliptic-curve/src/arithmetic.rs
+++ b/elliptic-curve/src/arithmetic.rs
@@ -25,14 +25,15 @@ pub trait AffineArithmetic: Curve + ScalarArithmetic {
 pub trait ProjectiveArithmetic: Curve + AffineArithmetic {
     /// Elliptic curve point in projective coordinates.
     ///
-    /// Note: the following bounds are enforced by [`group::Group`]:
-    /// - `Copy`
-    /// - `Clone`
-    /// - `Debug`
-    /// - `Eq`
-    /// - `Sized`
-    /// - `Send`
-    /// - `Sync`
+    /// Note: the following bounds are provided by [`group::Group`]:
+    /// - `'static`
+    /// - [`Copy`]
+    /// - [`Clone`]
+    /// - [`Debug`]
+    /// - [`Eq`]
+    /// - [`Sized`]
+    /// - [`Send`]
+    /// - [`Sync`]
     type ProjectivePoint: ConditionallySelectable
         + ConstantTimeEq
         + Default
@@ -48,13 +49,15 @@ pub trait ProjectiveArithmetic: Curve + AffineArithmetic {
 pub trait ScalarArithmetic: Curve {
     /// Scalar field type.
     ///
-    /// Note: the following bounds are enforced by [`ff::Field`]:
-    /// - `Copy`
-    /// - `Clone`
-    /// - `ConditionallySelectable`
-    /// - `Debug`
-    /// - `Default`
-    /// - `Send`
-    /// - `Sync`
-    type Scalar: ConstantTimeEq + ff::Field + ff::PrimeField<Repr = FieldBytes<Self>>;
+    /// Note: the following bounds are provided by [`ff::Field`]:
+    /// - `'static`
+    /// - [`Copy`]
+    /// - [`Clone`]
+    /// - [`ConditionallySelectable`]
+    /// - [`ConstantTimeEq`]
+    /// - [`Debug`]
+    /// - [`Default`]
+    /// - [`Send`]
+    /// - [`Sync`]
+    type Scalar: ff::Field + ff::PrimeField<Repr = FieldBytes<Self>>;
 }

--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -16,7 +16,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
-    html_root_url = "https://docs.rs/elliptic-curve/0.10.6"
+    html_root_url = "https://docs.rs/elliptic-curve/0.11.0-pre"
 )]
 
 #[cfg(feature = "alloc")]

--- a/elliptic-curve/src/scalar/bytes.rs
+++ b/elliptic-curve/src/scalar/bytes.rs
@@ -70,7 +70,7 @@ where
     where
         C: ProjectiveArithmetic,
     {
-        Scalar::<C>::from_repr(self.inner).expect("ScalarBytes order invariant violated")
+        Scalar::<C>::from_repr(self.inner).unwrap()
     }
 
     /// Borrow the inner [`FieldBytes`]
@@ -206,7 +206,7 @@ where
     type Error = Error;
 
     fn try_from(bytes: ScalarBytes<C>) -> Result<NonZeroScalar<C>> {
-        NonZeroScalar::<C>::from_repr(bytes.inner).ok_or(Error)
+        Option::from(NonZeroScalar::<C>::from_repr(bytes.inner)).ok_or(Error)
     }
 }
 


### PR DESCRIPTION
Release notes:

- `ff`: https://github.com/zkcrypto/ff/blob/main/CHANGELOG.md#0110---2021-09-02
- `group`: https://github.com/zkcrypto/group/blob/main/CHANGELOG.md#0110---2021-09-02