### PR TITLE
elliptic-curve: `non_zero` => `nonzero`

### DIFF
--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -98,7 +98,7 @@ pub use {
             AffineArithmetic, PrimeCurveArithmetic, ProjectiveArithmetic, ScalarArithmetic,
         },
         public_key::PublicKey,
-        scalar::{non_zero::NonZeroScalar, Scalar},
+        scalar::{nonzero::NonZeroScalar, Scalar},
     },
     ff::{self, Field, PrimeField},
     group::{self, Group},

--- a/elliptic-curve/src/ops.rs
+++ b/elliptic-curve/src/ops.rs
@@ -48,5 +48,5 @@ pub trait Reduce<UInt: Integer + ArrayEncoding>: Sized {
 /// End users can use the `Reduce` impl on `NonZeroScalar` instead.
 pub trait ReduceNonZero<UInt: Integer + ArrayEncoding>: Sized {
     /// Perform a modular reduction, returning a field element.
-    fn from_uint_reduced_non_zero(n: UInt) -> Self;
+    fn from_uint_reduced_nonzero(n: UInt) -> Self;
 }

--- a/elliptic-curve/src/scalar.rs
+++ b/elliptic-curve/src/scalar.rs
@@ -5,7 +5,7 @@ use subtle::Choice;
 pub(crate) mod core;
 
 #[cfg(feature = "arithmetic")]
-pub(crate) mod non_zero;
+pub(crate) mod nonzero;
 
 #[cfg(feature = "arithmetic")]
 use crate::ScalarArithmetic;

--- a/elliptic-curve/src/scalar/nonzero.rs
+++ b/elliptic-curve/src/scalar/nonzero.rs
@@ -207,7 +207,7 @@ where
     Scalar<C>: ReduceNonZero<I>,
 {
     fn from_uint_reduced(n: I) -> Self {
-        Self::from_uint_reduced_non_zero(n)
+        Self::from_uint_reduced_nonzero(n)
     }
 }
 
@@ -217,8 +217,8 @@ where
     I: Integer + ArrayEncoding,
     Scalar<C>: ReduceNonZero<I>,
 {
-    fn from_uint_reduced_non_zero(n: I) -> Self {
-        let scalar = Scalar::<C>::from_uint_reduced_non_zero(n);
+    fn from_uint_reduced_nonzero(n: I) -> Self {
+        let scalar = Scalar::<C>::from_uint_reduced_nonzero(n);
         debug_assert!(!bool::from(scalar.is_zero()));
         Self::new(scalar).unwrap()
     }


### PR DESCRIPTION
In #827, a `ReduceNonZero` trait was added whose method name uses an underscored `*_non_zero`.

However, there's already one bit of precedent in the public API:

- `SecretKey::to_nonzero_scalar`

Since this is already a stable API and providing precedent, for consistency this commit changes all of the unstable/unreleased APIs and internal module naming to use `nonzero` instead of `non_zero`, as this is a non-breaking change.