### PR TITLE
signature: show error source in `Display` impl

### DIFF
--- a/signature/src/error.rs
+++ b/signature/src/error.rs
@@ -78,7 +78,16 @@ impl Debug for Error {
 
 impl Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str("signature error")
+        f.write_str("signature error")?;
+
+        #[cfg(feature = "std")]
+        {
+            if let Some(source) = &self.source {
+                write!(f, ": {}", source)?;
+            }
+        }
+
+        Ok(())
     }
 }
 


### PR DESCRIPTION
Previously the `Display` impl on `Error` didn't include source information if available.

This change displays it if available.