### PR TITLE
signature v1.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -464,7 +464,7 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "1.3.1"
+version = "1.4.0"
 dependencies = [
  "digest 0.9.0",
  "hex-literal",

--- a/signature/CHANGELOG.md
+++ b/signature/CHANGELOG.md
@@ -4,13 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## 1.4.0 (2021-10-20)
 ### Added
-- Re-export `rand_core`. Emit compilation error if unstable functionality
-is enabled by bypassing the preview features. ([#683])
-- Defined the `SignerMut` trait
+- Re-export `rand_core` when the `rand-preview` feature is enabled ([#683])
+- `SignerMut` trait ([#734])
+- Show error source in `Display` impl ([#791])
 
 [#683]: https://github.com/RustCrypto/traits/pull/683
+[#734]: https://github.com/RustCrypto/traits/pull/734
+[#791]: https://github.com/RustCrypto/traits/pull/791
 
 ## 1.3.1 (2021-06-29)
 ### Added

--- a/signature/Cargo.toml
+++ b/signature/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name          = "signature"
 description   = "Traits for cryptographic signature algorithms (e.g. ECDSA, Ed25519)"
-version       = "1.3.1" # Also update html_root_url in lib.rs when bumping this
+version       = "1.4.0" # Also update html_root_url in lib.rs when bumping this
 authors       = ["RustCrypto Developers"]
 license       = "Apache-2.0 OR MIT"
 documentation = "https://docs.rs/signature"

--- a/signature/src/lib.rs
+++ b/signature/src/lib.rs
@@ -160,7 +160,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
-    html_root_url = "https://docs.rs/signature/1.3.1"
+    html_root_url = "https://docs.rs/signature/1.4.0"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
@@ -193,7 +193,7 @@ pub use signature_derive::{Signer, Verifier};
 #[cfg(feature = "digest-preview")]
 pub use digest;
 
-#[cfg(feature = "rand_core")]
+#[cfg(feature = "rand-preview")]
 #[cfg_attr(docsrs, doc(cfg(feature = "rand-preview")))]
 pub use rand_core;
 


### PR DESCRIPTION
### Added
- Re-export `rand_core` when the `rand-preview` feature is enabled ([#683])
- `SignerMut` trait ([#734])
- Show error source in `Display` impl ([#791])

[#683]: https://github.com/RustCrypto/traits/pull/683
[#734]: https://github.com/RustCrypto/traits/pull/734
[#791]: https://github.com/RustCrypto/traits/pull/791