### PR TITLE
elliptic-curve: add `scalar::IsHigh` trait

### DIFF
--- a/elliptic-curve/Cargo.lock
+++ b/elliptic-curve/Cargo.lock
@@ -34,9 +34,9 @@ checksum = "d355758f44afa81c21e66e1301d47cbffbbcde4b405cbe46b8b19f213abf9f60"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.3.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "476ecdba12db8402a1664482de8c37fff7dc96241258bd0de1f0d70e760a45fd"
+checksum = "03c6a1d5fa1de37e071642dfa44ec552ca5b299adb128fab16138e24b548fd21"
 dependencies = [
  "generic-array",
  "rand_core",
@@ -212,9 +212,9 @@ checksum = "f12d06de37cf59146fbdecab66aa99f9fe4f78722e3607577a5375d66bd0c913"
 
 [[package]]
 name = "serde_json"
-version = "1.0.70"
+version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e277c495ac6cd1a01a58d0a0c574568b4d1ddf14f59965c6a58b8d96400b54f3"
+checksum = "063bf466a64011ac24040a49009724ee60a57da1b437617ceb32e53ad61bfb19"
 dependencies = [
  "itoa",
  "ryu",

--- a/elliptic-curve/src/arithmetic.rs
+++ b/elliptic-curve/src/arithmetic.rs
@@ -1,6 +1,6 @@
 //! Elliptic curve arithmetic traits.
 
-use crate::{Curve, FieldBytes, PrimeCurve, ScalarCore};
+use crate::{Curve, FieldBytes, IsHigh, PrimeCurve, ScalarCore};
 use core::fmt::Debug;
 use subtle::{ConditionallySelectable, ConstantTimeEq};
 use zeroize::DefaultIsZeroes;
@@ -77,6 +77,7 @@ pub trait ScalarArithmetic: Curve {
         + From<ScalarCore<Self>>
         + Into<FieldBytes<Self>>
         + Into<Self::UInt>
+        + IsHigh
         + ff::Field
         + ff::PrimeField<Repr = FieldBytes<Self>>;
 }

--- a/elliptic-curve/src/dev.rs
+++ b/elliptic-curve/src/dev.rs
@@ -12,7 +12,7 @@ use crate::{
     sec1::{FromEncodedPoint, ToEncodedPoint},
     subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption},
     zeroize::DefaultIsZeroes,
-    AffineArithmetic, AlgorithmParameters, Curve, PrimeCurve, ProjectiveArithmetic,
+    AffineArithmetic, AlgorithmParameters, Curve, IsHigh, PrimeCurve, ProjectiveArithmetic,
     ScalarArithmetic,
 };
 use core::{
@@ -343,6 +343,12 @@ impl From<Scalar> for FieldBytes {
 impl From<&Scalar> for FieldBytes {
     fn from(scalar: &Scalar) -> Self {
         scalar.to_repr()
+    }
+}
+
+impl IsHigh for Scalar {
+    fn is_high(&self) -> Choice {
+        self.0.is_high()
     }
 }
 

--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -79,7 +79,7 @@ mod jwk;
 pub use crate::{
     error::{Error, Result},
     point::{DecompactPoint, DecompressPoint, PointCompaction, PointCompression},
-    scalar::core::ScalarCore,
+    scalar::{core::ScalarCore, IsHigh},
     secret_key::SecretKey,
 };
 pub use crypto_bigint as bigint;

--- a/elliptic-curve/src/scalar.rs
+++ b/elliptic-curve/src/scalar.rs
@@ -1,5 +1,7 @@
 //! Scalar types.
 
+use subtle::Choice;
+
 pub(crate) mod core;
 
 #[cfg(feature = "arithmetic")]
@@ -17,3 +19,14 @@ pub type Scalar<C> = <C as ScalarArithmetic>::Scalar;
 #[cfg(feature = "bits")]
 #[cfg_attr(docsrs, doc(cfg(feature = "bits")))]
 pub type ScalarBits<C> = ff::FieldBits<<Scalar<C> as ff::PrimeFieldBits>::ReprBits>;
+
+/// Is this scalar greater than n / 2?
+///
+/// # Returns
+///
+/// - For scalars 0 through n / 2: `Choice::from(0)`
+/// - For scalars (n / 2) + 1 through n - 1: `Choice::from(1)`
+pub trait IsHigh {
+    /// Is this scalar greater than or equal to n / 2?
+    fn is_high(&self) -> Choice;
+}

--- a/elliptic-curve/src/scalar/core.rs
+++ b/elliptic-curve/src/scalar/core.rs
@@ -7,7 +7,7 @@ use crate::{
         Choice, ConditionallySelectable, ConstantTimeEq, ConstantTimeGreater, ConstantTimeLess,
         CtOption,
     },
-    Curve, Error, FieldBytes, Result,
+    Curve, Error, FieldBytes, IsHigh, Result,
 };
 use core::{
     cmp::Ordering,
@@ -335,5 +335,15 @@ where
 
     fn neg(self) -> ScalarCore<C> {
         -*self
+    }
+}
+
+impl<C> IsHigh for ScalarCore<C>
+where
+    C: Curve,
+{
+    fn is_high(&self) -> Choice {
+        let n_2 = C::ORDER >> 1;
+        self.inner.ct_gt(&n_2)
     }
 }


### PR DESCRIPTION
Adds a trait for determining if a given scalar is larger than the order divided by 2.

This is useful for "normalization" use cases such as low-S normalized ECDSA signatures, where a scalar is conditionally negated if "high".