### PR TITLE
elliptic-curve: bump `pkcs8`; update encoding traits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,7 +40,7 @@ checksum = "8a32fd6af2b5827bce66c29053ba0e7c42b9dcab01835835058558c10851a46b"
 [[package]]
 name = "base64ct"
 version = "1.1.1"
-source = "git+https://github.com/RustCrypto/formats.git#98d7a2896d671169453f43ee57b43cee17b18b89"
+source = "git+https://github.com/RustCrypto/formats.git#3fb54bd27644e3f8bf8aeced336af77f4ed42813"
 
 [[package]]
 name = "bitvec"
@@ -123,7 +123,7 @@ dependencies = [
 [[package]]
 name = "const-oid"
 version = "0.6.2"
-source = "git+https://github.com/RustCrypto/formats.git#98d7a2896d671169453f43ee57b43cee17b18b89"
+source = "git+https://github.com/RustCrypto/formats.git#3fb54bd27644e3f8bf8aeced336af77f4ed42813"
 
 [[package]]
 name = "cpufeatures"
@@ -150,9 +150,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-bigint"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d12477e115c0d570c12a2dfd859f80b55b60ddb5075df210d3af06d133a69f45"
+checksum = "f83bd3bb4314701c568e340cd8cf78c975aa0ca79e03d3f6d1677d5b0c9c0c03"
 dependencies = [
  "generic-array",
  "rand_core",
@@ -193,9 +193,10 @@ dependencies = [
 [[package]]
 name = "der"
 version = "0.5.0-pre.1"
-source = "git+https://github.com/RustCrypto/formats.git#98d7a2896d671169453f43ee57b43cee17b18b89"
+source = "git+https://github.com/RustCrypto/formats.git#3fb54bd27644e3f8bf8aeced336af77f4ed42813"
 dependencies = [
  "const-oid",
+ "pem-rfc7468 0.2.2 (git+https://github.com/RustCrypto/formats.git)",
 ]
 
 [[package]]
@@ -320,9 +321,9 @@ checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "libc"
-version = "0.2.103"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8f7255a17a627354f321ef0055d63b898c6fb27eff628af4d1b66b7331edf6"
+checksum = "7b2f96d100e1cf1929e7719b7edb3b90ab5298072638fccd77be9ce942ecdfce"
 
 [[package]]
 name = "lock_api"
@@ -360,7 +361,7 @@ dependencies = [
 [[package]]
 name = "pem-rfc7468"
 version = "0.2.2"
-source = "git+https://github.com/RustCrypto/formats.git#98d7a2896d671169453f43ee57b43cee17b18b89"
+source = "git+https://github.com/RustCrypto/formats.git#3fb54bd27644e3f8bf8aeced336af77f4ed42813"
 dependencies = [
  "base64ct 1.1.1",
 ]
@@ -368,10 +369,9 @@ dependencies = [
 [[package]]
 name = "pkcs8"
 version = "0.8.0-pre"
-source = "git+https://github.com/RustCrypto/formats.git#98d7a2896d671169453f43ee57b43cee17b18b89"
+source = "git+https://github.com/RustCrypto/formats.git#3fb54bd27644e3f8bf8aeced336af77f4ed42813"
 dependencies = [
  "der",
- "pem-rfc7468 0.2.2 (git+https://github.com/RustCrypto/formats.git)",
  "spki",
  "zeroize",
 ]
@@ -423,8 +423,8 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "sec1"
-version = "0.2.0"
-source = "git+https://github.com/RustCrypto/formats.git#98d7a2896d671169453f43ee57b43cee17b18b89"
+version = "0.2.0-pre"
+source = "git+https://github.com/RustCrypto/formats.git#3fb54bd27644e3f8bf8aeced336af77f4ed42813"
 dependencies = [
  "der",
  "generic-array",
@@ -495,8 +495,9 @@ dependencies = [
 [[package]]
 name = "spki"
 version = "0.5.0-pre"
-source = "git+https://github.com/RustCrypto/formats.git#98d7a2896d671169453f43ee57b43cee17b18b89"
+source = "git+https://github.com/RustCrypto/formats.git#3fb54bd27644e3f8bf8aeced336af77f4ed42813"
 dependencies = [
+ "base64ct 1.1.1",
  "der",
 ]
 

--- a/elliptic-curve/src/secret_key/pkcs8.rs
+++ b/elliptic-curve/src/secret_key/pkcs8.rs
@@ -7,18 +7,18 @@ use crate::{
 };
 use core::convert::TryFrom;
 use der::Decodable;
-use pkcs8::FromPrivateKey;
+use pkcs8::DecodePrivateKey;
 use sec1::EcPrivateKey;
 
-// Imports for the `ToPrivateKey` impl
-// TODO(tarcieri): use weak activation of `pkcs8/alloc` for gating `ToPrivateKey` impl
+// Imports for the `EncodePrivateKey` impl
+// TODO(tarcieri): use weak activation of `pkcs8/alloc` for gating `EncodePrivateKey` impl
 #[cfg(all(feature = "arithmetic", feature = "pem"))]
 use {
     crate::{
         sec1::{FromEncodedPoint, ToEncodedPoint},
         AffinePoint, ProjectiveArithmetic,
     },
-    pkcs8::ToPrivateKey,
+    pkcs8::EncodePrivateKey,
 };
 
 // Imports for actual PEM support
@@ -29,7 +29,7 @@ use {
 };
 
 #[cfg_attr(docsrs, doc(cfg(feature = "pkcs8")))]
-impl<C> FromPrivateKey for SecretKey<C>
+impl<C> DecodePrivateKey for SecretKey<C>
 where
     C: Curve + AlgorithmParameters + ValidatePublicKey,
     FieldSize<C>: ModulusSize,
@@ -52,7 +52,7 @@ where
 #[cfg(all(feature = "arithmetic", feature = "pem"))]
 #[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
 #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
-impl<C> ToPrivateKey for SecretKey<C>
+impl<C> EncodePrivateKey for SecretKey<C>
 where
     C: Curve + AlgorithmParameters + ProjectiveArithmetic,
     AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
@@ -60,7 +60,7 @@ where
 {
     fn to_pkcs8_der(&self) -> pkcs8::Result<pkcs8::PrivateKeyDocument> {
         let ec_private_key = self.to_sec1_der()?;
-        Ok(pkcs8::PrivateKeyInfo::new(C::algorithm_identifier(), &ec_private_key).to_der())
+        pkcs8::PrivateKeyInfo::new(C::algorithm_identifier(), &ec_private_key).to_der()
     }
 }
 

--- a/elliptic-curve/tests/pkcs8.rs
+++ b/elliptic-curve/tests/pkcs8.rs
@@ -7,7 +7,7 @@ use elliptic_curve::{
     sec1::ToEncodedPoint,
 };
 use hex_literal::hex;
-use pkcs8::{FromPrivateKey, FromPublicKey, PrivateKeyDocument, ToPrivateKey};
+use pkcs8::{DecodePrivateKey, DecodePublicKey, EncodePrivateKey, PrivateKeyDocument};
 
 /// DER-encoded PKCS#8 public key
 const PKCS8_PUBLIC_KEY_DER: &[u8; 91] = include_bytes!("examples/pkcs8-public-key.der");


### PR DESCRIPTION
Updates `pkcs8` and related crates to use the new trait names after they were renamed in RustCrypto/formats#121.