### PR TITLE
elliptic-curve v0.11.5

### DIFF
--- a/elliptic-curve/CHANGELOG.md
+++ b/elliptic-curve/CHANGELOG.md
@@ -4,19 +4,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.11.4 (2021-12-04)
+## 0.11.5 (2021-12-05)
+### Changed
+- Revised `LinearCombination` trait ([#835])
+
+[#835]: https://github.com/RustCrypto/traits/pull/835
+
+## 0.11.4 (2021-12-04) [YANKED]
 ### Added
 - `LinearCombination` trait ([#832])
 
 [#832]: https://github.com/RustCrypto/traits/pull/832
 
-## 0.11.3 (2021-12-03)
+## 0.11.3 (2021-12-03) [YANKED]
 ### Added
 - `ReduceNonZero` trait ([#827])
 
 [#827]: https://github.com/RustCrypto/traits/pull/827
 
-## 0.11.2 (2021-12-03)
+## 0.11.2 (2021-12-03) [YANKED]
 ### Changed
 - Bump `pem-rfc7468` dependency to v0.3 ([#825])
 

--- a/elliptic-curve/Cargo.lock
+++ b/elliptic-curve/Cargo.lock
@@ -56,7 +56,7 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.11.4"
+version = "0.11.5"
 dependencies = [
  "base64ct",
  "crypto-bigint",

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elliptic-curve"
-version = "0.11.4" # Also update html_root_url in lib.rs when bumping this
+version = "0.11.5" # Also update html_root_url in lib.rs when bumping this
 description = """
 General purpose Elliptic Curve Cryptography (ECC) support, including types
 and traits for representing various elliptic curve forms, scalars, points,

--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -46,7 +46,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
-    html_root_url = "https://docs.rs/elliptic-curve/0.11.4"
+    html_root_url = "https://docs.rs/elliptic-curve/0.11.5"
 )]
 
 #[cfg(feature = "alloc")]


### PR DESCRIPTION
### Changed
- Revised `LinearCombination` trait ([#835])

[#835]: https://github.com/RustCrypto/traits/pull/835