### PR TITLE
elliptic-curve: remove narrow `Reduce` bound on `Scalar`

### DIFF
--- a/elliptic-curve/src/arithmetic.rs
+++ b/elliptic-curve/src/arithmetic.rs
@@ -1,6 +1,6 @@
 //! Elliptic curve arithmetic traits.
 
-use crate::{ops::Reduce, Curve, FieldBytes, PrimeCurve, ScalarCore};
+use crate::{Curve, FieldBytes, PrimeCurve, ScalarCore};
 use core::fmt::Debug;
 use subtle::{ConditionallySelectable, ConstantTimeEq};
 use zeroize::DefaultIsZeroes;
@@ -77,7 +77,6 @@ pub trait ScalarArithmetic: Curve {
         + From<ScalarCore<Self>>
         + Into<FieldBytes<Self>>
         + Into<Self::UInt>
-        + Reduce<Self::UInt>
         + ff::Field
         + ff::PrimeField<Repr = FieldBytes<Self>>;
 }


### PR DESCRIPTION
Narrow reductions are not ideal and introduce much more bias than a wide reduction. If we are going to bound on a `Reduce` impl, it should at least include a wide reduction so we don't accidentally drive people to narrow reductions instead.

While they are needed for ECDSA, narrow reductions should probably be discouraged in other non-legacy applications.