### PR TITLE
Defined the SignerMut trait

### DIFF
--- a/signature/CHANGELOG.md
+++ b/signature/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Re-export `rand_core`. Emit compilation error if unstable functionality
 is enabled by bypassing the preview features. ([#683])
+- Defined the `StatefulSigner` trait
 
 [#683]: https://github.com/RustCrypto/traits/pull/683
 

--- a/signature/CHANGELOG.md
+++ b/signature/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Re-export `rand_core`. Emit compilation error if unstable functionality
 is enabled by bypassing the preview features. ([#683])
-- Defined the `StatefulSigner` trait
+- Defined the `SignerMut` trait
 
 [#683]: https://github.com/RustCrypto/traits/pull/683
 

--- a/signature/src/signer.rs
+++ b/signature/src/signer.rs
@@ -40,6 +40,17 @@ pub trait SignerMut<S: Signature> {
     fn try_sign(&mut self, msg: &[u8]) -> Result<S, Error>;
 }
 
+// Blanket impl of SignerMut for all Signer types
+impl<T, S> SignerMut<S> for T
+where
+    T: Signer<S>,
+    S: Signature,
+{
+    fn try_sign(&mut self, msg: &[u8]) -> Result<S, Error> {
+        T::try_sign(&self, msg)
+    }
+}
+
 /// Sign the given prehashed message [`Digest`] using `Self`.
 ///
 /// ## Notes

--- a/signature/src/signer.rs
+++ b/signature/src/signer.rs
@@ -24,6 +24,22 @@ pub trait Signer<S: Signature> {
     fn try_sign(&self, msg: &[u8]) -> Result<S, Error>;
 }
 
+/// Sign the provided message bytestring using `&mut Self` (e.g., an evolving
+/// cryptographic key), returning a digital signature.
+pub trait StatefulSigner<S: Signature> {
+    /// Sign the given message, update the state, and return a digital signature
+    fn sign(&mut self, msg: &[u8]) -> S {
+        self.try_sign(msg).expect("signature operation failed")
+    }
+
+    /// Attempt to sign the given message, updating the state, and returning a
+    /// digital signature on success, or an error if something went wrong.
+    ///
+    /// Signing can fail, e.g., if the number of time periods allowed by the
+    /// current key is exceeded.
+    fn try_sign(&mut self, msg: &[u8]) -> Result<S, Error>;
+}
+
 /// Sign the given prehashed message [`Digest`] using `Self`.
 ///
 /// ## Notes

--- a/signature/src/signer.rs
+++ b/signature/src/signer.rs
@@ -26,7 +26,7 @@ pub trait Signer<S: Signature> {
 
 /// Sign the provided message bytestring using `&mut Self` (e.g., an evolving
 /// cryptographic key), returning a digital signature.
-pub trait StatefulSigner<S: Signature> {
+pub trait SignerMut<S: Signature> {
     /// Sign the given message, update the state, and return a digital signature
     fn sign(&mut self, msg: &[u8]) -> S {
         self.try_sign(msg).expect("signature operation failed")


### PR DESCRIPTION
As per our discussion on the RCIG Zulip, there seems to be a need for a stateful version of the `Signer` trait. This lets us support "Key Evolving Signature Schemes" such as [XMSS](https://eprint.iacr.org/2011/484).

One thing that is unclear so far is whether we also want to do stateful versions of `DigestSigner`, `RandomizedSigner`, and `AsyncSigner`. I think the latter two won't be an issue for now, since XMSS is a deterministic scheme, and HSMs do not support XMSS.