### PR TITLE
elliptic-curve: fix `ecdh` docs

### DIFF
--- a/elliptic-curve/src/ecdh.rs
+++ b/elliptic-curve/src/ecdh.rs
@@ -51,7 +51,7 @@ use zeroize::Zeroize;
 ///
 /// ```ignore
 /// let shared_secret = elliptic_curve::ecdh::diffie_hellman(
-///     secret_key.secret_scalar(),
+///     secret_key.to_nonzero_scalar(),
 ///     public_key.as_affine()
 /// );
 /// ```


### PR DESCRIPTION
There's an example marked `ignore` for the `diffie_hellman` function which is no longer valid. This commit fixes it.