### PR TITLE
elliptic-curve: make `FromEncodedPoint` return a `CtOption`

### DIFF
--- a/elliptic-curve/src/dev.rs
+++ b/elliptic-curve/src/dev.rs
@@ -367,8 +367,13 @@ impl ConstantTimeEq for AffinePoint {
 }
 
 impl ConditionallySelectable for AffinePoint {
-    fn conditional_select(_a: &Self, _b: &Self, _choice: Choice) -> Self {
-        unimplemented!();
+    fn conditional_select(a: &Self, b: &Self, choice: Choice) -> Self {
+        // Not really constant time, but this is dev code
+        if choice.into() {
+            *b
+        } else {
+            *a
+        }
     }
 }
 
@@ -381,12 +386,14 @@ impl Default for AffinePoint {
 impl DefaultIsZeroes for AffinePoint {}
 
 impl FromEncodedPoint<MockCurve> for AffinePoint {
-    fn from_encoded_point(point: &EncodedPoint) -> Option<Self> {
-        if point.is_identity() {
-            Some(Self::Identity)
+    fn from_encoded_point(encoded_point: &EncodedPoint) -> CtOption<Self> {
+        let point = if encoded_point.is_identity() {
+            Self::Identity
         } else {
-            Some(Self::Other(*point))
-        }
+            Self::Other(*encoded_point)
+        };
+
+        CtOption::new(point, Choice::from(1))
     }
 }
 
@@ -472,7 +479,7 @@ impl From<ProjectivePoint> for AffinePoint {
 }
 
 impl FromEncodedPoint<MockCurve> for ProjectivePoint {
-    fn from_encoded_point(_point: &EncodedPoint) -> Option<Self> {
+    fn from_encoded_point(_point: &EncodedPoint) -> CtOption<Self> {
         unimplemented!();
     }
 }

--- a/elliptic-curve/src/jwk.rs
+++ b/elliptic-curve/src/jwk.rs
@@ -6,7 +6,7 @@
 use crate::{
     sec1::{Coordinates, EncodedPoint, ModulusSize, ValidatePublicKey},
     secret_key::SecretKey,
-    Curve, Error, FieldBytes, FieldSize, PrimeCurve, Result,
+    Curve, Error, FieldBytes, FieldSize, Result,
 };
 use alloc::{
     borrow::ToOwned,
@@ -114,7 +114,7 @@ impl JwkEcKey {
     #[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
     pub fn to_public_key<C>(&self) -> Result<PublicKey<C>>
     where
-        C: PrimeCurve + JwkParameters + ProjectiveArithmetic,
+        C: Curve + JwkParameters + ProjectiveArithmetic,
         AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
         FieldSize<C>: ModulusSize,
     {
@@ -124,7 +124,7 @@ impl JwkEcKey {
     /// Create a JWK from a SEC1 [`EncodedPoint`].
     pub fn from_encoded_point<C>(point: &EncodedPoint<C>) -> Option<Self>
     where
-        C: PrimeCurve + JwkParameters,
+        C: Curve + JwkParameters,
         FieldSize<C>: ModulusSize,
     {
         match point.coordinates() {
@@ -141,7 +141,7 @@ impl JwkEcKey {
     /// Get the public key component of this JWK as a SEC1 [`EncodedPoint`].
     pub fn to_encoded_point<C>(&self) -> Result<EncodedPoint<C>>
     where
-        C: PrimeCurve + JwkParameters,
+        C: Curve + JwkParameters,
         FieldSize<C>: ModulusSize,
     {
         if self.crv != C::CRV {
@@ -158,7 +158,7 @@ impl JwkEcKey {
     #[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
     pub fn to_secret_key<C>(&self) -> Result<SecretKey<C>>
     where
-        C: PrimeCurve + JwkParameters + ValidatePublicKey,
+        C: Curve + JwkParameters + ValidatePublicKey,
         FieldSize<C>: ModulusSize,
     {
         self.try_into()
@@ -179,23 +179,10 @@ impl ToString for JwkEcKey {
     }
 }
 
-#[cfg(feature = "arithmetic")]
-#[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
-impl<C> FromEncodedPoint<C> for JwkEcKey
-where
-    C: PrimeCurve + JwkParameters + ProjectiveArithmetic,
-    AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
-    FieldSize<C>: ModulusSize,
-{
-    fn from_encoded_point(point: &EncodedPoint<C>) -> Option<Self> {
-        Self::from_encoded_point::<C>(point)
-    }
-}
-
 #[cfg_attr(docsrs, doc(cfg(feature = "jwk")))]
 impl<C> TryFrom<JwkEcKey> for SecretKey<C>
 where
-    C: PrimeCurve + JwkParameters + ValidatePublicKey,
+    C: Curve + JwkParameters + ValidatePublicKey,
     FieldSize<C>: ModulusSize,
 {
     type Error = Error;
@@ -208,7 +195,7 @@ where
 #[cfg_attr(docsrs, doc(cfg(feature = "jwk")))]
 impl<C> TryFrom<&JwkEcKey> for SecretKey<C>
 where
-    C: PrimeCurve + JwkParameters + ValidatePublicKey,
+    C: Curve + JwkParameters + ValidatePublicKey,
     FieldSize<C>: ModulusSize,
 {
     type Error = Error;
@@ -235,7 +222,7 @@ where
 #[cfg_attr(docsrs, doc(cfg(feature = "jwk")))]
 impl<C> From<SecretKey<C>> for JwkEcKey
 where
-    C: PrimeCurve + JwkParameters + ProjectiveArithmetic,
+    C: Curve + JwkParameters + ProjectiveArithmetic,
     AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
     FieldSize<C>: ModulusSize,
 {
@@ -249,7 +236,7 @@ where
 #[cfg_attr(docsrs, doc(cfg(feature = "jwk")))]
 impl<C> From<&SecretKey<C>> for JwkEcKey
 where
-    C: PrimeCurve + JwkParameters + ProjectiveArithmetic,
+    C: Curve + JwkParameters + ProjectiveArithmetic,
     AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
     FieldSize<C>: ModulusSize,
 {
@@ -267,7 +254,7 @@ where
 #[cfg_attr(docsrs, doc(cfg(feature = "jwk")))]
 impl<C> TryFrom<JwkEcKey> for PublicKey<C>
 where
-    C: PrimeCurve + JwkParameters + ProjectiveArithmetic,
+    C: Curve + JwkParameters + ProjectiveArithmetic,
     AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
     FieldSize<C>: ModulusSize,
 {
@@ -283,7 +270,7 @@ where
 #[cfg_attr(docsrs, doc(cfg(feature = "jwk")))]
 impl<C> TryFrom<&JwkEcKey> for PublicKey<C>
 where
-    C: PrimeCurve + JwkParameters + ProjectiveArithmetic,
+    C: Curve + JwkParameters + ProjectiveArithmetic,
     AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
     FieldSize<C>: ModulusSize,
 {
@@ -299,7 +286,7 @@ where
 #[cfg_attr(docsrs, doc(cfg(feature = "jwk")))]
 impl<C> From<PublicKey<C>> for JwkEcKey
 where
-    C: PrimeCurve + JwkParameters + ProjectiveArithmetic,
+    C: Curve + JwkParameters + ProjectiveArithmetic,
     AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
     FieldSize<C>: ModulusSize,
 {
@@ -313,7 +300,7 @@ where
 #[cfg_attr(docsrs, doc(cfg(feature = "jwk")))]
 impl<C> From<&PublicKey<C>> for JwkEcKey
 where
-    C: PrimeCurve + JwkParameters + ProjectiveArithmetic,
+    C: Curve + JwkParameters + ProjectiveArithmetic,
     AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
     FieldSize<C>: ModulusSize,
 {
@@ -587,7 +574,7 @@ impl Serialize for JwkEcKey {
 }
 
 /// Decode a Base64url-encoded field element
-fn decode_base64url_fe<C: PrimeCurve>(s: &str) -> Result<FieldBytes<C>> {
+fn decode_base64url_fe<C: Curve>(s: &str) -> Result<FieldBytes<C>> {
     let mut result = FieldBytes::<C>::default();
     Base64Url::decode(s, &mut result).map_err(|_| Error)?;
     Ok(result)

--- a/elliptic-curve/src/sec1.rs
+++ b/elliptic-curve/src/sec1.rs
@@ -4,7 +4,8 @@
 
 pub use sec1::point::{Coordinates, ModulusSize, Tag};
 
-use crate::{FieldSize, PrimeCurve, Result, SecretKey};
+use crate::{Curve, FieldSize, Result, SecretKey};
+use subtle::CtOption;
 
 #[cfg(feature = "arithmetic")]
 use crate::{AffinePoint, Error, ProjectiveArithmetic};
@@ -18,15 +19,11 @@ pub type EncodedPoint<C> = sec1::point::EncodedPoint<FieldSize<C>>;
 pub trait FromEncodedPoint<C>
 where
     Self: Sized,
-    C: PrimeCurve,
+    C: Curve,
     FieldSize<C>: ModulusSize,
 {
     /// Deserialize the type this trait is impl'd on from an [`EncodedPoint`].
-    ///
-    /// # Returns
-    ///
-    /// `None` if the [`EncodedPoint`] is invalid.
-    fn from_encoded_point(point: &EncodedPoint<C>) -> Option<Self>;
+    fn from_encoded_point(point: &EncodedPoint<C>) -> CtOption<Self>;
 }
 
 /// Trait for serializing a value to a SEC1 encoded curve point.
@@ -34,7 +31,7 @@ where
 /// This is intended for use with the `AffinePoint` type for a given elliptic curve.
 pub trait ToEncodedPoint<C>
 where
-    C: PrimeCurve,
+    C: Curve,
     FieldSize<C>: ModulusSize,
 {
     /// Serialize this value as a SEC1 [`EncodedPoint`], optionally applying
@@ -47,7 +44,7 @@ where
 /// This is intended for use with the `AffinePoint` type for a given elliptic curve.
 pub trait ToCompactEncodedPoint<C>
 where
-    C: PrimeCurve,
+    C: Curve,
     FieldSize<C>: ModulusSize,
 {
     /// Serialize this value as a SEC1 [`EncodedPoint`], optionally applying
@@ -62,7 +59,7 @@ where
 /// a blanket default impl of this trait.
 pub trait ValidatePublicKey
 where
-    Self: PrimeCurve,
+    Self: Curve,
     FieldSize<Self>: ModulusSize,
 {
     /// Validate that the given [`EncodedPoint`] is a valid public key for the
@@ -86,7 +83,7 @@ where
 #[cfg(all(feature = "arithmetic"))]
 impl<C> ValidatePublicKey for C
 where
-    C: PrimeCurve + ProjectiveArithmetic,
+    C: Curve + ProjectiveArithmetic,
     AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
     FieldSize<C>: ModulusSize,
 {


### PR DESCRIPTION
Internally `k256`/`p256` return a `CtOption` for this method, then convert to an `Option`.

It would be helpful when implementing other traits from the `group` crate, e.g. `GroupEncoding`, if this instead returned a `CtOption`.