### PR TITLE
password-hash: pin `base64ct` to <1.1

### DIFF
--- a/password-hash/Cargo.toml
+++ b/password-hash/Cargo.toml
@@ -16,7 +16,7 @@ categories = ["cryptography", "no-std"]
 keywords = ["crypt", "mcf", "password", "pbkdf", "phc"]
 
 [dependencies]
-base64ct = "1"
+base64ct = ">=1, <1.1.0"
 subtle = { version = ">=2, <2.5", default-features = false }
 
 # optional features


### PR DESCRIPTION
Prevents an MSRV bump