### PR TITLE
elliptic-curve: revised `LinearCombination` trait

### DIFF
--- a/elliptic-curve/src/arithmetic.rs
+++ b/elliptic-curve/src/arithmetic.rs
@@ -1,6 +1,8 @@
 //! Elliptic curve arithmetic traits.
 
-use crate::{AffineXCoordinate, Curve, FieldBytes, IsHigh, PrimeCurve, ScalarCore};
+use crate::{
+    ops::LinearCombination, AffineXCoordinate, Curve, FieldBytes, IsHigh, PrimeCurve, ScalarCore,
+};
 use core::fmt::Debug;
 use subtle::{ConditionallySelectable, ConstantTimeEq};
 use zeroize::DefaultIsZeroes;
@@ -54,6 +56,7 @@ pub trait ProjectiveArithmetic: Curve + AffineArithmetic {
         + DefaultIsZeroes
         + From<Self::AffinePoint>
         + Into<Self::AffinePoint>
+        + LinearCombination
         + group::Curve<AffineRepr = Self::AffinePoint>
         + group::Group<Scalar = Self::Scalar>;
 }

--- a/elliptic-curve/src/dev.rs
+++ b/elliptic-curve/src/dev.rs
@@ -6,7 +6,7 @@
 use crate::{
     bigint::{Limb, U256},
     error::{Error, Result},
-    ops::Reduce,
+    ops::{LinearCombination, Reduce},
     pkcs8,
     rand_core::RngCore,
     sec1::{FromEncodedPoint, ToEncodedPoint},
@@ -540,6 +540,8 @@ impl group::Curve for ProjectivePoint {
         }
     }
 }
+
+impl LinearCombination for ProjectivePoint {}
 
 impl Add<ProjectivePoint> for ProjectivePoint {
     type Output = ProjectivePoint;

--- a/elliptic-curve/src/ops.rs
+++ b/elliptic-curve/src/ops.rs
@@ -6,7 +6,7 @@ use crypto_bigint::{ArrayEncoding, ByteArray, Integer};
 use subtle::CtOption;
 
 #[cfg(feature = "arithmetic")]
-use crate::ProjectiveArithmetic;
+use group::Group;
 
 /// Perform an inversion on a field element (i.e. base field element or scalar)
 pub trait Invert {
@@ -34,14 +34,9 @@ impl<F: ff::Field> Invert for F {
 // TODO(tarcieri): replace this with a trait from the `group` crate? (see zkcrypto/group#25)
 #[cfg(feature = "arithmetic")]
 #[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
-pub trait LinearCombination: ProjectiveArithmetic {
+pub trait LinearCombination: Group {
     /// Calculates `x * k + y * l`.
-    fn lincomb(
-        x: &Self::ProjectivePoint,
-        k: &Self::Scalar,
-        y: &Self::ProjectivePoint,
-        l: &Self::Scalar,
-    ) -> Self::ProjectivePoint {
+    fn lincomb(x: &Self, k: &Self::Scalar, y: &Self, l: &Self::Scalar) -> Self {
         (*x * k) + (*y * l)
     }
 }


### PR DESCRIPTION
Changes `LinearCombination` to be impl'd on the `ProjectivePoint` type for a given curve, rather than the curve ZST.

This better fits the trait-based structure used by the `group` crate, and also makes sense as `ProjectivePoint` is the return type, so it's almost certain to be in scope (as opposed to importing a curve ZST to do the operation)

This is technically a breaking change as the `LinearCombination` trait was just released an hour ago in v0.11.4, but given that it's unlikely anyone is using it yet, so it can probably be safely yanked and the updated version included in a new release.