### PR TITLE
elliptic-curve: refactor `PrimeCurve` crate

### DIFF
--- a/elliptic-curve/src/dev.rs
+++ b/elliptic-curve/src/dev.rs
@@ -7,9 +7,9 @@ use crate::{
     rand_core::RngCore,
     sec1::{FromEncodedPoint, ToEncodedPoint},
     subtle::{Choice, ConditionallySelectable, ConstantTimeEq, ConstantTimeLess, CtOption},
-    weierstrass,
     zeroize::Zeroize,
-    AffineArithmetic, AlgorithmParameters, Curve, ProjectiveArithmetic, ScalarArithmetic,
+    AffineArithmetic, AlgorithmParameters, Curve, PrimeCurve, ProjectiveArithmetic,
+    ScalarArithmetic,
 };
 use core::{
     convert::TryFrom,
@@ -44,7 +44,7 @@ impl Curve for MockCurve {
         U256::from_be_hex("ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551");
 }
 
-impl weierstrass::Curve for MockCurve {}
+impl PrimeCurve for MockCurve {}
 
 impl AffineArithmetic for MockCurve {
     type AffinePoint = AffinePoint;

--- a/elliptic-curve/src/ecdh.rs
+++ b/elliptic-curve/src/ecdh.rs
@@ -27,8 +27,8 @@
 //! [SIGMA]: https://webee.technion.ac.il/~hugo/sigma-pdf.pdf
 
 use crate::{
-    weierstrass::Curve, AffinePoint, FieldBytes, NonZeroScalar, ProjectiveArithmetic,
-    ProjectivePoint, PublicKey, Scalar,
+    AffinePoint, Curve, FieldBytes, NonZeroScalar, ProjectiveArithmetic, ProjectivePoint,
+    PublicKey, Scalar,
 };
 use core::borrow::Borrow;
 use group::Curve as _;

--- a/elliptic-curve/src/jwk.rs
+++ b/elliptic-curve/src/jwk.rs
@@ -8,8 +8,7 @@ use crate::{
         Coordinates, EncodedPoint, UncompressedPointSize, UntaggedPointSize, ValidatePublicKey,
     },
     secret_key::SecretKey,
-    weierstrass::Curve,
-    Error, FieldBytes,
+    Curve, Error, FieldBytes, PrimeCurve,
 };
 use alloc::{
     borrow::ToOwned,
@@ -119,7 +118,7 @@ impl JwkEcKey {
     #[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
     pub fn to_public_key<C>(&self) -> Result<PublicKey<C>, Error>
     where
-        C: Curve + JwkParameters + ProjectiveArithmetic,
+        C: PrimeCurve + JwkParameters + ProjectiveArithmetic,
         AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
         UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
         UncompressedPointSize<C>: ArrayLength<u8>,
@@ -132,7 +131,7 @@ impl JwkEcKey {
     #[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
     pub fn to_secret_key<C>(&self) -> Result<SecretKey<C>, Error>
     where
-        C: Curve + JwkParameters + ValidatePublicKey,
+        C: PrimeCurve + JwkParameters + ValidatePublicKey,
         UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
         UncompressedPointSize<C>: ArrayLength<u8>,
     {
@@ -157,7 +156,7 @@ impl ToString for JwkEcKey {
 #[cfg_attr(docsrs, doc(cfg(feature = "jwk")))]
 impl<C> TryFrom<JwkEcKey> for EncodedPoint<C>
 where
-    C: Curve + JwkParameters,
+    C: PrimeCurve + JwkParameters,
     UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
     UncompressedPointSize<C>: ArrayLength<u8>,
 {
@@ -171,7 +170,7 @@ where
 #[cfg_attr(docsrs, doc(cfg(feature = "jwk")))]
 impl<C> TryFrom<&JwkEcKey> for EncodedPoint<C>
 where
-    C: Curve + JwkParameters,
+    C: PrimeCurve + JwkParameters,
     UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
     UncompressedPointSize<C>: ArrayLength<u8>,
 {
@@ -191,7 +190,7 @@ where
 #[cfg_attr(docsrs, doc(cfg(feature = "jwk")))]
 impl<C> TryFrom<EncodedPoint<C>> for JwkEcKey
 where
-    C: Curve + JwkParameters,
+    C: PrimeCurve + JwkParameters,
     UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
     UncompressedPointSize<C>: ArrayLength<u8>,
 {
@@ -205,7 +204,7 @@ where
 #[cfg_attr(docsrs, doc(cfg(feature = "jwk")))]
 impl<C> TryFrom<&EncodedPoint<C>> for JwkEcKey
 where
-    C: Curve + JwkParameters,
+    C: PrimeCurve + JwkParameters,
     UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
     UncompressedPointSize<C>: ArrayLength<u8>,
 {
@@ -227,7 +226,7 @@ where
 #[cfg_attr(docsrs, doc(cfg(feature = "jwk")))]
 impl<C> TryFrom<JwkEcKey> for SecretKey<C>
 where
-    C: Curve + JwkParameters + ValidatePublicKey,
+    C: PrimeCurve + JwkParameters + ValidatePublicKey,
     UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
     UncompressedPointSize<C>: ArrayLength<u8>,
 {
@@ -241,7 +240,7 @@ where
 #[cfg_attr(docsrs, doc(cfg(feature = "jwk")))]
 impl<C> TryFrom<&JwkEcKey> for SecretKey<C>
 where
-    C: Curve + JwkParameters + ValidatePublicKey,
+    C: PrimeCurve + JwkParameters + ValidatePublicKey,
     UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
     UncompressedPointSize<C>: ArrayLength<u8>,
 {
@@ -269,7 +268,7 @@ where
 #[cfg_attr(docsrs, doc(cfg(feature = "jwk")))]
 impl<C> From<SecretKey<C>> for JwkEcKey
 where
-    C: Curve + JwkParameters + ProjectiveArithmetic,
+    C: PrimeCurve + JwkParameters + ProjectiveArithmetic,
     AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
     Scalar<C>: Zeroize,
     UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
@@ -285,7 +284,7 @@ where
 #[cfg_attr(docsrs, doc(cfg(feature = "jwk")))]
 impl<C> From<&SecretKey<C>> for JwkEcKey
 where
-    C: Curve + JwkParameters + ProjectiveArithmetic,
+    C: PrimeCurve + JwkParameters + ProjectiveArithmetic,
     AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
     Scalar<C>: Zeroize,
     UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
@@ -305,7 +304,7 @@ where
 #[cfg_attr(docsrs, doc(cfg(feature = "jwk")))]
 impl<C> TryFrom<JwkEcKey> for PublicKey<C>
 where
-    C: Curve + JwkParameters + ProjectiveArithmetic,
+    C: PrimeCurve + JwkParameters + ProjectiveArithmetic,
     AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
     UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
     UncompressedPointSize<C>: ArrayLength<u8>,
@@ -322,7 +321,7 @@ where
 #[cfg_attr(docsrs, doc(cfg(feature = "jwk")))]
 impl<C> TryFrom<&JwkEcKey> for PublicKey<C>
 where
-    C: Curve + JwkParameters + ProjectiveArithmetic,
+    C: PrimeCurve + JwkParameters + ProjectiveArithmetic,
     AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
     UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
     UncompressedPointSize<C>: ArrayLength<u8>,
@@ -339,7 +338,7 @@ where
 #[cfg_attr(docsrs, doc(cfg(feature = "jwk")))]
 impl<C> From<PublicKey<C>> for JwkEcKey
 where
-    C: Curve + JwkParameters + ProjectiveArithmetic,
+    C: PrimeCurve + JwkParameters + ProjectiveArithmetic,
     AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
     UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
     UncompressedPointSize<C>: ArrayLength<u8>,
@@ -354,7 +353,7 @@ where
 #[cfg_attr(docsrs, doc(cfg(feature = "jwk")))]
 impl<C> From<&PublicKey<C>> for JwkEcKey
 where
-    C: Curve + JwkParameters + ProjectiveArithmetic,
+    C: PrimeCurve + JwkParameters + ProjectiveArithmetic,
     AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
     UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
     UncompressedPointSize<C>: ArrayLength<u8>,
@@ -631,7 +630,7 @@ impl Serialize for JwkEcKey {
 }
 
 /// Decode a Base64url-encoded field element
-fn decode_base64url_fe<C: Curve>(s: &str) -> Result<FieldBytes<C>, Error> {
+fn decode_base64url_fe<C: PrimeCurve>(s: &str) -> Result<FieldBytes<C>, Error> {
     let mut result = FieldBytes::<C>::default();
     Base64Url::decode(s, &mut result).map_err(|_| Error)?;
     Ok(result)

--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -33,9 +33,9 @@ pub use rand_core;
 
 pub mod ops;
 pub mod sec1;
-pub mod weierstrass;
 
 mod error;
+mod point;
 mod scalar;
 mod secret_key;
 
@@ -57,6 +57,7 @@ mod jwk;
 
 pub use crate::{
     error::{Error, Result},
+    point::{DecompactPoint, DecompressPoint, PointCompaction, PointCompression},
     scalar::ScalarCore,
     secret_key::SecretKey,
 };
@@ -125,6 +126,9 @@ pub trait Curve: 'static + Copy + Clone + Debug + Default + Eq + Ord + Send + Sy
     /// target CPU's word size), specified from least to most significant.
     const ORDER: Self::UInt;
 }
+
+/// Marker trait for elliptic curves with prime order.
+pub trait PrimeCurve: Curve {}
 
 /// Size of field elements of this elliptic curve.
 pub type FieldSize<C> = <<C as Curve>::UInt as bigint::ArrayEncoding>::ByteSize;

--- a/elliptic-curve/src/point.rs
+++ b/elliptic-curve/src/point.rs
@@ -1,10 +1,7 @@
-//! Elliptic curves in short Weierstrass form.
+//! Traits for elliptic curve points.
 
-use crate::FieldBytes;
+use crate::{Curve, FieldBytes};
 use subtle::{Choice, CtOption};
-
-/// Marker trait for elliptic curves in short Weierstrass form.
-pub trait Curve: super::Curve {}
 
 /// Point compression settings.
 pub trait PointCompression {
@@ -12,7 +9,7 @@ pub trait PointCompression {
     const COMPRESS_POINTS: bool;
 }
 
-/// Point compaction settings
+/// Point compaction settings.
 pub trait PointCompaction {
     /// Should point compaction be applied by default?
     const COMPACT_POINTS: bool;
@@ -25,7 +22,7 @@ pub trait DecompressPoint<C: Curve>: Sized {
     fn decompress(x: &FieldBytes<C>, y_is_odd: Choice) -> CtOption<Self>;
 }
 
-/// Attempt to decompact an elliptic curve point from an x-coordinate
+/// Attempt to decompact an elliptic curve point from an x-coordinate.
 pub trait DecompactPoint<C: Curve>: Sized {
     /// Attempt to decompact an elliptic curve point
     fn decompact(x: &FieldBytes<C>) -> CtOption<Self>;

--- a/elliptic-curve/src/public_key.rs
+++ b/elliptic-curve/src/public_key.rs
@@ -2,11 +2,12 @@
 
 use crate::{
     consts::U1,
+    point::PointCompression,
     sec1::{
         EncodedPoint, FromEncodedPoint, ToEncodedPoint, UncompressedPointSize, UntaggedPointSize,
     },
-    weierstrass::{Curve, PointCompression},
-    AffinePoint, Error, NonZeroScalar, ProjectiveArithmetic, ProjectivePoint, Result,
+    AffinePoint, Curve, Error, NonZeroScalar, PrimeCurve, ProjectiveArithmetic, ProjectivePoint,
+    Result,
 };
 use core::{
     cmp::Ordering,
@@ -98,6 +99,7 @@ where
     pub fn from_sec1_bytes(bytes: &[u8]) -> Result<Self>
     where
         Self: TryFrom<EncodedPoint<C>, Error = Error>,
+        C: PrimeCurve,
         UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
         UncompressedPointSize<C>: ArrayLength<u8>,
     {
@@ -123,7 +125,7 @@ where
     #[cfg_attr(docsrs, doc(cfg(feature = "jwk")))]
     pub fn from_jwk(jwk: &JwkEcKey) -> Result<Self>
     where
-        C: JwkParameters,
+        C: PrimeCurve + JwkParameters,
         AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
         UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
         UncompressedPointSize<C>: ArrayLength<u8>,
@@ -136,7 +138,7 @@ where
     #[cfg_attr(docsrs, doc(cfg(feature = "jwk")))]
     pub fn from_jwk_str(jwk: &str) -> Result<Self>
     where
-        C: JwkParameters,
+        C: PrimeCurve + JwkParameters,
         AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
         UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
         UncompressedPointSize<C>: ArrayLength<u8>,
@@ -149,7 +151,7 @@ where
     #[cfg_attr(docsrs, doc(cfg(feature = "jwk")))]
     pub fn to_jwk(&self) -> JwkEcKey
     where
-        C: JwkParameters,
+        C: PrimeCurve + JwkParameters,
         AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
         UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
         UncompressedPointSize<C>: ArrayLength<u8>,
@@ -162,7 +164,7 @@ where
     #[cfg_attr(docsrs, doc(cfg(feature = "jwk")))]
     pub fn to_jwk_string(&self) -> String
     where
-        C: JwkParameters,
+        C: PrimeCurve + JwkParameters,
         AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
         UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
         UncompressedPointSize<C>: ArrayLength<u8>,
@@ -184,7 +186,7 @@ impl<C> Copy for PublicKey<C> where C: Curve + ProjectiveArithmetic {}
 
 impl<C> TryFrom<EncodedPoint<C>> for PublicKey<C>
 where
-    C: Curve + ProjectiveArithmetic,
+    C: PrimeCurve + ProjectiveArithmetic,
     AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
     UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
     UncompressedPointSize<C>: ArrayLength<u8>,
@@ -198,7 +200,7 @@ where
 
 impl<C> TryFrom<&EncodedPoint<C>> for PublicKey<C>
 where
-    C: Curve + ProjectiveArithmetic,
+    C: PrimeCurve + ProjectiveArithmetic,
     AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
     UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
     UncompressedPointSize<C>: ArrayLength<u8>,
@@ -212,7 +214,7 @@ where
 
 impl<C> From<PublicKey<C>> for EncodedPoint<C>
 where
-    C: Curve + ProjectiveArithmetic + PointCompression,
+    C: PrimeCurve + ProjectiveArithmetic + PointCompression,
     AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
     UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
     UncompressedPointSize<C>: ArrayLength<u8>,
@@ -224,7 +226,7 @@ where
 
 impl<C> From<&PublicKey<C>> for EncodedPoint<C>
 where
-    C: Curve + ProjectiveArithmetic + PointCompression,
+    C: PrimeCurve + ProjectiveArithmetic + PointCompression,
     AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
     UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
     UncompressedPointSize<C>: ArrayLength<u8>,
@@ -236,7 +238,7 @@ where
 
 impl<C> FromEncodedPoint<C> for PublicKey<C>
 where
-    C: Curve + ProjectiveArithmetic,
+    C: PrimeCurve + ProjectiveArithmetic,
     AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
     UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
     UncompressedPointSize<C>: ArrayLength<u8>,
@@ -250,7 +252,7 @@ where
 
 impl<C> ToEncodedPoint<C> for PublicKey<C>
 where
-    C: Curve + ProjectiveArithmetic,
+    C: PrimeCurve + ProjectiveArithmetic,
     AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
     UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
     UncompressedPointSize<C>: ArrayLength<u8>,
@@ -264,7 +266,7 @@ where
 
 impl<C> Eq for PublicKey<C>
 where
-    C: Curve + ProjectiveArithmetic,
+    C: PrimeCurve + ProjectiveArithmetic,
     AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
     UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
     UncompressedPointSize<C>: ArrayLength<u8>,
@@ -273,7 +275,7 @@ where
 
 impl<C> PartialEq for PublicKey<C>
 where
-    C: Curve + ProjectiveArithmetic,
+    C: PrimeCurve + ProjectiveArithmetic,
     AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
     UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
     UncompressedPointSize<C>: ArrayLength<u8>,
@@ -285,7 +287,7 @@ where
 
 impl<C> PartialOrd for PublicKey<C>
 where
-    C: Curve + ProjectiveArithmetic,
+    C: PrimeCurve + ProjectiveArithmetic,
     AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
     UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
     UncompressedPointSize<C>: ArrayLength<u8>,
@@ -297,7 +299,7 @@ where
 
 impl<C> Ord for PublicKey<C>
 where
-    C: Curve + ProjectiveArithmetic,
+    C: PrimeCurve + ProjectiveArithmetic,
     AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
     UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
     UncompressedPointSize<C>: ArrayLength<u8>,
@@ -315,7 +317,7 @@ where
 impl<C> FromPublicKey for PublicKey<C>
 where
     Self: TryFrom<EncodedPoint<C>, Error = Error>,
-    C: Curve + AlgorithmParameters + ProjectiveArithmetic,
+    C: PrimeCurve + AlgorithmParameters + ProjectiveArithmetic,
     UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
     UncompressedPointSize<C>: ArrayLength<u8>,
 {
@@ -342,7 +344,7 @@ where
 #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
 impl<C> ToPublicKey for PublicKey<C>
 where
-    C: Curve + AlgorithmParameters + ProjectiveArithmetic,
+    C: PrimeCurve + AlgorithmParameters + ProjectiveArithmetic,
     AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
     UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
     UncompressedPointSize<C>: ArrayLength<u8>,
@@ -363,7 +365,7 @@ where
 impl<C> FromStr for PublicKey<C>
 where
     Self: TryFrom<EncodedPoint<C>, Error = Error>,
-    C: Curve + AlgorithmParameters + ProjectiveArithmetic,
+    C: PrimeCurve + AlgorithmParameters + ProjectiveArithmetic,
     UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
     UncompressedPointSize<C>: ArrayLength<u8>,
 {
@@ -378,7 +380,7 @@ where
 #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
 impl<C> ToString for PublicKey<C>
 where
-    C: Curve + AlgorithmParameters + ProjectiveArithmetic,
+    C: PrimeCurve + AlgorithmParameters + ProjectiveArithmetic,
     AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
     UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
     UncompressedPointSize<C>: ArrayLength<u8>,

--- a/elliptic-curve/src/scalar.rs
+++ b/elliptic-curve/src/scalar.rs
@@ -79,7 +79,7 @@ where
         Self::new(C::UInt::from_le_byte_array(bytes))
     }
 
-    /// Borrow the inner [`UInt`].
+    /// Borrow the inner `C::UInt`.
     pub fn as_uint(&self) -> &C::UInt {
         &self.inner
     }

--- a/elliptic-curve/src/secret_key.rs
+++ b/elliptic-curve/src/secret_key.rs
@@ -23,7 +23,7 @@ use zeroize::Zeroize;
 #[cfg(feature = "arithmetic")]
 use crate::{
     rand_core::{CryptoRng, RngCore},
-    weierstrass, NonZeroScalar, ProjectiveArithmetic, PublicKey, Scalar,
+    NonZeroScalar, ProjectiveArithmetic, PublicKey, Scalar,
 };
 
 #[cfg(feature = "jwk")]
@@ -38,7 +38,7 @@ use crate::{
 use {
     crate::{
         sec1::{FromEncodedPoint, ToEncodedPoint},
-        AffinePoint,
+        AffinePoint, PrimeCurve,
     },
     alloc::string::{String, ToString},
 };
@@ -149,7 +149,7 @@ where
     #[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
     pub fn public_key(&self) -> PublicKey<C>
     where
-        C: weierstrass::Curve + ProjectiveArithmetic,
+        C: Curve + ProjectiveArithmetic,
         Scalar<C>: Zeroize,
     {
         PublicKey::from_secret_scalar(&self.to_secret_scalar())
@@ -185,7 +185,7 @@ where
     #[cfg_attr(docsrs, doc(cfg(feature = "jwk")))]
     pub fn to_jwk(&self) -> JwkEcKey
     where
-        C: JwkParameters + ProjectiveArithmetic,
+        C: PrimeCurve + JwkParameters + ProjectiveArithmetic,
         AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
         Scalar<C>: Zeroize,
         UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
@@ -200,7 +200,7 @@ where
     #[cfg_attr(docsrs, doc(cfg(feature = "jwk")))]
     pub fn to_jwk_string(&self) -> String
     where
-        C: JwkParameters + ProjectiveArithmetic,
+        C: PrimeCurve + JwkParameters + ProjectiveArithmetic,
         AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
         Scalar<C>: Zeroize,
         UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,

--- a/elliptic-curve/src/secret_key/pkcs8.rs
+++ b/elliptic-curve/src/secret_key/pkcs8.rs
@@ -3,7 +3,7 @@
 use super::SecretKey;
 use crate::{
     sec1::{self, UncompressedPointSize, UntaggedPointSize, ValidatePublicKey},
-    weierstrass, AlgorithmParameters, ALGORITHM_OID,
+    AlgorithmParameters, Curve, ALGORITHM_OID,
 };
 use core::ops::Add;
 use generic_array::{typenum::U1, ArrayLength};
@@ -35,7 +35,7 @@ use {
 // Imports for actual PEM support
 #[cfg(feature = "pem")]
 use {
-    crate::{error::Error, Result},
+    crate::{error::Error, PrimeCurve, Result},
     core::str::FromStr,
 };
 
@@ -48,7 +48,7 @@ const PUBLIC_KEY_TAG: TagNumber = TagNumber::new(1);
 #[cfg_attr(docsrs, doc(cfg(feature = "pkcs8")))]
 impl<C> FromPrivateKey for SecretKey<C>
 where
-    C: weierstrass::Curve + AlgorithmParameters + ValidatePublicKey,
+    C: Curve + AlgorithmParameters + ValidatePublicKey,
     UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
     UncompressedPointSize<C>: ArrayLength<u8>,
 {
@@ -95,7 +95,7 @@ where
 #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
 impl<C> ToPrivateKey for SecretKey<C>
 where
-    C: weierstrass::Curve + AlgorithmParameters + ProjectiveArithmetic,
+    C: PrimeCurve + AlgorithmParameters + ProjectiveArithmetic,
     AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
     Scalar<C>: Zeroize,
     UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
@@ -131,7 +131,7 @@ where
 #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
 impl<C> FromStr for SecretKey<C>
 where
-    C: weierstrass::Curve + AlgorithmParameters + ValidatePublicKey,
+    C: PrimeCurve + AlgorithmParameters + ValidatePublicKey,
     UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
     UncompressedPointSize<C>: ArrayLength<u8>,
 {


### PR DESCRIPTION
Renames `weierstrass::Curve` to `PrimeCurve`, a marker trait for curves of prime order.

The `weierstrass` module is otherwise removed/renamed internally, with the traits previously contained re-exported from the toplevel.