### PR TITLE
elliptic-curve: additional `ScalarArithmetic::Scalar` bounds

### DIFF
--- a/elliptic-curve/src/arithmetic.rs
+++ b/elliptic-curve/src/arithmetic.rs
@@ -1,6 +1,6 @@
 //! Elliptic curve arithmetic traits.
 
-use crate::{Curve, FieldBytes, PrimeCurve};
+use crate::{Curve, FieldBytes, PrimeCurve, ScalarCore};
 use core::fmt::Debug;
 use subtle::{ConditionallySelectable, ConstantTimeEq};
 use zeroize::DefaultIsZeroes;
@@ -70,5 +70,10 @@ pub trait ScalarArithmetic: Curve {
     /// - [`Default`]
     /// - [`Send`]
     /// - [`Sync`]
-    type Scalar: DefaultIsZeroes + ff::Field + ff::PrimeField<Repr = FieldBytes<Self>>;
+    type Scalar: DefaultIsZeroes
+        + From<ScalarCore<Self>>
+        + Into<Self::UInt>
+        + Into<FieldBytes<Self>>
+        + ff::Field
+        + ff::PrimeField<Repr = FieldBytes<Self>>;
 }

--- a/elliptic-curve/src/dev.rs
+++ b/elliptic-curve/src/dev.rs
@@ -197,6 +197,12 @@ impl TryFrom<U256> for Scalar {
     }
 }
 
+impl From<Scalar> for U256 {
+    fn from(scalar: Scalar) -> U256 {
+        scalar.0
+    }
+}
+
 impl ConditionallySelectable for Scalar {
     fn conditional_select(a: &Self, b: &Self, choice: Choice) -> Self {
         Scalar(U256::conditional_select(&a.0, &b.0, choice))
@@ -306,6 +312,12 @@ impl Neg for Scalar {
 impl From<u64> for Scalar {
     fn from(_: u64) -> Scalar {
         unimplemented!();
+    }
+}
+
+impl From<ScalarCore> for Scalar {
+    fn from(scalar: ScalarCore) -> Scalar {
+        Scalar(*scalar.as_uint())
     }
 }
 


### PR DESCRIPTION
Adds more `From` and `Into` bounds:

- From<ScalarCore<C>>`
- Into<Self::UInt>
- Into<FieldBytes<C>>