### PR TITLE
elliptic-curve: enable `sec1` crate's `subtle` and `zeroize` features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -400,6 +400,7 @@ source = "git+https://github.com/rustcrypto/formats#77564c368c60486dbbdfb6e8ab6b
 dependencies = [
  "der",
  "generic-array",
+ "subtle",
  "zeroize",
 ]
 

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -29,7 +29,7 @@ group = { version = "0.11", optional = true, default-features = false }
 hex-literal = { version = "0.3", optional = true }
 pem-rfc7468 = { version = "0.2", optional = true }
 pkcs8 = { version = "0.7", optional = true }
-sec1 = { version = "0", optional = true }
+sec1 = { version = "0", optional = true, features = ["subtle", "zeroize"] }
 serde = { version = "1", optional = true, default-features = false }
 serde_json = { version = "1", optional = true, default-features = false, features = ["alloc"] }
 


### PR DESCRIPTION
These are both hard dependencies of `elliptic-curve` anyway