### PR TITLE
elliptic-curve v0.11.0

### DIFF
--- a/crypto/Cargo.lock
+++ b/crypto/Cargo.lock
@@ -17,11 +17,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a32fd6af2b5827bce66c29053ba0e7c42b9dcab01835835058558c10851a46b"
 
 [[package]]
-name = "base64ct"
-version = "1.2.0"
-source = "git+https://github.com/RustCrypto/formats.git#271163d6c48d930190cc434c155574b1281385cf"
-
-[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -39,7 +34,8 @@ dependencies = [
 [[package]]
 name = "const-oid"
 version = "0.7.0"
-source = "git+https://github.com/RustCrypto/formats.git#271163d6c48d930190cc434c155574b1281385cf"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d355758f44afa81c21e66e1301d47cbffbbcde4b405cbe46b8b19f213abf9f60"
 
 [[package]]
 name = "crypto"
@@ -80,7 +76,8 @@ dependencies = [
 [[package]]
 name = "der"
 version = "0.5.1"
-source = "git+https://github.com/RustCrypto/formats.git#271163d6c48d930190cc434c155574b1281385cf"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6919815d73839e7ad218de758883aae3a257ba6759ce7a9992501efbb53d705c"
 dependencies = [
  "const-oid",
 ]
@@ -96,7 +93,7 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.11.0-pre"
+version = "0.11.0"
 dependencies = [
  "crypto-bigint",
  "der",
@@ -161,7 +158,7 @@ checksum = "fbe5e23404da5b4f555ef85ebed98fb4083e55a00c317800bc2a50ede9f3d219"
 name = "password-hash"
 version = "0.3.2"
 dependencies = [
- "base64ct 1.0.1",
+ "base64ct",
  "rand_core",
  "subtle",
 ]
@@ -169,7 +166,8 @@ dependencies = [
 [[package]]
 name = "pkcs8"
 version = "0.8.0"
-source = "git+https://github.com/RustCrypto/formats.git#271163d6c48d930190cc434c155574b1281385cf"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cabda3fb821068a9a4fab19a683eac3af12edf0f34b94a8be53c4972b8149d0"
 dependencies = [
  "der",
  "spki",
@@ -187,8 +185,9 @@ dependencies = [
 
 [[package]]
 name = "sec1"
-version = "0.2.0"
-source = "git+https://github.com/RustCrypto/formats.git#271163d6c48d930190cc434c155574b1281385cf"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08da66b8b0965a5555b6bd6639e68ccba85e1e2506f5fbb089e93f8a04e1a2d1"
 dependencies = [
  "der",
  "generic-array",
@@ -204,9 +203,10 @@ version = "1.4.0"
 [[package]]
 name = "spki"
 version = "0.5.2"
-source = "git+https://github.com/RustCrypto/formats.git#271163d6c48d930190cc434c155574b1281385cf"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8a277a21925310de1d31bb6b021da3550b00e9127096ef84ee38f44609925c4"
 dependencies = [
- "base64ct 1.2.0",
+ "base64ct",
  "der",
 ]
 

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -22,7 +22,7 @@ members = ["."]
 aead = { version = "0.4", optional = true, path = "../aead" }
 cipher = { version = "0.3", optional = true }
 digest = { version = "0.9", optional = true }
-elliptic-curve = { version = "=0.11.0-pre", optional = true, path = "../elliptic-curve" }
+elliptic-curve = { version = "0.11", optional = true, path = "../elliptic-curve" }
 mac = { version = "0.11", package = "crypto-mac", optional = true }
 password-hash = { version = "0.3", optional = true, path = "../password-hash" }
 signature = { version = "1.3.0", optional = true, default-features = false, path = "../signature" }
@@ -42,7 +42,3 @@ std = [
 
 [package.metadata.docs.rs]
 all-features = true
-
-[patch.crates-io]
-der = { git = "https://github.com/RustCrypto/formats.git" }
-sec1 = { git = "https://github.com/RustCrypto/formats.git" }

--- a/elliptic-curve/CHANGELOG.md
+++ b/elliptic-curve/CHANGELOG.md
@@ -4,6 +4,56 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.11.0 (2021-11-19)
+### Added
+- `ScalarCore<C>` type ([#732])
+- `PrimeCurveArithmetic` trait ([#739])
+- SEC1 private key support ([#762])
+- `Reduce` trait ([#768])
+- Re-export `ff` and `PrimeField` ([#796])
+- `Encoding` bound on `Curve::UInt` ([#806])
+- `scalar::IsHigh` trait ([#814], [#815])
+- `Neg` impl for `NonZeroScalar<C>` ([#816])
+- `AffineXCoordinate` trait ([#817])
+- `serde` support for scalar and `PublicKey` types ([#818])
+
+### Changed
+- Bump `ff` + `group` to v0.11 ([#730])
+- Make `SecretKey::to_jwk_string` self-zeroizing ([#742])
+- Use `sec1` crate's `EncodedPoint` ([#771])
+- Make `FromEncodedPoint` return a `CtOption` ([#782])
+- Rust 2021 edition upgrade; MSRV to 1.56 ([#795])
+- Bump `crypto-bigint` dependency to v0.3 ([#807])
+- Use `sec1` crate for `pkcs8` support ([#809])
+- Bump `spki` dependency to v0.5 release ([#810])
+- `NonZeroScalar` is now bounded on `ScalarArithmetic` instead of
+  `ProjectiveArithmetic` ([#812])
+
+### Fixed
+- `Zeroize` impl on `NonZeroScalar` ([#785])
+
+[#730]: https://github.com/RustCrypto/traits/pull/730
+[#732]: https://github.com/RustCrypto/traits/pull/732
+[#739]: https://github.com/RustCrypto/traits/pull/739
+[#742]: https://github.com/RustCrypto/traits/pull/742
+[#762]: https://github.com/RustCrypto/traits/pull/762
+[#768]: https://github.com/RustCrypto/traits/pull/768
+[#771]: https://github.com/RustCrypto/traits/pull/771
+[#782]: https://github.com/RustCrypto/traits/pull/782
+[#785]: https://github.com/RustCrypto/traits/pull/785
+[#795]: https://github.com/RustCrypto/traits/pull/795
+[#796]: https://github.com/RustCrypto/traits/pull/796
+[#806]: https://github.com/RustCrypto/traits/pull/806
+[#807]: https://github.com/RustCrypto/traits/pull/807
+[#809]: https://github.com/RustCrypto/traits/pull/809
+[#810]: https://github.com/RustCrypto/traits/pull/810
+[#812]: https://github.com/RustCrypto/traits/pull/812
+[#814]: https://github.com/RustCrypto/traits/pull/814
+[#815]: https://github.com/RustCrypto/traits/pull/815
+[#816]: https://github.com/RustCrypto/traits/pull/816
+[#817]: https://github.com/RustCrypto/traits/pull/817
+[#818]: https://github.com/RustCrypto/traits/pull/818
+
 ## 0.10.6 (2021-08-23)
 ### Changed
 - Bump `crypto-bigint` dependency to v0.2.4 ([#710])
@@ -12,7 +62,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 0.10.5 (2021-07-20)
 ### Changed
-- Pin `zeroize` dependency to v1.4 and `subtle` to v2.4 ([#349])
+- Pin `zeroize` dependency to v1.4 and `subtle` to v2.4 ([#689])
 
 [#689]: https://github.com/RustCrypto/traits/pull/689
 

--- a/elliptic-curve/Cargo.lock
+++ b/elliptic-curve/Cargo.lock
@@ -56,7 +56,7 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.11.0-pre"
+version = "0.11.0"
 dependencies = [
  "base64ct",
  "crypto-bigint",

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elliptic-curve"
-version = "0.11.0-pre" # Also update html_root_url in lib.rs when bumping this
+version = "0.11.0" # Also update html_root_url in lib.rs when bumping this
 description = """
 General purpose Elliptic Curve Cryptography (ECC) support, including types
 and traits for representing various elliptic curve forms, scalars, points,

--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -35,7 +35,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
-    html_root_url = "https://docs.rs/elliptic-curve/0.11.0-pre"
+    html_root_url = "https://docs.rs/elliptic-curve/0.11.0"
 )]
 
 #[cfg(feature = "alloc")]


### PR DESCRIPTION
### Added
- `ScalarCore<C>` type ([#732])
- `PrimeCurveArithmetic` trait ([#739])
- SEC1 private key support ([#762])
- `Reduce` trait ([#768])
- Re-export `ff` and `PrimeField` ([#796])
- `Encoding` bound on `Curve::UInt` ([#806])
- `scalar::IsHigh` trait ([#814], [#815])
- `Neg` impl for `NonZeroScalar<C>` ([#816])
- `AffineXCoordinate` trait ([#817])
- `serde` support for scalar and `PublicKey` types ([#818])

### Changed
- Bump `ff` + `group` to v0.11 ([#730])
- Make `SecretKey::to_jwk_string` self-zeroizing ([#742])
- Use `sec1` crate's `EncodedPoint` ([#771])
- Make `FromEncodedPoint` return a `CtOption` ([#782])
- Rust 2021 edition upgrade; MSRV to 1.56 ([#795])
- Bump `crypto-bigint` dependency to v0.3 ([#807])
- Use `sec1` crate for `pkcs8` support ([#809])
- Bump `spki` dependency to v0.5 release ([#810])
- `NonZeroScalar` is now bounded on `ScalarArithmetic` instead of
  `ProjectiveArithmetic` ([#812])

### Fixed
- `Zeroize` impl on `NonZeroScalar` ([#785])

[#730]: https://github.com/RustCrypto/traits/pull/730
[#732]: https://github.com/RustCrypto/traits/pull/732
[#739]: https://github.com/RustCrypto/traits/pull/739
[#742]: https://github.com/RustCrypto/traits/pull/742
[#762]: https://github.com/RustCrypto/traits/pull/762
[#768]: https://github.com/RustCrypto/traits/pull/768
[#771]: https://github.com/RustCrypto/traits/pull/771
[#782]: https://github.com/RustCrypto/traits/pull/782
[#785]: https://github.com/RustCrypto/traits/pull/785
[#795]: https://github.com/RustCrypto/traits/pull/795
[#796]: https://github.com/RustCrypto/traits/pull/796
[#806]: https://github.com/RustCrypto/traits/pull/806
[#807]: https://github.com/RustCrypto/traits/pull/807
[#809]: https://github.com/RustCrypto/traits/pull/809
[#810]: https://github.com/RustCrypto/traits/pull/810
[#812]: https://github.com/RustCrypto/traits/pull/812
[#814]: https://github.com/RustCrypto/traits/pull/814
[#815]: https://github.com/RustCrypto/traits/pull/815
[#816]: https://github.com/RustCrypto/traits/pull/816
[#817]: https://github.com/RustCrypto/traits/pull/817
[#818]: https://github.com/RustCrypto/traits/pull/818