### PR TITLE
elliptic-curve: bump `crypto-bigint` to v0.2.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,9 +146,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-bigint"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc209804a22c34a98fe26a32d997ac64d4284816f65cf1a529c4e31a256218a0"
+checksum = "8658c15c5d921ddf980f7fe25b1e82f4b7a4083b2c4985fea4922edb8e43e07d"
 dependencies = [
  "generic-array",
  "rand_core",

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["cryptography", "no-std"]
 keywords   = ["crypto", "ecc", "elliptic", "weierstrass"]
 
 [dependencies]
-crypto-bigint = { version = "0.2.4", features = ["generic-array"] }
+crypto-bigint = { version = "0.2.5", features = ["generic-array"] }
 generic-array = { version = "0.14", default-features = false }
 rand_core = { version = "0.6", default-features = false }
 subtle = { version = "=2.4", default-features = false }

--- a/elliptic-curve/src/dev.rs
+++ b/elliptic-curve/src/dev.rs
@@ -658,3 +658,17 @@ impl Neg for ProjectivePoint {
         unimplemented!();
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::Scalar;
+    use ff::PrimeField;
+    use hex_literal::hex;
+
+    #[test]
+    fn round_trip() {
+        let bytes = hex!("c9afa9d845ba75166b5c215767b1d6934e50c3db36e89b127b8a622b120f6721");
+        let scalar = Scalar::from_repr(bytes.into()).unwrap();
+        assert_eq!(&bytes, scalar.to_repr().as_slice());
+    }
+}

--- a/elliptic-curve/src/scalar/non_zero.rs
+++ b/elliptic-curve/src/scalar/non_zero.rs
@@ -36,7 +36,7 @@ impl<C> NonZeroScalar<C>
 where
     C: Curve + ProjectiveArithmetic,
 {
-    /// Generate a random `NonZeroScalar`
+    /// Generate a random `NonZeroScalar`.
     pub fn random(mut rng: impl CryptoRng + RngCore) -> Self {
         // Use rejection sampling to eliminate zero values.
         // While this method isn't constant-time, the attacker shouldn't learn
@@ -48,14 +48,14 @@ where
         }
     }
 
-    /// Decode a [`NonZeroScalar`] from a serialized field element
-    pub fn from_repr(repr: FieldBytes<C>) -> CtOption<Self> {
-        Scalar::<C>::from_repr(repr).and_then(Self::new)
-    }
-
     /// Create a [`NonZeroScalar`] from a scalar.
     pub fn new(scalar: Scalar<C>) -> CtOption<Self> {
         CtOption::new(Self { scalar }, !scalar.is_zero())
+    }
+
+    /// Decode a [`NonZeroScalar`] from a big endian-serialized field element.
+    pub fn from_repr(repr: FieldBytes<C>) -> CtOption<Self> {
+        Scalar::<C>::from_repr(repr).and_then(Self::new)
     }
 }
 
@@ -181,5 +181,19 @@ where
 {
     fn zeroize(&mut self) {
         self.scalar.zeroize();
+    }
+}
+
+#[cfg(all(test, feature = "dev"))]
+mod tests {
+    use crate::dev::NonZeroScalar;
+    use ff::PrimeField;
+    use hex_literal::hex;
+
+    #[test]
+    fn round_trip() {
+        let bytes = hex!("c9afa9d845ba75166b5c215767b1d6934e50c3db36e89b127b8a622b120f6721");
+        let scalar = NonZeroScalar::from_repr(bytes.into()).unwrap();
+        assert_eq!(&bytes, scalar.to_repr().as_slice());
     }
 }


### PR DESCRIPTION
Also adds smoke tests that `NonZeroScalar` and `dev::Scalar` round trip successfully to their reprs.