### PR TITLE
elliptic-curve: (re)re-export `sec1::Tag`

### DIFF
--- a/elliptic-curve/src/sec1.rs
+++ b/elliptic-curve/src/sec1.rs
@@ -6,7 +6,7 @@ mod ec_private_key;
 mod encoded_point;
 
 pub use self::encoded_point::{
-    CompressedPointSize, Coordinates, EncodedPoint, UncompressedPointSize, UntaggedPointSize,
+    CompressedPointSize, Coordinates, EncodedPoint, Tag, UncompressedPointSize, UntaggedPointSize,
 };
 
 pub(crate) use self::ec_private_key::EcPrivateKey;


### PR DESCRIPTION
This was accidentally hidden during the refactoring in #762