### PR TITLE
elliptic-curve: use `sec1` crate for `pkcs8` support

### DIFF
--- a/elliptic-curve/Cargo.lock
+++ b/elliptic-curve/Cargo.lock
@@ -11,7 +11,7 @@ checksum = "392c772b012d685a640cdad68a5a21f4a45e696f85a2c2c907aab2fe49a91e19"
 [[package]]
 name = "base64ct"
 version = "1.2.0"
-source = "git+https://github.com/RustCrypto/formats.git#edb2c6a29ba96594f69759cbc331d669ef8e6a9d"
+source = "git+https://github.com/RustCrypto/formats.git#43d3ca3f8bca8d7f0a779489885d21a77b0f64a5"
 
 [[package]]
 name = "bitvec"
@@ -33,8 +33,8 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "const-oid"
-version = "0.7.0-pre"
-source = "git+https://github.com/RustCrypto/formats.git#edb2c6a29ba96594f69759cbc331d669ef8e6a9d"
+version = "0.7.0"
+source = "git+https://github.com/RustCrypto/formats.git#43d3ca3f8bca8d7f0a779489885d21a77b0f64a5"
 
 [[package]]
 name = "crypto-bigint"
@@ -50,11 +50,11 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.5.0-pre.1"
-source = "git+https://github.com/RustCrypto/formats.git#edb2c6a29ba96594f69759cbc331d669ef8e6a9d"
+version = "0.5.0"
+source = "git+https://github.com/RustCrypto/formats.git#43d3ca3f8bca8d7f0a779489885d21a77b0f64a5"
 dependencies = [
  "const-oid",
- "pem-rfc7468 0.3.0-pre",
+ "pem-rfc7468 0.3.0",
 ]
 
 [[package]]
@@ -69,7 +69,6 @@ dependencies = [
  "group",
  "hex-literal",
  "pem-rfc7468 0.2.3",
- "pkcs8",
  "rand_core",
  "sec1",
  "serde",
@@ -156,8 +155,8 @@ dependencies = [
 
 [[package]]
 name = "pem-rfc7468"
-version = "0.3.0-pre"
-source = "git+https://github.com/RustCrypto/formats.git#edb2c6a29ba96594f69759cbc331d669ef8e6a9d"
+version = "0.3.0"
+source = "git+https://github.com/RustCrypto/formats.git#43d3ca3f8bca8d7f0a779489885d21a77b0f64a5"
 dependencies = [
  "base64ct 1.2.0 (git+https://github.com/RustCrypto/formats.git)",
 ]
@@ -165,7 +164,7 @@ dependencies = [
 [[package]]
 name = "pkcs8"
 version = "0.8.0-pre"
-source = "git+https://github.com/RustCrypto/formats.git#edb2c6a29ba96594f69759cbc331d669ef8e6a9d"
+source = "git+https://github.com/RustCrypto/formats.git#43d3ca3f8bca8d7f0a779489885d21a77b0f64a5"
 dependencies = [
  "der",
  "spki",
@@ -196,10 +195,11 @@ checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 [[package]]
 name = "sec1"
 version = "0.2.0-pre"
-source = "git+https://github.com/RustCrypto/formats.git#edb2c6a29ba96594f69759cbc331d669ef8e6a9d"
+source = "git+https://github.com/RustCrypto/formats.git#43d3ca3f8bca8d7f0a779489885d21a77b0f64a5"
 dependencies = [
  "der",
  "generic-array",
+ "pkcs8",
  "subtle",
  "zeroize",
 ]
@@ -223,8 +223,8 @@ dependencies = [
 
 [[package]]
 name = "spki"
-version = "0.5.0-pre"
-source = "git+https://github.com/RustCrypto/formats.git#edb2c6a29ba96594f69759cbc331d669ef8e6a9d"
+version = "0.5.0"
+source = "git+https://github.com/RustCrypto/formats.git#43d3ca3f8bca8d7f0a779489885d21a77b0f64a5"
 dependencies = [
  "base64ct 1.2.0 (git+https://github.com/RustCrypto/formats.git)",
  "der",

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -21,11 +21,11 @@ members = ["."]
 
 [dependencies]
 crypto-bigint = { version = "0.3", default-features = false, features = ["rand_core", "generic-array", "zeroize"] }
-der = { version = "=0.5.0-pre.1", default-features = false, features = ["oid"] }
+der = { version = "0.5", default-features = false, features = ["oid"] }
 generic-array = { version = "0.14", default-features = false }
 rand_core = { version = "0.6", default-features = false }
 subtle = { version = ">=2, <2.5", default-features = false }
-zeroize = { version = ">=1, <1.5", default-features = false }
+zeroize = { version = "1", default-features = false }
 
 # optional dependencies
 base64ct = { version = "1", optional = true, default-features = false }
@@ -33,8 +33,7 @@ ff = { version = "0.11", optional = true, default-features = false }
 group = { version = "0.11", optional = true, default-features = false }
 hex-literal = { version = "0.3", optional = true }
 pem-rfc7468 = { version = "0.2", optional = true }
-pkcs8 = { version = "0.8.0-pre", optional = true }
-sec1 = { version = "0.2.0-pre", optional = true, features = ["subtle", "zeroize"] }
+sec1 = { version = "=0.2.0-pre", optional = true, features = ["subtle", "zeroize"] }
 serde = { version = "1", optional = true, default-features = false }
 serde_json = { version = "1", optional = true, default-features = false, features = ["alloc"] }
 
@@ -46,11 +45,12 @@ default = ["arithmetic"]
 alloc = ["der/alloc", "sec1/alloc", "zeroize/alloc"] # todo: use weak activation for `group`/`sec1` alloc when available
 arithmetic = ["ff", "group"]
 bits = ["arithmetic", "ff/bits"]
-dev = ["arithmetic", "hex-literal", "pem"]
+dev = ["arithmetic", "hex-literal", "pem", "pkcs8"]
 ecdh = ["arithmetic"]
 hazmat = []
 jwk = ["alloc", "base64ct/alloc", "serde", "serde_json", "zeroize/alloc"]
-pem = ["alloc", "arithmetic", "pem-rfc7468/alloc", "pkcs8/pem", "sec1/alloc"]
+pem = ["alloc", "arithmetic", "pem-rfc7468/alloc", "pkcs8", "sec1/pem"]
+pkcs8 = ["sec1/pkcs8"]
 std = ["alloc", "rand_core/std"]
 
 [package.metadata.docs.rs]

--- a/elliptic-curve/src/dev.rs
+++ b/elliptic-curve/src/dev.rs
@@ -5,6 +5,7 @@ use crate::{
     bigint::{Limb, U256},
     error::{Error, Result},
     ops::Reduce,
+    pkcs8,
     rand_core::RngCore,
     sec1::{FromEncodedPoint, ToEncodedPoint},
     subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption},

--- a/elliptic-curve/src/error.rs
+++ b/elliptic-curve/src/error.rs
@@ -2,6 +2,9 @@
 
 use core::fmt::{self, Display};
 
+#[cfg(feature = "pkcs8")]
+use crate::pkcs8;
+
 /// Result type with the `elliptic-curve` crate's [`Error`] type.
 pub type Result<T> = core::result::Result<T, Error>;
 

--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -89,7 +89,7 @@ pub use crate::scalar::ScalarBits;
 pub use crate::jwk::{JwkEcKey, JwkParameters};
 
 #[cfg(feature = "pkcs8")]
-pub use pkcs8;
+pub use ::sec1::pkcs8;
 
 use core::fmt::Debug;
 use generic_array::GenericArray;

--- a/elliptic-curve/tests/pkcs8.rs
+++ b/elliptic-curve/tests/pkcs8.rs
@@ -4,10 +4,10 @@
 
 use elliptic_curve::{
     dev::{PublicKey, SecretKey},
+    pkcs8::{DecodePrivateKey, DecodePublicKey, EncodePrivateKey, PrivateKeyDocument},
     sec1::ToEncodedPoint,
 };
 use hex_literal::hex;
-use pkcs8::{DecodePrivateKey, DecodePublicKey, EncodePrivateKey, PrivateKeyDocument};
 
 /// DER-encoded PKCS#8 public key
 const PKCS8_PUBLIC_KEY_DER: &[u8; 91] = include_bytes!("examples/pkcs8-public-key.der");


### PR DESCRIPTION
The `sec1` crate provides a blanket impl of traits like `DecodeEcPrivateKey` and `EncodeEcPrivateKey` for types which impl the `pkcs8` traits.

This commit leverages them.