### PR TITLE
elliptic-curve v0.11.1

### DIFF
--- a/crypto/Cargo.lock
+++ b/crypto/Cargo.lock
@@ -93,7 +93,7 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "crypto-bigint",
  "der",

--- a/elliptic-curve/CHANGELOG.md
+++ b/elliptic-curve/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.11.1 (2021-11-21)
+### Added
+- `NonZeroScalar::from_uint` ([#822])
+
+[#822]: https://github.com/RustCrypto/traits/pull/822
+
 ## 0.11.0 (2021-11-19)
 ### Added
 - `ScalarCore<C>` type ([#732])

--- a/elliptic-curve/Cargo.lock
+++ b/elliptic-curve/Cargo.lock
@@ -56,7 +56,7 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "base64ct",
  "crypto-bigint",

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elliptic-curve"
-version = "0.11.0" # Also update html_root_url in lib.rs when bumping this
+version = "0.11.1" # Also update html_root_url in lib.rs when bumping this
 description = """
 General purpose Elliptic Curve Cryptography (ECC) support, including types
 and traits for representing various elliptic curve forms, scalars, points,

--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -35,7 +35,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
-    html_root_url = "https://docs.rs/elliptic-curve/0.11.0"
+    html_root_url = "https://docs.rs/elliptic-curve/0.11.1"
 )]
 
 #[cfg(feature = "alloc")]


### PR DESCRIPTION
### Added
- `NonZeroScalar::from_uint` ([#822])

[#822]: https://github.com/RustCrypto/traits/pull/822