### PR TITLE
elliptic-curve: rename `SecretKey` scalar accessors

### DIFF
--- a/elliptic-curve/src/arithmetic.rs
+++ b/elliptic-curve/src/arithmetic.rs
@@ -23,6 +23,7 @@ pub trait AffineArithmetic: Curve + ScalarArithmetic {
 }
 
 /// Prime order elliptic curve with projective arithmetic implementation.
+#[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
 pub trait PrimeCurveArithmetic:
     PrimeCurve + ProjectiveArithmetic<ProjectivePoint = Self::CurveGroup>
 {

--- a/elliptic-curve/src/scalar/non_zero.rs
+++ b/elliptic-curve/src/scalar/non_zero.rs
@@ -149,7 +149,7 @@ where
     C: Curve + ProjectiveArithmetic,
 {
     fn from(sk: &SecretKey<C>) -> NonZeroScalar<C> {
-        let scalar = sk.as_secret_scalar().to_scalar();
+        let scalar = sk.as_scalar_core().to_scalar();
         debug_assert!(!bool::from(scalar.is_zero()));
         Self { scalar }
     }

--- a/elliptic-curve/src/sec1.rs
+++ b/elliptic-curve/src/sec1.rs
@@ -121,7 +121,7 @@ where
         C: PrimeCurve + ProjectiveArithmetic,
         AffinePoint<C>: ToEncodedPoint<C>,
     {
-        (C::ProjectivePoint::generator() * secret_key.to_secret_scalar().as_ref())
+        (C::ProjectivePoint::generator() * secret_key.to_nonzero_scalar().as_ref())
             .to_affine()
             .to_encoded_point(compress)
     }

--- a/elliptic-curve/src/secret_key.rs
+++ b/elliptic-curve/src/secret_key.rs
@@ -124,19 +124,25 @@ where
 
     /// Borrow the inner secret [`ScalarCore`] value.
     ///
-    /// # Warning
+    /// # ⚠️ Warning
     ///
     /// This value is key material.
     ///
     /// Please treat it with the care it deserves!
-    pub fn as_secret_scalar(&self) -> &ScalarCore<C> {
+    pub fn as_scalar_core(&self) -> &ScalarCore<C> {
         &self.inner
     }
 
-    /// Get the secret scalar value for this key.
+    /// Get the secret [`NonZeroScalar`] value for this key.
+    ///
+    /// # ⚠️ Warning
+    ///
+    /// This value is key material.
+    ///
+    /// Please treat it with the care it deserves!
     #[cfg(feature = "arithmetic")]
     #[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
-    pub fn to_secret_scalar(&self) -> NonZeroScalar<C>
+    pub fn to_nonzero_scalar(&self) -> NonZeroScalar<C>
     where
         C: Curve + ProjectiveArithmetic,
     {
@@ -150,7 +156,7 @@ where
     where
         C: Curve + ProjectiveArithmetic,
     {
-        PublicKey::from_secret_scalar(&self.to_secret_scalar())
+        PublicKey::from_secret_scalar(&self.to_nonzero_scalar())
     }
 
     /// Parse a [`JwkEcKey`] JSON Web Key (JWK) into a [`SecretKey`].


### PR DESCRIPTION
Renames the following:

- `SecretKey::as_secret_scalar` => `::as_scalar_core`
- `SecretKey::to_secret_scalar` => `::to_nonzero_scalar`