### PR TITLE
elliptic-curve: bump `spki` to v0.5 release

### DIFF
--- a/elliptic-curve/Cargo.lock
+++ b/elliptic-curve/Cargo.lock
@@ -9,11 +9,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "392c772b012d685a640cdad68a5a21f4a45e696f85a2c2c907aab2fe49a91e19"
 
 [[package]]
-name = "base64ct"
-version = "1.2.0"
-source = "git+https://github.com/RustCrypto/formats.git#43d3ca3f8bca8d7f0a779489885d21a77b0f64a5"
-
-[[package]]
 name = "bitvec"
 version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -34,7 +29,8 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 [[package]]
 name = "const-oid"
 version = "0.7.0"
-source = "git+https://github.com/RustCrypto/formats.git#43d3ca3f8bca8d7f0a779489885d21a77b0f64a5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d355758f44afa81c21e66e1301d47cbffbbcde4b405cbe46b8b19f213abf9f60"
 
 [[package]]
 name = "crypto-bigint"
@@ -50,8 +46,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.5.0"
-source = "git+https://github.com/RustCrypto/formats.git#43d3ca3f8bca8d7f0a779489885d21a77b0f64a5"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6919815d73839e7ad218de758883aae3a257ba6759ce7a9992501efbb53d705c"
 dependencies = [
  "const-oid",
  "pem-rfc7468 0.3.0",
@@ -61,7 +58,7 @@ dependencies = [
 name = "elliptic-curve"
 version = "0.11.0-pre"
 dependencies = [
- "base64ct 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "base64ct",
  "crypto-bigint",
  "der",
  "ff",
@@ -150,21 +147,23 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f22eb0e3c593294a99e9ff4b24cf6b752d43f193aa4415fe5077c159996d497"
 dependencies = [
- "base64ct 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "base64ct",
 ]
 
 [[package]]
 name = "pem-rfc7468"
 version = "0.3.0"
-source = "git+https://github.com/RustCrypto/formats.git#43d3ca3f8bca8d7f0a779489885d21a77b0f64a5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af1254538022fc9aaf1db9f36f315f7a622dc4d46bedc42f8f8220ee23f932ee"
 dependencies = [
- "base64ct 1.2.0 (git+https://github.com/RustCrypto/formats.git)",
+ "base64ct",
 ]
 
 [[package]]
 name = "pkcs8"
-version = "0.8.0-pre"
-source = "git+https://github.com/RustCrypto/formats.git#43d3ca3f8bca8d7f0a779489885d21a77b0f64a5"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cabda3fb821068a9a4fab19a683eac3af12edf0f34b94a8be53c4972b8149d0"
 dependencies = [
  "der",
  "spki",
@@ -194,8 +193,9 @@ checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
 name = "sec1"
-version = "0.2.0-pre"
-source = "git+https://github.com/RustCrypto/formats.git#43d3ca3f8bca8d7f0a779489885d21a77b0f64a5"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2503adcd8c83e7081b3f9a3173f328f4d6cd50e116aaa324389b46f2d771d595"
 dependencies = [
  "der",
  "generic-array",
@@ -223,10 +223,11 @@ dependencies = [
 
 [[package]]
 name = "spki"
-version = "0.5.0"
-source = "git+https://github.com/RustCrypto/formats.git#43d3ca3f8bca8d7f0a779489885d21a77b0f64a5"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707c346225adc965b02243d87a3951bb6f8cbd039947cd99430ee2b2fdad09a3"
 dependencies = [
- "base64ct 1.2.0 (git+https://github.com/RustCrypto/formats.git)",
+ "base64ct",
  "der",
 ]
 

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -24,7 +24,7 @@ crypto-bigint = { version = "0.3", default-features = false, features = ["rand_c
 der = { version = "0.5", default-features = false, features = ["oid"] }
 generic-array = { version = "0.14", default-features = false }
 rand_core = { version = "0.6", default-features = false }
-subtle = { version = ">=2, <2.5", default-features = false }
+subtle = { version = "2", default-features = false }
 zeroize = { version = "1", default-features = false }
 
 # optional dependencies
@@ -33,7 +33,7 @@ ff = { version = "0.11", optional = true, default-features = false }
 group = { version = "0.11", optional = true, default-features = false }
 hex-literal = { version = "0.3", optional = true }
 pem-rfc7468 = { version = "0.2", optional = true }
-sec1 = { version = "=0.2.0-pre", optional = true, features = ["subtle", "zeroize"] }
+sec1 = { version = "0.2", optional = true, features = ["subtle", "zeroize"] }
 serde = { version = "1", optional = true, default-features = false }
 serde_json = { version = "1", optional = true, default-features = false, features = ["alloc"] }
 
@@ -56,8 +56,3 @@ std = ["alloc", "rand_core/std"]
 [package.metadata.docs.rs]
 features = ["arithmetic", "ecdh", "jwk", "pem", "std"]
 rustdoc-args = ["--cfg", "docsrs"]
-
-[patch.crates-io]
-der = { git = "https://github.com/RustCrypto/formats.git" }
-pkcs8 = { git = "https://github.com/RustCrypto/formats.git" }
-sec1 = { git = "https://github.com/RustCrypto/formats.git" }


### PR DESCRIPTION
This removes all of the git-based dependencies on `RustCrypto/formats`