### PR TITLE
elliptic-curve: add Encoding bound on Curve::UInt

### DIFF
--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -113,10 +113,11 @@ pub const ALGORITHM_OID: pkcs8::ObjectIdentifier =
 /// curves (e.g. [`SecretKey`]).
 pub trait Curve: 'static + Copy + Clone + Debug + Default + Eq + Ord + Send + Sync {
     /// Integer type used to represent field elements of this elliptic curve.
-    // TODO(tarcieri): replace this with an e.g. `const Curve::MODULUS: uint`.
+    // TODO(tarcieri): replace this with an e.g. `const Curve::MODULUS: UInt`.
     // Requires rust-lang/rust#60551, i.e. `const_evaluatable_checked`
     type UInt: bigint::AddMod<Output = Self::UInt>
         + bigint::ArrayEncoding
+        + bigint::Encoding
         + bigint::Integer
         + bigint::NegMod<Output = Self::UInt>
         + bigint::Random


### PR DESCRIPTION
It was removed upstream to allow the `Integer` trait to be blanket impl'd instead of using a macro.