### PR TITLE
elliptic-curve: rename `from_be_bytes`/`from_le_bytes` and `to_be_bytes`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,8 +146,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-bigint"
-version = "0.2.5"
-source = "git+https://github.com/RustCrypto/utils.git#8fa1b4fb22789fb5afd51bc1fad08ebf95789965"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e49339137316df1914fdb54a5eae75a73f45068fd0d2178fe235b11d93238a6e"
 dependencies = [
  "generic-array",
  "rand_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,3 @@ members = [
     "signature/async",
     "universal-hash",
 ]
-
-[patch.crates-io]
-crypto-bigint = { git = "https://github.com/RustCrypto/utils.git" }

--- a/elliptic-curve/src/jwk.rs
+++ b/elliptic-curve/src/jwk.rs
@@ -250,7 +250,7 @@ where
         if let Some(d_base64) = &jwk.d {
             let pk = EncodedPoint::<C>::try_from(jwk)?;
             let mut d_bytes = decode_base64url_fe::<C>(d_base64)?;
-            let result = SecretKey::from_bytes_be(&d_bytes);
+            let result = SecretKey::from_be_bytes(&d_bytes);
             d_bytes.zeroize();
 
             result.and_then(|secret_key| {
@@ -290,7 +290,7 @@ where
 {
     fn from(sk: &SecretKey<C>) -> JwkEcKey {
         let mut jwk = sk.public_key().to_jwk();
-        let mut d = sk.to_bytes_be();
+        let mut d = sk.to_be_bytes();
         jwk.d = Some(Base64Url::encode_string(&d));
         d.zeroize();
         jwk

--- a/elliptic-curve/src/scalar.rs
+++ b/elliptic-curve/src/scalar.rs
@@ -70,12 +70,12 @@ where
     }
 
     /// Decode [`ScalarCore`] from big endian bytes.
-    pub fn from_bytes_be(bytes: FieldBytes<C>) -> CtOption<Self> {
+    pub fn from_be_bytes(bytes: FieldBytes<C>) -> CtOption<Self> {
         Self::new(C::UInt::from_be_byte_array(bytes))
     }
 
     /// Decode [`ScalarCore`] from little endian bytes.
-    pub fn from_bytes_le(bytes: FieldBytes<C>) -> CtOption<Self> {
+    pub fn from_le_bytes(bytes: FieldBytes<C>) -> CtOption<Self> {
         Self::new(C::UInt::from_le_byte_array(bytes))
     }
 
@@ -105,7 +105,7 @@ where
     }
 
     /// Encode [`ScalarCore`] as big endian bytes.
-    pub fn to_bytes_be(self) -> FieldBytes<C> {
+    pub fn to_be_bytes(self) -> FieldBytes<C> {
         self.inner.to_be_byte_array()
     }
 
@@ -123,7 +123,7 @@ where
     /// Convert [`ScalarCore`] into a given curve's scalar type
     // TODO(tarcieri): replace curve-specific scalars with `ScalarCore`
     fn to_scalar(self) -> Scalar<C> {
-        Scalar::<C>::from_repr(self.to_bytes_be()).unwrap()
+        Scalar::<C>::from_repr(self.to_be_bytes()).unwrap()
     }
 }
 

--- a/elliptic-curve/src/scalar/non_zero.rs
+++ b/elliptic-curve/src/scalar/non_zero.rs
@@ -122,7 +122,7 @@ where
     C: Curve + ProjectiveArithmetic,
 {
     fn from(scalar: NonZeroScalar<C>) -> ScalarCore<C> {
-        ScalarCore::from_bytes_be(scalar.to_repr()).unwrap()
+        ScalarCore::from_be_bytes(scalar.to_repr()).unwrap()
     }
 }
 
@@ -131,7 +131,7 @@ where
     C: Curve + ProjectiveArithmetic,
 {
     fn from(scalar: &NonZeroScalar<C>) -> ScalarCore<C> {
-        ScalarCore::from_bytes_be(scalar.to_repr()).unwrap()
+        ScalarCore::from_be_bytes(scalar.to_repr()).unwrap()
     }
 }
 

--- a/elliptic-curve/src/secret_key.rs
+++ b/elliptic-curve/src/secret_key.rs
@@ -99,12 +99,12 @@ where
     }
 
     /// Deserialize raw private scalar as a big endian integer.
-    pub fn from_bytes_be(bytes: &[u8]) -> Result<Self> {
+    pub fn from_be_bytes(bytes: &[u8]) -> Result<Self> {
         if bytes.len() != C::UInt::BYTE_SIZE {
             return Err(Error);
         }
 
-        let inner: ScalarCore<C> = Option::from(ScalarCore::from_bytes_be(
+        let inner: ScalarCore<C> = Option::from(ScalarCore::from_be_bytes(
             GenericArray::clone_from_slice(bytes),
         ))
         .ok_or(Error)?;
@@ -117,8 +117,8 @@ where
     }
 
     /// Expose the byte serialization of the value this [`SecretKey`] wraps.
-    pub fn to_bytes_be(&self) -> FieldBytes<C> {
-        self.inner.to_bytes_be()
+    pub fn to_be_bytes(&self) -> FieldBytes<C> {
+        self.inner.to_be_bytes()
     }
 
     /// Borrow the inner secret [`ScalarCore`] value.
@@ -253,7 +253,7 @@ where
     type Error = Error;
 
     fn try_from(slice: &[u8]) -> Result<Self> {
-        Self::from_bytes_be(slice)
+        Self::from_be_bytes(slice)
     }
 }
 

--- a/elliptic-curve/src/secret_key/pkcs8.rs
+++ b/elliptic-curve/src/secret_key/pkcs8.rs
@@ -65,7 +65,7 @@ where
                 return Err(der::Tag::Integer.value_error());
             }
 
-            let secret_key = Self::from_bytes_be(decoder.octet_string()?.as_ref())
+            let secret_key = Self::from_be_bytes(decoder.octet_string()?.as_ref())
                 .map_err(|_| der::Tag::Sequence.value_error())?;
 
             let public_key = decoder
@@ -101,7 +101,7 @@ where
 {
     fn to_pkcs8_der(&self) -> pkcs8::Result<pkcs8::PrivateKeyDocument> {
         // TODO(tarcieri): wrap `secret_key_bytes` in `Zeroizing`
-        let mut secret_key_bytes = self.to_bytes_be();
+        let mut secret_key_bytes = self.to_be_bytes();
         let secret_key_field = OctetString::new(&secret_key_bytes)?;
         let public_key_bytes = self.public_key().to_encoded_point(false);
         let public_key_field = ContextSpecific {

--- a/elliptic-curve/tests/pkcs8.rs
+++ b/elliptic-curve/tests/pkcs8.rs
@@ -22,7 +22,7 @@ const EXAMPLE_SCALAR: [u8; 32] =
 
 /// Example PKCS#8 private key
 fn example_private_key() -> PrivateKeyDocument {
-    SecretKey::from_bytes_be(&EXAMPLE_SCALAR)
+    SecretKey::from_be_bytes(&EXAMPLE_SCALAR)
         .unwrap()
         .to_pkcs8_der()
         .unwrap()
@@ -31,7 +31,7 @@ fn example_private_key() -> PrivateKeyDocument {
 #[test]
 fn decode_pkcs8_private_key_from_der() {
     let secret_key = SecretKey::from_pkcs8_der(example_private_key().as_ref()).unwrap();
-    assert_eq!(secret_key.to_bytes_be().as_slice(), &EXAMPLE_SCALAR);
+    assert_eq!(secret_key.to_be_bytes().as_slice(), &EXAMPLE_SCALAR);
 }
 
 #[test]

--- a/elliptic-curve/tests/secret_key.rs
+++ b/elliptic-curve/tests/secret_key.rs
@@ -6,5 +6,5 @@ use elliptic_curve::dev::SecretKey;
 
 #[test]
 fn undersize_secret_key() {
-    assert!(SecretKey::from_bytes_be(&[]).is_err());
+    assert!(SecretKey::from_be_bytes(&[]).is_err());
 }


### PR DESCRIPTION
Changes the names to be consistent with the `core` methods on unsigned integer types as well as the names in the `crypto-bigint` crate.