### PR TITLE
elliptic-curve: `serde` support for scalar and `PublicKey` types

### DIFF
--- a/.github/workflows/elliptic-curve.yml
+++ b/.github/workflows/elliptic-curve.yml
@@ -36,6 +36,7 @@ jobs:
           target: ${{ matrix.target }}
           override: true
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features alloc
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features arithmetic
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features bits
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features dev
@@ -45,9 +46,10 @@ jobs:
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features pem
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features pkcs8
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features sec1
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features serde
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features pkcs8,sec1
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features pem,pkcs8,sec1
-      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features ecdh,hazmat,jwk,pem,pkcs8,sec1
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features alloc,ecdh,hazmat,jwk,pem,pkcs8,sec1,serde
 
   test:
     runs-on: ubuntu-latest

--- a/elliptic-curve/Cargo.lock
+++ b/elliptic-curve/Cargo.lock
@@ -193,9 +193,9 @@ checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
 name = "sec1"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2503adcd8c83e7081b3f9a3173f328f4d6cd50e116aaa324389b46f2d771d595"
+checksum = "08da66b8b0965a5555b6bd6639e68ccba85e1e2506f5fbb089e93f8a04e1a2d1"
 dependencies = [
  "der",
  "generic-array",

--- a/elliptic-curve/src/hex.rs
+++ b/elliptic-curve/src/hex.rs
@@ -1,0 +1,127 @@
+//! Hexadecimal encoding helpers
+
+use crate::{Error, Result};
+use core::{fmt, str};
+
+/// Write the provided slice to the formatter as lower case hexadecimal
+#[inline]
+pub(crate) fn write_lower(slice: &[u8], formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+    for byte in slice {
+        write!(formatter, "{:02x}", byte)?;
+    }
+    Ok(())
+}
+
+/// Write the provided slice to the formatter as upper case hexadecimal
+#[inline]
+pub(crate) fn write_upper(slice: &[u8], formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+    for byte in slice {
+        write!(formatter, "{:02X}", byte)?;
+    }
+    Ok(())
+}
+
+/// Decode the provided hexadecimal string into the provided buffer.
+///
+/// Accepts either lower case or upper case hexadecimal, but not mixed.
+// TODO(tarcieri): constant-time hex decoder?
+pub(crate) fn decode(hex: &str, out: &mut [u8]) -> Result<()> {
+    if hex.as_bytes().len() != out.len() * 2 {
+        return Err(Error);
+    }
+
+    let mut upper_case = None;
+
+    // Ensure all characters are valid and case is not mixed
+    for &byte in hex.as_bytes() {
+        match byte {
+            b'0'..=b'9' => (),
+            b'a'..=b'z' => match upper_case {
+                Some(true) => return Err(Error),
+                Some(false) => (),
+                None => upper_case = Some(false),
+            },
+            b'A'..=b'Z' => match upper_case {
+                Some(true) => (),
+                Some(false) => return Err(Error),
+                None => upper_case = Some(true),
+            },
+            _ => return Err(Error),
+        }
+    }
+
+    for (digit, byte) in hex.as_bytes().chunks_exact(2).zip(out.iter_mut()) {
+        *byte = str::from_utf8(digit)
+            .ok()
+            .and_then(|s| u8::from_str_radix(s, 16).ok())
+            .ok_or(Error)?;
+    }
+
+    Ok(())
+}
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use core::fmt;
+    use hex_literal::hex;
+
+    const EXAMPLE_DATA: &[u8] = &hex!("0123456789ABCDEF");
+    const EXAMPLE_HEX_LOWER: &str = "0123456789abcdef";
+    const EXAMPLE_HEX_UPPER: &str = "0123456789ABCDEF";
+
+    struct Wrapper<'a>(&'a [u8]);
+
+    impl fmt::LowerHex for Wrapper<'_> {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            super::write_lower(self.0, f)
+        }
+    }
+
+    impl fmt::UpperHex for Wrapper<'_> {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            super::write_upper(self.0, f)
+        }
+    }
+
+    #[test]
+    fn decode_lower() {
+        let mut buf = [0u8; 8];
+        super::decode(EXAMPLE_HEX_LOWER, &mut buf).unwrap();
+        assert_eq!(buf, EXAMPLE_DATA);
+    }
+
+    #[test]
+    fn decode_upper() {
+        let mut buf = [0u8; 8];
+        super::decode(EXAMPLE_HEX_LOWER, &mut buf).unwrap();
+        assert_eq!(buf, EXAMPLE_DATA);
+    }
+
+    #[test]
+    fn decode_rejects_mixed_case() {
+        let mut buf = [0u8; 8];
+        assert!(super::decode("0123456789abcDEF", &mut buf).is_err());
+    }
+
+    #[test]
+    fn decode_rejects_too_short() {
+        let mut buf = [0u8; 9];
+        assert!(super::decode(EXAMPLE_HEX_LOWER, &mut buf).is_err());
+    }
+
+    #[test]
+    fn decode_rejects_too_long() {
+        let mut buf = [0u8; 7];
+        assert!(super::decode(EXAMPLE_HEX_LOWER, &mut buf).is_err());
+    }
+
+    #[test]
+    fn encode_lower() {
+        assert_eq!(format!("{:x}", Wrapper(EXAMPLE_DATA)), EXAMPLE_HEX_LOWER);
+    }
+
+    #[test]
+    fn encode_upper() {
+        assert_eq!(format!("{:X}", Wrapper(EXAMPLE_DATA)), EXAMPLE_HEX_UPPER);
+    }
+}

--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -56,6 +56,7 @@ pub mod ops;
 pub mod sec1;
 
 mod error;
+mod hex;
 mod point;
 mod scalar;
 mod secret_key;
@@ -111,6 +112,9 @@ pub use crate::jwk::{JwkEcKey, JwkParameters};
 
 #[cfg(feature = "pkcs8")]
 pub use ::sec1::pkcs8;
+
+#[cfg(feature = "serde")]
+pub use serde;
 
 use core::fmt::Debug;
 use generic_array::GenericArray;

--- a/elliptic-curve/src/scalar/non_zero.rs
+++ b/elliptic-curve/src/scalar/non_zero.rs
@@ -2,11 +2,16 @@
 
 use crate::{
     bigint::Encoding as _,
+    hex,
     ops::Invert,
     rand_core::{CryptoRng, RngCore},
     Curve, Error, FieldBytes, IsHigh, Result, Scalar, ScalarArithmetic, ScalarCore, SecretKey,
 };
-use core::ops::{Deref, Neg};
+use core::{
+    fmt,
+    ops::{Deref, Neg},
+    str,
+};
 use ff::{Field, PrimeField};
 use generic_array::GenericArray;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
@@ -217,6 +222,46 @@ where
         // Write a 1 instead of a 0 to ensure this type's non-zero invariant
         // is upheld.
         self.scalar = Scalar::<C>::one();
+    }
+}
+
+impl<C> fmt::Display for NonZeroScalar<C>
+where
+    C: Curve + ScalarArithmetic,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:X}", self)
+    }
+}
+
+impl<C> fmt::LowerHex for NonZeroScalar<C>
+where
+    C: Curve + ScalarArithmetic,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        hex::write_lower(&self.to_repr(), f)
+    }
+}
+
+impl<C> fmt::UpperHex for NonZeroScalar<C>
+where
+    C: Curve + ScalarArithmetic,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        hex::write_upper(&self.to_repr(), f)
+    }
+}
+
+impl<C> str::FromStr for NonZeroScalar<C>
+where
+    C: Curve + ScalarArithmetic,
+{
+    type Err = Error;
+
+    fn from_str(hex: &str) -> Result<Self> {
+        let mut bytes = FieldBytes::<C>::default();
+        hex::decode(hex, &mut bytes)?;
+        Option::from(Self::from_repr(bytes)).ok_or(Error)
     }
 }
 


### PR DESCRIPTION
Adds support for serializing/deserializing the following types using serde:

- `ScalarCore`
- `NonZeroScalar`
- `PublicKey`

While this crate had `serde` support previously, it was entirely limited to the JWK implementation.

This commit expands it to support more types, and provides the underpinnings for better leveraging `serde` in all of the dependent crates.