### PR TITLE
elliptic-curve: bump `crypto-bigint` to v0.3.0-pre.1

### DIFF
--- a/elliptic-curve/Cargo.lock
+++ b/elliptic-curve/Cargo.lock
@@ -38,9 +38,9 @@ source = "git+https://github.com/RustCrypto/formats.git#4ec825666bcd552a87359674
 
 [[package]]
 name = "crypto-bigint"
-version = "0.2.11"
+version = "0.3.0-pre.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83bd3bb4314701c568e340cd8cf78c975aa0ca79e03d3f6d1677d5b0c9c0c03"
+checksum = "d174cafe51590ef0e0a6e540b9ffc8b35a1ff47fb3adda3ab272bcc9f5bfc86c"
 dependencies = [
  "generic-array",
  "rand_core",

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -20,7 +20,7 @@ rust-version = "1.56"
 members = ["."]
 
 [dependencies]
-crypto-bigint = { version = "0.2.9", features = ["generic-array", "zeroize"] }
+crypto-bigint = { version = "=0.3.0-pre.1", default-features = false, features = ["rand_core", "generic-array", "zeroize"] }
 der = { version = "=0.5.0-pre.1", default-features = false, features = ["oid"] }
 generic-array = { version = "0.14", default-features = false }
 rand_core = { version = "0.6", default-features = false }

--- a/elliptic-curve/src/dev.rs
+++ b/elliptic-curve/src/dev.rs
@@ -2,7 +2,7 @@
 //! against concrete implementations of the traits in this crate.
 
 use crate::{
-    bigint::{Encoding, Limb, U256},
+    bigint::{Limb, U256},
     error::{Error, Result},
     ops::Reduce,
     rand_core::RngCore,

--- a/elliptic-curve/src/scalar/core.rs
+++ b/elliptic-curve/src/scalar/core.rs
@@ -1,7 +1,7 @@
 //! Generic scalar type with core functionality.
 
 use crate::{
-    bigint::{AddMod, ArrayEncoding, Encoding, Integer, Limb, NegMod, RandomMod, SubMod},
+    bigint::{prelude::*, Limb, NonZero},
     rand_core::{CryptoRng, RngCore},
     subtle::{
         Choice, ConditionallySelectable, ConstantTimeEq, ConstantTimeGreater, ConstantTimeLess,
@@ -55,7 +55,7 @@ where
     /// Generate a random [`ScalarCore`].
     pub fn random(rng: impl CryptoRng + RngCore) -> Self {
         Self {
-            inner: C::UInt::random_mod(rng, &Self::MODULUS),
+            inner: C::UInt::random_mod(rng, &NonZero::new(Self::MODULUS).unwrap()),
         }
     }
 


### PR DESCRIPTION
Vetting the prerelease to make sure there aren't any showstoppers