### PR TITLE
elliptic-curve: add `Reduce` trait

### DIFF
--- a/elliptic-curve/src/arithmetic.rs
+++ b/elliptic-curve/src/arithmetic.rs
@@ -1,6 +1,6 @@
 //! Elliptic curve arithmetic traits.
 
-use crate::{Curve, FieldBytes, PrimeCurve, ScalarCore};
+use crate::{ops::Reduce, Curve, FieldBytes, PrimeCurve, ScalarCore};
 use core::fmt::Debug;
 use subtle::{ConditionallySelectable, ConstantTimeEq};
 use zeroize::DefaultIsZeroes;
@@ -73,8 +73,9 @@ pub trait ScalarArithmetic: Curve {
     /// - [`Sync`]
     type Scalar: DefaultIsZeroes
         + From<ScalarCore<Self>>
-        + Into<Self::UInt>
         + Into<FieldBytes<Self>>
+        + Into<Self::UInt>
+        + Reduce<Self::UInt>
         + ff::Field
         + ff::PrimeField<Repr = FieldBytes<Self>>;
 }

--- a/elliptic-curve/src/dev.rs
+++ b/elliptic-curve/src/dev.rs
@@ -4,6 +4,7 @@
 use crate::{
     bigint::U256,
     error::{Error, Result},
+    ops::Reduce,
     rand_core::RngCore,
     sec1::{FromEncodedPoint, ToEncodedPoint},
     subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption},
@@ -307,6 +308,12 @@ impl Neg for Scalar {
 
     fn neg(self) -> Scalar {
         Self(self.0.neg())
+    }
+}
+
+impl Reduce<U256> for Scalar {
+    fn from_uint_reduced(_: U256) -> Self {
+        unimplemented!();
     }
 }
 

--- a/elliptic-curve/src/ops.rs
+++ b/elliptic-curve/src/ops.rs
@@ -2,6 +2,7 @@
 
 pub use core::ops::{Add, AddAssign, Mul, Neg, Sub, SubAssign};
 
+use crypto_bigint::{ArrayEncoding, ByteArray, Integer};
 use subtle::CtOption;
 
 /// Perform an inversion on a field element (i.e. base field element or scalar)
@@ -19,5 +20,23 @@ impl<F: ff::Field> Invert for F {
 
     fn invert(&self) -> CtOption<F> {
         ff::Field::invert(self)
+    }
+}
+
+/// Modular reduction.
+pub trait Reduce<UInt: Integer + ArrayEncoding>: Sized {
+    /// Perform a modular reduction, returning a field element.
+    fn from_uint_reduced(n: UInt) -> Self;
+
+    /// Interpret the given byte array as a big endian integer and perform a
+    /// modular reduction.
+    fn from_be_bytes_reduced(bytes: ByteArray<UInt>) -> Self {
+        Self::from_uint_reduced(UInt::from_be_byte_array(bytes))
+    }
+
+    /// Interpret the given byte array as a big endian integer and perform a
+    /// modular reduction.
+    fn from_le_bytes_reduced(bytes: ByteArray<UInt>) -> Self {
+        Self::from_uint_reduced(UInt::from_le_byte_array(bytes))
     }
 }


### PR DESCRIPTION
Adds a trait for modular reduction, primarily intended for use cases like hashing to a field element.

The trait is generic around a `UInt` to permit overlapping impls, allowing either "narrow" or "wide" reduction, selected by the size of the input.