### PR TITLE
elliptic-curve: add `PrimeCurveArithmetic` trait; MSRV 1.52+

### DIFF
--- a/.github/workflows/crypto.yml
+++ b/.github/workflows/crypto.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.51.0 # MSRV
+          - 1.52.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -43,7 +43,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.51.0 # MSRV
+          - 1.52.0 # MSRV
           - stable
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/elliptic-curve.yml
+++ b/.github/workflows/elliptic-curve.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.51.0 # MSRV
+          - 1.52.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -50,7 +50,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.51.0 # MSRV
+          - 1.52.0 # MSRV
           - stable
           - nightly
     steps:

--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/checkout@v1
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: 1.51.0 # Highest MSRV in repo
+        toolchain: 1.52.0
         components: clippy
         override: true
         profile: minimal

--- a/crypto/README.md
+++ b/crypto/README.md
@@ -14,7 +14,7 @@ access compatible versions of all traits from the Rust Crypto project.
 
 ## Minimum Supported Rust Version
 
-Rust **1.51** or higher.
+Rust **1.52** or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be
 done with a minor version bump.
@@ -46,7 +46,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/crypto/badge.svg
 [docs-link]: https://docs.rs/crypto/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.51+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.52+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260050-Traits
 [build-image]: https://github.com/RustCrypto/traits/workflows/crypto/badge.svg?branch=master&event=push

--- a/elliptic-curve/README.md
+++ b/elliptic-curve/README.md
@@ -15,7 +15,7 @@ and public/secret keys composed thereof.
 
 ## Minimum Supported Rust Version
 
-Requires Rust **1.51** or higher.
+Requires Rust **1.52** or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be
 done with a minor version bump.
@@ -47,7 +47,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/elliptic-curve/badge.svg
 [docs-link]: https://docs.rs/elliptic-curve/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.51+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.52+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260040-elliptic-curves
 [build-image]: https://github.com/RustCrypto/elliptic-curves/workflows/elliptic-curve%20crate/badge.svg?branch=master&event=push

--- a/elliptic-curve/src/arithmetic.rs
+++ b/elliptic-curve/src/arithmetic.rs
@@ -1,6 +1,6 @@
 //! Elliptic curve arithmetic traits.
 
-use crate::{Curve, FieldBytes};
+use crate::{Curve, FieldBytes, PrimeCurve};
 use core::fmt::Debug;
 use subtle::{ConditionallySelectable, ConstantTimeEq};
 use zeroize::DefaultIsZeroes;
@@ -20,6 +20,14 @@ pub trait AffineArithmetic: Curve + ScalarArithmetic {
         + Sized
         + Send
         + Sync;
+}
+
+/// Prime order elliptic curve with projective arithmetic implementation.
+pub trait PrimeCurveArithmetic:
+    PrimeCurve + ProjectiveArithmetic<ProjectivePoint = Self::CurveGroup>
+{
+    /// Prime order elliptic curve group.
+    type CurveGroup: group::prime::PrimeCurve<Affine = <Self as AffineArithmetic>::AffinePoint>;
 }
 
 /// Elliptic curve with projective arithmetic implementation.

--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -4,7 +4,7 @@
 //!
 //! ## Minimum Supported Rust Version
 //!
-//! Rust **1.51** or higher.
+//! Rust **1.52** or higher.
 //!
 //! Minimum supported Rust version can be changed in the future, but it will be
 //! done with a minor version bump.
@@ -70,7 +70,9 @@ pub use zeroize;
 #[cfg(feature = "arithmetic")]
 pub use {
     crate::{
-        arithmetic::{AffineArithmetic, ProjectiveArithmetic, ScalarArithmetic},
+        arithmetic::{
+            AffineArithmetic, PrimeCurveArithmetic, ProjectiveArithmetic, ScalarArithmetic,
+        },
         public_key::PublicKey,
         scalar::{non_zero::NonZeroScalar, Scalar},
     },


### PR DESCRIPTION
Adds a trait for elliptic curves with a prime order curve group which bounds on the corresponding traits from `group::prime`.