### PR TITLE
elliptic-curve: `dev` module improvements

### DIFF
--- a/elliptic-curve/src/dev.rs
+++ b/elliptic-curve/src/dev.rs
@@ -2,11 +2,11 @@
 //! against concrete implementations of the traits in this crate.
 
 use crate::{
-    bigint::{ArrayEncoding as _, U256},
+    bigint::U256,
     error::{Error, Result},
     rand_core::RngCore,
     sec1::{FromEncodedPoint, ToEncodedPoint},
-    subtle::{Choice, ConditionallySelectable, ConstantTimeEq, ConstantTimeLess, CtOption},
+    subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption},
     zeroize::DefaultIsZeroes,
     AffineArithmetic, AlgorithmParameters, Curve, PrimeCurve, ProjectiveArithmetic,
     ScalarArithmetic,
@@ -17,10 +17,11 @@ use core::{
     ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign},
 };
 use ff::{Field, PrimeField};
+use generic_array::arr;
 use hex_literal::hex;
 
 #[cfg(feature = "bits")]
-use crate::{group::ff::PrimeFieldBits, ScalarBits};
+use crate::group::ff::PrimeFieldBits;
 
 #[cfg(feature = "jwk")]
 use crate::JwkParameters;
@@ -28,6 +29,29 @@ use crate::JwkParameters;
 /// Pseudo-coordinate for fixed-based scalar mult output
 pub const PSEUDO_COORDINATE_FIXED_BASE_MUL: [u8; 32] =
     hex!("deadbeef00000000000000000000000000000000000000000000000000000001");
+
+/// SEC1 encoded point.
+pub type EncodedPoint = crate::sec1::EncodedPoint<MockCurve>;
+
+/// Field element bytes.
+pub type FieldBytes = crate::FieldBytes<MockCurve>;
+
+/// Non-zero scalar value.
+pub type NonZeroScalar = crate::NonZeroScalar<MockCurve>;
+
+/// Public key.
+pub type PublicKey = crate::PublicKey<MockCurve>;
+
+/// Secret key.
+pub type SecretKey = crate::SecretKey<MockCurve>;
+
+/// Scalar core.
+// TODO(tarcieri): make this the scalar type
+pub type ScalarCore = crate::ScalarCore<MockCurve>;
+
+/// Scalar bits.
+#[cfg(feature = "bits")]
+pub type ScalarBits = crate::ScalarBits<MockCurve>;
 
 /// Mock elliptic curve type useful for writing tests which require a concrete
 /// curve type.
@@ -69,40 +93,28 @@ impl JwkParameters for MockCurve {
     const CRV: &'static str = "P-256";
 }
 
-/// SEC1 encoded point.
-pub type EncodedPoint = crate::sec1::EncodedPoint<MockCurve>;
-
-/// Field element bytes.
-pub type FieldBytes = crate::FieldBytes<MockCurve>;
-
-/// Non-zero scalar value.
-pub type NonZeroScalar = crate::NonZeroScalar<MockCurve>;
-
-/// Public key.
-pub type PublicKey = crate::PublicKey<MockCurve>;
-
-/// Secret key.
-pub type SecretKey = crate::SecretKey<MockCurve>;
-
-/// Scalar core.
-// TODO(tarcieri): make this the scalar type
-pub type ScalarCore = crate::ScalarCore<MockCurve>;
-
 /// Example scalar type
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
-pub struct Scalar(U256);
+pub struct Scalar(ScalarCore);
 
 impl Field for Scalar {
-    fn random(_rng: impl RngCore) -> Self {
-        unimplemented!();
+    fn random(mut rng: impl RngCore) -> Self {
+        let mut bytes = FieldBytes::default();
+
+        loop {
+            rng.fill_bytes(&mut bytes);
+            if let Some(scalar) = Self::from_repr(bytes).into() {
+                return scalar;
+            }
+        }
     }
 
     fn zero() -> Self {
-        Self(U256::ZERO)
+        Self(ScalarCore::ZERO)
     }
 
     fn one() -> Self {
-        Self(U256::ONE)
+        Self(ScalarCore::ONE)
     }
 
     fn is_zero(&self) -> Choice {
@@ -116,7 +128,7 @@ impl Field for Scalar {
 
     #[must_use]
     fn double(&self) -> Self {
-        unimplemented!();
+        self.add(self)
     }
 
     fn invert(&self) -> CtOption<Self> {
@@ -136,24 +148,28 @@ impl PrimeField for Scalar {
     const S: u32 = 4;
 
     fn from_repr(bytes: FieldBytes) -> CtOption<Self> {
-        let inner = U256::from_be_byte_array(bytes);
-        CtOption::new(Scalar(inner), inner.ct_lt(&MockCurve::ORDER))
+        ScalarCore::from_be_bytes(bytes).map(Self)
     }
 
     fn to_repr(&self) -> FieldBytes {
-        self.0.to_be_byte_array()
+        self.0.to_be_bytes()
     }
 
     fn is_odd(&self) -> Choice {
-        unimplemented!();
+        self.0.is_odd()
     }
 
     fn multiplicative_generator() -> Self {
-        unimplemented!();
+        7u64.into()
     }
 
     fn root_of_unity() -> Self {
-        unimplemented!();
+        Self::from_repr(arr![u8;
+            0xff, 0xc9, 0x7f, 0x06, 0x2a, 0x77, 0x09, 0x92, 0xba, 0x80, 0x7a, 0xce, 0x84, 0x2a,
+            0x3d, 0xfc, 0x15, 0x46, 0xca, 0xd0, 0x04, 0x37, 0x8d, 0xaf, 0x05, 0x92, 0xd7, 0xfb,
+            0xb4, 0x1e, 0x66, 0x02,
+        ])
+        .unwrap()
     }
 }
 
@@ -161,27 +177,16 @@ impl PrimeField for Scalar {
 impl PrimeFieldBits for Scalar {
     #[cfg(target_pointer_width = "32")]
     type ReprBits = [u32; 8];
+
     #[cfg(target_pointer_width = "64")]
     type ReprBits = [u64; 4];
 
-    fn to_le_bits(&self) -> ScalarBits<MockCurve> {
-        let mut limbs = Self::ReprBits::default();
-
-        for (i, limb) in self.0.limbs().iter().cloned().enumerate() {
-            limbs[i] = limb.into();
-        }
-
-        limbs.into()
+    fn to_le_bits(&self) -> ScalarBits {
+        self.0.as_uint().to_uint_array().into()
     }
 
-    fn char_le_bits() -> ScalarBits<MockCurve> {
-        let mut limbs = Self::ReprBits::default();
-
-        for (i, limb) in MockCurve::ORDER.limbs().iter().cloned().enumerate() {
-            limbs[i] = limb.into();
-        }
-
-        limbs.into()
+    fn char_le_bits() -> ScalarBits {
+        MockCurve::ORDER.to_uint_array().into()
     }
 }
 
@@ -189,23 +194,19 @@ impl TryFrom<U256> for Scalar {
     type Error = Error;
 
     fn try_from(w: U256) -> Result<Self> {
-        if w < MockCurve::ORDER {
-            Ok(Scalar(w))
-        } else {
-            Err(Error)
-        }
+        Option::from(ScalarCore::new(w)).map(Self).ok_or(Error)
     }
 }
 
 impl From<Scalar> for U256 {
     fn from(scalar: Scalar) -> U256 {
-        scalar.0
+        *scalar.0.as_uint()
     }
 }
 
 impl ConditionallySelectable for Scalar {
     fn conditional_select(a: &Self, b: &Self, choice: Choice) -> Self {
-        Scalar(U256::conditional_select(&a.0, &b.0, choice))
+        Self(ScalarCore::conditional_select(&a.0, &b.0, choice))
     }
 }
 
@@ -220,56 +221,56 @@ impl DefaultIsZeroes for Scalar {}
 impl Add<Scalar> for Scalar {
     type Output = Scalar;
 
-    fn add(self, _other: Scalar) -> Scalar {
-        unimplemented!();
+    fn add(self, other: Scalar) -> Scalar {
+        self.add(&other)
     }
 }
 
 impl Add<&Scalar> for Scalar {
     type Output = Scalar;
 
-    fn add(self, _other: &Scalar) -> Scalar {
-        unimplemented!();
+    fn add(self, other: &Scalar) -> Scalar {
+        Self(self.0.add(&other.0))
     }
 }
 
 impl AddAssign<Scalar> for Scalar {
-    fn add_assign(&mut self, _rhs: Scalar) {
-        unimplemented!();
+    fn add_assign(&mut self, other: Scalar) {
+        *self = *self + other;
     }
 }
 
 impl AddAssign<&Scalar> for Scalar {
-    fn add_assign(&mut self, _rhs: &Scalar) {
-        unimplemented!();
+    fn add_assign(&mut self, other: &Scalar) {
+        *self = *self + other;
     }
 }
 
 impl Sub<Scalar> for Scalar {
     type Output = Scalar;
 
-    fn sub(self, _other: Scalar) -> Scalar {
-        unimplemented!();
+    fn sub(self, other: Scalar) -> Scalar {
+        self.sub(&other)
     }
 }
 
 impl Sub<&Scalar> for Scalar {
     type Output = Scalar;
 
-    fn sub(self, _other: &Scalar) -> Scalar {
-        unimplemented!();
+    fn sub(self, other: &Scalar) -> Scalar {
+        Self(self.0.sub(&other.0))
     }
 }
 
 impl SubAssign<Scalar> for Scalar {
-    fn sub_assign(&mut self, _rhs: Scalar) {
-        unimplemented!();
+    fn sub_assign(&mut self, other: Scalar) {
+        *self = *self - other;
     }
 }
 
 impl SubAssign<&Scalar> for Scalar {
-    fn sub_assign(&mut self, _rhs: &Scalar) {
-        unimplemented!();
+    fn sub_assign(&mut self, other: &Scalar) {
+        *self = *self - other;
     }
 }
 
@@ -305,19 +306,19 @@ impl Neg for Scalar {
     type Output = Scalar;
 
     fn neg(self) -> Scalar {
-        unimplemented!();
+        Self(self.0.neg())
     }
 }
 
 impl From<u64> for Scalar {
-    fn from(_: u64) -> Scalar {
-        unimplemented!();
+    fn from(n: u64) -> Scalar {
+        Self(n.into())
     }
 }
 
 impl From<ScalarCore> for Scalar {
     fn from(scalar: ScalarCore) -> Scalar {
-        Scalar(*scalar.as_uint())
+        Self(scalar)
     }
 }
 
@@ -336,16 +337,16 @@ impl From<&Scalar> for FieldBytes {
 /// Example affine point type
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum AffinePoint {
-    /// Result of fixed-based scalar multiplication
+    /// Result of fixed-based scalar multiplication.
     FixedBaseOutput(Scalar),
 
-    /// Is this point the identity point?
+    /// Identity.
     Identity,
 
-    /// Is this point the generator point?
+    /// Base point.
     Generator,
 
-    /// Is this point a different point corresponding to a given [`EncodedPoint`]
+    /// Point corresponding to a given [`EncodedPoint`].
     Other(EncodedPoint),
 }
 


### PR DESCRIPTION
Uses `ScalarCore` as the internal representation of the `dev::Scalar` newtype, and implements more functionality in terms of it.