### PR TITLE
Return early if `Ident` is too long

### DIFF
--- a/password-hash/src/ident.rs
+++ b/password-hash/src/ident.rs
@@ -126,14 +126,14 @@ impl<'a> TryFrom<&'a str> for Ident<'a> {
         let bytes = s.as_bytes();
         let too_long = bytes.len() > Self::MAX_LENGTH;
 
+        if too_long {
+            return Err(Error::ParamNameInvalid);
+        }
+
         for &c in bytes {
             if !is_char_valid(c) {
                 return Err(Error::ParamNameInvalid);
             }
-        }
-
-        if too_long {
-            return Err(Error::ParamNameInvalid);
         }
 
         Ok(Self::new(s))


### PR DESCRIPTION
At this point, we (can) know whether `too_long` is true, so don't iterate over all the `bytes`. (Both invalid chars and excessive length result in the same kind of error.) I don't think I see a constant-time/timing-independence concern — if a malicious input is too long, saying so immediately does not give the attacker any information about the `bytes` value.