### PR TITLE
elliptic-curve: re-export `ff` and `PrimeField`

### DIFF
--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -78,7 +78,7 @@ pub use {
         public_key::PublicKey,
         scalar::{non_zero::NonZeroScalar, Scalar},
     },
-    ff::Field,
+    ff::{self, Field, PrimeField},
     group::{self, Group},
 };
 


### PR DESCRIPTION
Provides more convenient access to these important traits.