### PR TITLE
elliptic-curve: use prerelease format parsers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,6 +38,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a32fd6af2b5827bce66c29053ba0e7c42b9dcab01835835058558c10851a46b"
 
 [[package]]
+name = "base64ct"
+version = "1.1.0"
+source = "git+https://github.com/RustCrypto/formats.git#8df9765ec9ca6fa728c797051e780997052b0bb2"
+
+[[package]]
 name = "bitvec"
 version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -118,8 +123,7 @@ dependencies = [
 [[package]]
 name = "const-oid"
 version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdab415d6744056100f40250a66bc430c1a46f7a02e20bc11c94c79a0f0464df"
+source = "git+https://github.com/RustCrypto/formats.git#8df9765ec9ca6fa728c797051e780997052b0bb2"
 
 [[package]]
 name = "cpufeatures"
@@ -188,9 +192,8 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28e98c534e9c8a0483aa01d6f6913bc063de254311bd267c9cf535e9b70e15b2"
+version = "0.5.0-pre"
+source = "git+https://github.com/RustCrypto/formats.git#8df9765ec9ca6fa728c797051e780997052b0bb2"
 dependencies = [
  "const-oid",
 ]
@@ -217,14 +220,14 @@ dependencies = [
 name = "elliptic-curve"
 version = "0.11.0-pre"
 dependencies = [
- "base64ct",
+ "base64ct 1.0.1",
  "crypto-bigint",
  "der",
  "ff",
  "generic-array",
  "group",
  "hex-literal",
- "pem-rfc7468",
+ "pem-rfc7468 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkcs8",
  "rand_core",
  "sec1",
@@ -340,7 +343,7 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 name = "password-hash"
 version = "0.3.2"
 dependencies = [
- "base64ct",
+ "base64ct 1.0.1",
  "rand_core",
  "subtle",
 ]
@@ -351,17 +354,24 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e71fb2d401a15271d52aade6d9410fb4ead603a86da5503f92e872e1df790265"
 dependencies = [
- "base64ct",
+ "base64ct 1.0.1",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.2.2"
+source = "git+https://github.com/RustCrypto/formats.git#8df9765ec9ca6fa728c797051e780997052b0bb2"
+dependencies = [
+ "base64ct 1.1.0",
 ]
 
 [[package]]
 name = "pkcs8"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee3ef9b64d26bad0536099c816c6734379e45bbd5f14798def6809e5cc350447"
+version = "0.8.0-pre"
+source = "git+https://github.com/RustCrypto/formats.git#8df9765ec9ca6fa728c797051e780997052b0bb2"
 dependencies = [
  "der",
- "pem-rfc7468",
+ "pem-rfc7468 0.2.2 (git+https://github.com/RustCrypto/formats.git)",
  "spki",
  "zeroize",
 ]
@@ -413,9 +423,8 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "sec1"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "821f61b502d21d297a599436b55d03fff2340961a13bfd0a2c010380b8435823"
+version = "0.2.0"
+source = "git+https://github.com/RustCrypto/formats.git#8df9765ec9ca6fa728c797051e780997052b0bb2"
 dependencies = [
  "der",
  "generic-array",
@@ -485,9 +494,8 @@ dependencies = [
 
 [[package]]
 name = "spki"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c01a0c15da1b0b0e1494112e7af814a678fec9bd157881b49beac661e9b6f32"
+version = "0.5.0-pre"
+source = "git+https://github.com/RustCrypto/formats.git#8df9765ec9ca6fa728c797051e780997052b0bb2"
 dependencies = [
  "der",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,8 @@ members = [
     "signature/async",
     "universal-hash",
 ]
+
+[patch.crates-io]
+der = { git = "https://github.com/RustCrypto/formats.git" }
+pkcs8 = { git = "https://github.com/RustCrypto/formats.git" }
+sec1 = { git = "https://github.com/RustCrypto/formats.git" }

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -16,7 +16,7 @@ keywords   = ["crypto", "ecc", "elliptic", "weierstrass"]
 
 [dependencies]
 crypto-bigint = { version = "0.2.9", features = ["generic-array", "zeroize"] }
-der = { version = "0.4.4", default-features = false, features = ["oid"] }
+der = { version = "0.5.0-pre", default-features = false, features = ["oid"] }
 generic-array = { version = "0.14", default-features = false }
 rand_core = { version = "0.6", default-features = false }
 subtle = { version = ">=2, <2.5", default-features = false }
@@ -28,8 +28,8 @@ ff = { version = "0.11", optional = true, default-features = false }
 group = { version = "0.11", optional = true, default-features = false }
 hex-literal = { version = "0.3", optional = true }
 pem-rfc7468 = { version = "0.2", optional = true }
-pkcs8 = { version = "0.7", optional = true }
-sec1 = { version = "0.1", optional = true, features = ["subtle", "zeroize"] }
+pkcs8 = { version = "0.8.0-pre", optional = true }
+sec1 = { version = "0.2.0-pre", optional = true, features = ["subtle", "zeroize"] }
 serde = { version = "1", optional = true, default-features = false }
 serde_json = { version = "1", optional = true, default-features = false, features = ["alloc"] }
 


### PR DESCRIPTION
The `elliptic-curve` crate is presently a prerelease as well.

This commit has it pull in the prerelease format parsers so we can properly integration test them for the elliptic curve use case.