### PR TITLE
fixed fmt::Display for PasswordHash

### DIFF
--- a/password-hash/src/lib.rs
+++ b/password-hash/src/lib.rs
@@ -276,10 +276,10 @@ impl<'a> fmt::Display for PasswordHash<'a> {
 
         if let Some(salt) = &self.salt {
             write!(f, "{}{}", PASSWORD_HASH_SEPARATOR, salt)?;
-        }
 
-        if let Some(hash) = &self.hash {
-            write!(f, "{}{}", PASSWORD_HASH_SEPARATOR, hash)?;
+            if let Some(hash) = &self.hash {
+                write!(f, "{}{}", PASSWORD_HASH_SEPARATOR, hash)?;
+            }
         }
 
         Ok(())


### PR DESCRIPTION
The hash should only be added if there is a salt according to the PHC specification.
```
$<id>[$v=<version>][$<param>=<value>(,<param>=<value>)*][$<salt>[$<hash>]]
```
This shouldn't be a vulnerability as it is **not** in the parser. Even though the parser code looks the same it shouldn't be susceptible due to the use of a iterator.