### PR TITLE
elliptic-curve: mandatory `DefaultIsZeroes` bounds

### DIFF
--- a/elliptic-curve/src/arithmetic.rs
+++ b/elliptic-curve/src/arithmetic.rs
@@ -3,21 +3,23 @@
 use crate::{Curve, FieldBytes};
 use core::fmt::Debug;
 use subtle::{ConditionallySelectable, ConstantTimeEq};
+use zeroize::DefaultIsZeroes;
 
 /// Elliptic curve with affine arithmetic implementation.
 #[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
 pub trait AffineArithmetic: Curve + ScalarArithmetic {
     /// Elliptic curve point in affine coordinates.
-    type AffinePoint: Copy
+    type AffinePoint: 'static
+        + Copy
         + Clone
         + ConditionallySelectable
         + ConstantTimeEq
         + Debug
         + Default
+        + DefaultIsZeroes
         + Sized
         + Send
-        + Sync
-        + 'static;
+        + Sync;
 }
 
 /// Elliptic curve with projective arithmetic implementation.
@@ -37,6 +39,7 @@ pub trait ProjectiveArithmetic: Curve + AffineArithmetic {
     type ProjectivePoint: ConditionallySelectable
         + ConstantTimeEq
         + Default
+        + DefaultIsZeroes
         + From<Self::AffinePoint>
         + Into<Self::AffinePoint>
         + group::Curve<AffineRepr = Self::AffinePoint>
@@ -59,5 +62,5 @@ pub trait ScalarArithmetic: Curve {
     /// - [`Default`]
     /// - [`Send`]
     /// - [`Sync`]
-    type Scalar: ff::Field + ff::PrimeField<Repr = FieldBytes<Self>>;
+    type Scalar: DefaultIsZeroes + ff::Field + ff::PrimeField<Repr = FieldBytes<Self>>;
 }

--- a/elliptic-curve/src/dev.rs
+++ b/elliptic-curve/src/dev.rs
@@ -7,7 +7,7 @@ use crate::{
     rand_core::RngCore,
     sec1::{FromEncodedPoint, ToEncodedPoint},
     subtle::{Choice, ConditionallySelectable, ConstantTimeEq, ConstantTimeLess, CtOption},
-    zeroize::Zeroize,
+    zeroize::DefaultIsZeroes,
     AffineArithmetic, AlgorithmParameters, Curve, PrimeCurve, ProjectiveArithmetic,
     ScalarArithmetic,
 };
@@ -209,6 +209,8 @@ impl ConstantTimeEq for Scalar {
     }
 }
 
+impl DefaultIsZeroes for Scalar {}
+
 impl Add<Scalar> for Scalar {
     type Output = Scalar;
 
@@ -319,12 +321,6 @@ impl From<&Scalar> for FieldBytes {
     }
 }
 
-impl Zeroize for Scalar {
-    fn zeroize(&mut self) {
-        self.0.as_mut().zeroize();
-    }
-}
-
 /// Example affine point type
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum AffinePoint {
@@ -358,6 +354,8 @@ impl Default for AffinePoint {
         Self::Identity
     }
 }
+
+impl DefaultIsZeroes for AffinePoint {}
 
 impl FromEncodedPoint<MockCurve> for AffinePoint {
     fn from_encoded_point(point: &EncodedPoint) -> Option<Self> {
@@ -430,6 +428,8 @@ impl Default for ProjectivePoint {
         Self::Identity
     }
 }
+
+impl DefaultIsZeroes for ProjectivePoint {}
 
 impl From<AffinePoint> for ProjectivePoint {
     fn from(point: AffinePoint) -> ProjectivePoint {

--- a/elliptic-curve/src/ecdh.rs
+++ b/elliptic-curve/src/ecdh.rs
@@ -27,8 +27,7 @@
 //! [SIGMA]: https://webee.technion.ac.il/~hugo/sigma-pdf.pdf
 
 use crate::{
-    AffinePoint, Curve, FieldBytes, NonZeroScalar, ProjectiveArithmetic, ProjectivePoint,
-    PublicKey, Scalar,
+    AffinePoint, Curve, FieldBytes, NonZeroScalar, ProjectiveArithmetic, ProjectivePoint, PublicKey,
 };
 use core::borrow::Borrow;
 use group::Curve as _;
@@ -61,8 +60,6 @@ pub fn diffie_hellman<C>(
 ) -> SharedSecret<C>
 where
     C: Curve + ProjectiveArithmetic,
-    AffinePoint<C>: Zeroize,
-    Scalar<C>: Zeroize,
     SharedSecret<C>: for<'a> From<&'a AffinePoint<C>>,
 {
     let public_point = ProjectivePoint::<C>::from(*public_key.borrow());
@@ -96,7 +93,6 @@ where
 pub struct EphemeralSecret<C>
 where
     C: Curve + ProjectiveArithmetic,
-    Scalar<C>: Zeroize,
 {
     scalar: NonZeroScalar<C>,
 }
@@ -104,8 +100,6 @@ where
 impl<C> EphemeralSecret<C>
 where
     C: Curve + ProjectiveArithmetic,
-    AffinePoint<C>: Zeroize,
-    Scalar<C>: Zeroize,
     SharedSecret<C>: for<'a> From<&'a AffinePoint<C>>,
 {
     /// Generate a cryptographically random [`EphemeralSecret`].
@@ -132,8 +126,6 @@ where
 impl<C> From<&EphemeralSecret<C>> for PublicKey<C>
 where
     C: Curve + ProjectiveArithmetic,
-    AffinePoint<C>: Zeroize,
-    Scalar<C>: Zeroize,
     SharedSecret<C>: for<'a> From<&'a AffinePoint<C>>,
 {
     fn from(ephemeral_secret: &EphemeralSecret<C>) -> Self {
@@ -144,7 +136,6 @@ where
 impl<C> Zeroize for EphemeralSecret<C>
 where
     C: Curve + ProjectiveArithmetic,
-    Scalar<C>: Zeroize,
 {
     fn zeroize(&mut self) {
         self.scalar.zeroize()
@@ -154,7 +145,6 @@ where
 impl<C> Drop for EphemeralSecret<C>
 where
     C: Curve + ProjectiveArithmetic,
-    Scalar<C>: Zeroize,
 {
     fn drop(&mut self) {
         self.zeroize();

--- a/elliptic-curve/src/jwk.rs
+++ b/elliptic-curve/src/jwk.rs
@@ -31,7 +31,7 @@ use zeroize::Zeroize;
 use crate::{
     public_key::PublicKey,
     sec1::{FromEncodedPoint, ToEncodedPoint},
-    AffinePoint, ProjectiveArithmetic, Scalar,
+    AffinePoint, ProjectiveArithmetic,
 };
 
 /// Key Type (`kty`) for elliptic curve keys.
@@ -270,7 +270,6 @@ impl<C> From<SecretKey<C>> for JwkEcKey
 where
     C: PrimeCurve + JwkParameters + ProjectiveArithmetic,
     AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
-    Scalar<C>: Zeroize,
     UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
     UncompressedPointSize<C>: ArrayLength<u8>,
 {
@@ -286,7 +285,6 @@ impl<C> From<&SecretKey<C>> for JwkEcKey
 where
     C: PrimeCurve + JwkParameters + ProjectiveArithmetic,
     AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
-    Scalar<C>: Zeroize,
     UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
     UncompressedPointSize<C>: ArrayLength<u8>,
 {

--- a/elliptic-curve/src/scalar/non_zero.rs
+++ b/elliptic-curve/src/scalar/non_zero.rs
@@ -188,7 +188,6 @@ where
 impl<C> Zeroize for NonZeroScalar<C>
 where
     C: Curve + ProjectiveArithmetic,
-    Scalar<C>: Zeroize,
 {
     fn zeroize(&mut self) {
         self.scalar.zeroize();

--- a/elliptic-curve/src/sec1.rs
+++ b/elliptic-curve/src/sec1.rs
@@ -21,10 +21,7 @@ use alloc::boxed::Box;
 use crate::{point::DecompressPoint, AffinePoint, ProjectiveArithmetic};
 
 #[cfg(all(feature = "arithmetic"))]
-use crate::{
-    group::{Curve as _, Group},
-    Scalar,
-};
+use crate::group::{Curve as _, Group};
 
 /// Size of a compressed point for the given elliptic curve when encoded
 /// using the SEC1 `Elliptic-Curve-Point-to-Octet-String` algorithm
@@ -123,7 +120,6 @@ where
     where
         C: PrimeCurve + ProjectiveArithmetic,
         AffinePoint<C>: ToEncodedPoint<C>,
-        Scalar<C>: Zeroize,
     {
         (C::ProjectivePoint::generator() * secret_key.to_secret_scalar().as_ref())
             .to_affine()
@@ -552,7 +548,6 @@ impl<C> ValidatePublicKey for C
 where
     C: PrimeCurve + ProjectiveArithmetic,
     AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
-    Scalar<C>: Zeroize,
     UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
     UncompressedPointSize<C>: ArrayLength<u8>,
 {

--- a/elliptic-curve/src/secret_key.rs
+++ b/elliptic-curve/src/secret_key.rs
@@ -23,7 +23,7 @@ use zeroize::Zeroize;
 #[cfg(feature = "arithmetic")]
 use crate::{
     rand_core::{CryptoRng, RngCore},
-    NonZeroScalar, ProjectiveArithmetic, PublicKey, Scalar,
+    NonZeroScalar, ProjectiveArithmetic, PublicKey,
 };
 
 #[cfg(feature = "jwk")]
@@ -87,7 +87,6 @@ where
     pub fn random(rng: impl CryptoRng + RngCore) -> Self
     where
         C: ProjectiveArithmetic,
-        Scalar<C>: Zeroize,
     {
         Self {
             inner: NonZeroScalar::<C>::random(rng).into(),
@@ -139,7 +138,6 @@ where
     pub fn to_secret_scalar(&self) -> NonZeroScalar<C>
     where
         C: Curve + ProjectiveArithmetic,
-        Scalar<C>: Zeroize,
     {
         self.into()
     }
@@ -150,7 +148,6 @@ where
     pub fn public_key(&self) -> PublicKey<C>
     where
         C: Curve + ProjectiveArithmetic,
-        Scalar<C>: Zeroize,
     {
         PublicKey::from_secret_scalar(&self.to_secret_scalar())
     }
@@ -187,7 +184,7 @@ where
     where
         C: PrimeCurve + JwkParameters + ProjectiveArithmetic,
         AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
-        Scalar<C>: Zeroize,
+
         UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
         UncompressedPointSize<C>: ArrayLength<u8>,
     {
@@ -202,7 +199,7 @@ where
     where
         C: PrimeCurve + JwkParameters + ProjectiveArithmetic,
         AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
-        Scalar<C>: Zeroize,
+
         UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
         UncompressedPointSize<C>: ArrayLength<u8>,
     {

--- a/elliptic-curve/src/secret_key/pkcs8.rs
+++ b/elliptic-curve/src/secret_key/pkcs8.rs
@@ -17,7 +17,6 @@ use pkcs8::{
 #[cfg(all(feature = "arithmetic", feature = "pem"))]
 use {
     crate::{
-        scalar::Scalar,
         sec1::{FromEncodedPoint, ToEncodedPoint},
         AffinePoint, ProjectiveArithmetic,
     },
@@ -97,7 +96,6 @@ impl<C> ToPrivateKey for SecretKey<C>
 where
     C: PrimeCurve + AlgorithmParameters + ProjectiveArithmetic,
     AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
-    Scalar<C>: Zeroize,
     UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
     UncompressedPointSize<C>: ArrayLength<u8>,
 {


### PR DESCRIPTION
Makes `DefaultIsZeroes` a mandatory bound for all `*Arithmetic` traits (i.e. scalar, affine, projective)