### PR TITLE
Add optional support for bytes crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,6 +7,7 @@ name = "aead"
 version = "0.4.3"
 dependencies = [
  "blobby",
+ "bytes",
  "generic-array",
  "heapless",
  "rand_core",
@@ -76,6 +77,12 @@ name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+
+[[package]]
+name = "bytes"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 
 [[package]]
 name = "cfg-if"

--- a/aead/Cargo.toml
+++ b/aead/Cargo.toml
@@ -20,6 +20,7 @@ generic-array = { version = "0.14", default-features = false }
 # optional dependencies
 blobby = { version = "0.3", optional = true }
 heapless = { version = "0.7", optional = true, default-features = false }
+bytes = { version = "1.1.0", optional = true }
 rand_core = { version = "0.6", optional = true }
 
 [features]

--- a/aead/src/lib.rs
+++ b/aead/src/lib.rs
@@ -43,6 +43,10 @@ pub use generic_array::{self, typenum::consts};
 #[cfg_attr(docsrs, doc(cfg(feature = "heapless")))]
 pub use heapless;
 
+#[cfg(feature = "bytes")]
+#[cfg_attr(docsrs, doc(cfg(feature = "heapless")))]
+pub use bytes;
+
 #[cfg(feature = "rand_core")]
 #[cfg_attr(docsrs, doc(cfg(feature = "rand_core")))]
 pub use rand_core;
@@ -52,6 +56,8 @@ use generic_array::{typenum::Unsigned, ArrayLength, GenericArray};
 
 #[cfg(feature = "alloc")]
 use alloc::vec::Vec;
+use bytes::BytesMut;
+use std::io::Bytes;
 
 #[cfg(feature = "rand_core")]
 use rand_core::{CryptoRng, RngCore};
@@ -503,6 +509,25 @@ impl Buffer for Vec<u8> {
 
     fn truncate(&mut self, len: usize) {
         Vec::truncate(self, len);
+    }
+}
+
+#[cfg(feature = "bytes")]
+impl Buffer for bytes::BytesMut {
+    fn len(&self) -> usize {
+        BytesMut::len(self)
+    }
+
+    fn is_empty(&self) -> bool {
+        BytesMut::is_empty(self)
+    }
+
+    fn extend_from_slice(&mut self, other: &[u8]) -> Result<()> {
+        Ok(BytesMut::extend_from_slice(self, other))
+    }
+
+    fn truncate(&mut self, len: usize) {
+        BytesMut::truncate(self, len);
     }
 }
 


### PR DESCRIPTION
The `BytesMut` struct from `bytes` crate already provides an interface that is basically same as the `Buffer` trait.

This PR adds an optional dependency on the bytes crate, and implements the buffer for the `BytesMut`. This should be useful when writing network protocols, that require encryption.