### PR TITLE
elliptic-curve: remove `TryFrom`/`TryInto` imports

### DIFF
--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "elliptic-curve"
+version = "0.11.0-pre" # Also update html_root_url in lib.rs when bumping this
 description = """
 General purpose Elliptic Curve Cryptography (ECC) support, including types
 and traits for representing various elliptic curve forms, scalars, points,
 and public/secret keys composed thereof.
 """
-version = "0.11.0-pre" # Also update html_root_url in lib.rs when bumping this
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/RustCrypto/traits/tree/master/elliptic-curve"

--- a/elliptic-curve/src/dev.rs
+++ b/elliptic-curve/src/dev.rs
@@ -13,7 +13,6 @@ use crate::{
     ScalarArithmetic,
 };
 use core::{
-    convert::TryFrom,
     iter::Sum,
     ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign},
 };

--- a/elliptic-curve/src/jwk.rs
+++ b/elliptic-curve/src/jwk.rs
@@ -15,7 +15,6 @@ use alloc::{
 };
 use base64ct::{Base64UrlUnpadded as Base64Url, Encoding};
 use core::{
-    convert::{TryFrom, TryInto},
     fmt::{self, Debug},
     marker::PhantomData,
     str::{self, FromStr},

--- a/elliptic-curve/src/public_key.rs
+++ b/elliptic-curve/src/public_key.rs
@@ -16,10 +16,7 @@ use {
 };
 
 #[cfg(feature = "pem")]
-use {
-    core::{convert::TryInto, str::FromStr},
-    pkcs8::EncodePublicKey,
-};
+use {core::str::FromStr, pkcs8::EncodePublicKey};
 
 #[cfg(feature = "sec1")]
 use {

--- a/elliptic-curve/src/scalar/non_zero.rs
+++ b/elliptic-curve/src/scalar/non_zero.rs
@@ -7,7 +7,7 @@ use crate::{
     rand_core::{CryptoRng, RngCore},
     Curve, Error, FieldBytes, ProjectiveArithmetic, Result, Scalar, ScalarCore, SecretKey,
 };
-use core::{convert::TryFrom, ops::Deref};
+use core::ops::Deref;
 use ff::{Field, PrimeField};
 use generic_array::GenericArray;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};

--- a/elliptic-curve/src/secret_key.rs
+++ b/elliptic-curve/src/secret_key.rs
@@ -47,12 +47,9 @@ use alloc::string::ToString;
 use pem_rfc7468 as pem;
 
 #[cfg(feature = "sec1")]
-use {
-    crate::{
-        sec1::{EncodedPoint, ModulusSize, ValidatePublicKey},
-        FieldSize,
-    },
-    core::convert::{TryFrom, TryInto},
+use crate::{
+    sec1::{EncodedPoint, ModulusSize, ValidatePublicKey},
+    FieldSize,
 };
 
 #[cfg(all(docsrs, feature = "pkcs8"))]

--- a/elliptic-curve/src/secret_key/pkcs8.rs
+++ b/elliptic-curve/src/secret_key/pkcs8.rs
@@ -5,7 +5,6 @@ use crate::{
     sec1::{ModulusSize, ValidatePublicKey},
     AlgorithmParameters, Curve, FieldSize, ALGORITHM_OID,
 };
-use core::convert::TryFrom;
 use der::Decodable;
 use pkcs8::DecodePrivateKey;
 use sec1::EcPrivateKey;


### PR DESCRIPTION
Now that we've upgraded to Rust 2021 edition, these are now available via the prelude, making explicit imports redundant.