### PR TITLE
password-hash: remove unused lifetimes

### DIFF
--- a/password-hash/src/lib.rs
+++ b/password-hash/src/lib.rs
@@ -42,7 +42,7 @@
     html_root_url = "https://docs.rs/password-hash/0.3.1"
 )]
 #![forbid(unsafe_code)]
-#![warn(missing_docs, rust_2018_idioms)]
+#![warn(missing_docs, rust_2018_idioms, unused_lifetimes)]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;
@@ -412,7 +412,7 @@ impl FromStr for PasswordHashString {
 }
 
 #[cfg(feature = "alloc")]
-impl<'a> fmt::Display for PasswordHashString {
+impl fmt::Display for PasswordHashString {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(self.as_str())
     }

--- a/password-hash/src/traits.rs
+++ b/password-hash/src/traits.rs
@@ -13,7 +13,7 @@ pub trait PasswordHasher {
         + Debug
         + Default
         + for<'a> TryFrom<&'a PasswordHash<'a>, Error = Error>
-        + for<'a> TryInto<ParamsString, Error = Error>;
+        + TryInto<ParamsString, Error = Error>;
 
     /// Compute a [`PasswordHash`] from the provided password using an
     /// explicit set of customized algorithm parameters as opposed to the


### PR DESCRIPTION
Also adds a `warn(unused_lifetimes)` lint to prevent this going forward