### PR TITLE
elliptic-curve: add `AffineXCoordinate` trait

### DIFF
--- a/elliptic-curve/src/arithmetic.rs
+++ b/elliptic-curve/src/arithmetic.rs
@@ -1,6 +1,6 @@
 //! Elliptic curve arithmetic traits.
 
-use crate::{Curve, FieldBytes, IsHigh, PrimeCurve, ScalarCore};
+use crate::{AffineXCoordinate, Curve, FieldBytes, IsHigh, PrimeCurve, ScalarCore};
 use core::fmt::Debug;
 use subtle::{ConditionallySelectable, ConstantTimeEq};
 use zeroize::DefaultIsZeroes;
@@ -10,6 +10,7 @@ use zeroize::DefaultIsZeroes;
 pub trait AffineArithmetic: Curve + ScalarArithmetic {
     /// Elliptic curve point in affine coordinates.
     type AffinePoint: 'static
+        + AffineXCoordinate<Self>
         + Copy
         + Clone
         + ConditionallySelectable

--- a/elliptic-curve/src/dev.rs
+++ b/elliptic-curve/src/dev.rs
@@ -12,8 +12,8 @@ use crate::{
     sec1::{FromEncodedPoint, ToEncodedPoint},
     subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption},
     zeroize::DefaultIsZeroes,
-    AffineArithmetic, AlgorithmParameters, Curve, IsHigh, PrimeCurve, ProjectiveArithmetic,
-    ScalarArithmetic,
+    AffineArithmetic, AffineXCoordinate, AlgorithmParameters, Curve, IsHigh, PrimeCurve,
+    ProjectiveArithmetic, ScalarArithmetic,
 };
 use core::{
     iter::Sum,
@@ -366,6 +366,12 @@ pub enum AffinePoint {
 
     /// Point corresponding to a given [`EncodedPoint`].
     Other(EncodedPoint),
+}
+
+impl AffineXCoordinate<MockCurve> for AffinePoint {
+    fn x(&self) -> FieldBytes {
+        unimplemented!();
+    }
 }
 
 impl ConstantTimeEq for AffinePoint {

--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -78,7 +78,9 @@ mod jwk;
 
 pub use crate::{
     error::{Error, Result},
-    point::{DecompactPoint, DecompressPoint, PointCompaction, PointCompression},
+    point::{
+        AffineXCoordinate, DecompactPoint, DecompressPoint, PointCompaction, PointCompression,
+    },
     scalar::{core::ScalarCore, IsHigh},
     secret_key::SecretKey,
 };

--- a/elliptic-curve/src/point.rs
+++ b/elliptic-curve/src/point.rs
@@ -3,16 +3,10 @@
 use crate::{Curve, FieldBytes};
 use subtle::{Choice, CtOption};
 
-/// Point compression settings.
-pub trait PointCompression {
-    /// Should point compression be applied by default?
-    const COMPRESS_POINTS: bool;
-}
-
-/// Point compaction settings.
-pub trait PointCompaction {
-    /// Should point compaction be applied by default?
-    const COMPACT_POINTS: bool;
+/// Obtain the affine x-coordinate of an elliptic curve point.
+pub trait AffineXCoordinate<C: Curve> {
+    /// Get the affine x-coordinate as a serialized field element.
+    fn x(&self) -> FieldBytes<C>;
 }
 
 /// Attempt to decompress an elliptic curve point from its x-coordinate and
@@ -26,4 +20,16 @@ pub trait DecompressPoint<C: Curve>: Sized {
 pub trait DecompactPoint<C: Curve>: Sized {
     /// Attempt to decompact an elliptic curve point
     fn decompact(x: &FieldBytes<C>) -> CtOption<Self>;
+}
+
+/// Point compression settings.
+pub trait PointCompression {
+    /// Should point compression be applied by default?
+    const COMPRESS_POINTS: bool;
+}
+
+/// Point compaction settings.
+pub trait PointCompaction {
+    /// Should point compaction be applied by default?
+    const COMPACT_POINTS: bool;
 }


### PR DESCRIPTION
Protocols like ECDH and ECDSA rely on x-coordinate access.

We've tried various ways of trying to keep affine coordinate access out of the public API, but it complicates generic implementations of these protocols.

Most recently RustCrypto/signatures#395 attempted to add a trait which encapsulated ECDSA signing, but a similar (or expanded version of the same) trait is needed for verification.

All of these problems go away, and can be expressed with simple trait bounds, if there is some way to access the x-coordinate of an `AffinePoint` as serialized `FieldBytes`.

This commit adds such a trait: `AffineXCoordinate`, which is a mandatory bound of `AffineArithmetic::AffinePoint`.