### PR TITLE
password-hash v0.3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -325,7 +325,7 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "password-hash"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "base64ct",
  "rand_core",

--- a/password-hash/CHANGELOG.md
+++ b/password-hash/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.3.1 (2021-09-14)
+### Added
+- `PasswordHashString` ([#758])
+
+### Fixed
+- Handling of empty salts in `fmt::Display` impl for PasswordHash ([#748])
+- MSRV regression from `base64ct` ([#757])
+
+[#748]: https://github.com/RustCrypto/traits/pull/748
+[#757]: https://github.com/RustCrypto/traits/pull/757
+[#758]: https://github.com/RustCrypto/traits/pull/758
+
 ## 0.3.0 (2021-08-27)
 ### Added
 - More details to `ParamValueInvalid` ([#713])

--- a/password-hash/Cargo.toml
+++ b/password-hash/Cargo.toml
@@ -5,7 +5,7 @@ Traits which describe the functionality of password hashing algorithms,
 as well as a `no_std`-friendly implementation of the PHC string format
 (a well-defined subset of the Modular Crypt Format a.k.a. MCF)
 """
-version = "0.3.0" # Also update html_root_url in lib.rs when bumping this
+version = "0.3.1" # Also update html_root_url in lib.rs when bumping this
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/password-hash/src/lib.rs
+++ b/password-hash/src/lib.rs
@@ -39,7 +39,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
-    html_root_url = "https://docs.rs/password-hash/0.3.0"
+    html_root_url = "https://docs.rs/password-hash/0.3.1"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]
@@ -153,7 +153,7 @@ pub struct PasswordHash<'a> {
 impl<'a> PasswordHash<'a> {
     /// Parse a password hash from a string in the PHC string format.
     pub fn new(s: &'a str) -> Result<Self> {
-        Self::parse(s, Encoding::B64)
+        Self::parse(s, Encoding::default())
     }
 
     /// Parse a password hash from the given [`Encoding`].
@@ -319,7 +319,7 @@ pub struct PasswordHashString {
 impl PasswordHashString {
     /// Parse a password hash from a string in the PHC string format.
     pub fn new(s: &str) -> Result<Self> {
-        Self::parse(s, Encoding::B64)
+        Self::parse(s, Encoding::default())
     }
 
     /// Parse a password hash from the given [`Encoding`].


### PR DESCRIPTION
### Added
- `PasswordHashString` ([#758])

### Fixed
- Handling of empty salts in `fmt::Display` impl for PasswordHash ([#748])
- MSRV regression from `base64ct` ([#757])

[#748]: https://github.com/RustCrypto/traits/pull/748
[#757]: https://github.com/RustCrypto/traits/pull/757
[#758]: https://github.com/RustCrypto/traits/pull/758