### PR TITLE
rand_core fixes for digest and crypto-common

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,7 +94,7 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "generic-array",
  "rand_core",
@@ -111,7 +111,7 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "blobby",
  "block-buffer 0.10.0",

--- a/crypto-common/CHANGELOG.md
+++ b/crypto-common/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.10.1 (2021-12-14)
+## 0.1.1 (2021-12-14)
 ### Added
 - `rand_core` re-export and proper exposure of key/IV generation methods on docs.rs ([#847])
 

--- a/crypto-common/CHANGELOG.md
+++ b/crypto-common/CHANGELOG.md
@@ -5,5 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.10.1 (2021-12-14)
+### Added
+- `rand_core` re-export and proper exposure of key/IV generation methods on docs.rs ([#847])
+
+[#847]: https://github.com/RustCrypto/traits/pull/847
+
 ## 0.1.0 (2021-12-07)
 - Initial release

--- a/crypto-common/Cargo.toml
+++ b/crypto-common/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "crypto-common"
 description = "Common cryptographic traits"
-version = "0.1.0"
+version = "0.1.1" # Also update html_root_url in lib.rs when bumping this
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
@@ -17,3 +17,7 @@ rand_core = { version = "0.6", optional = true }
 
 [features]
 std = []
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crypto-common/src/lib.rs
+++ b/crypto-common/src/lib.rs
@@ -3,14 +3,18 @@
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc(
-    html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg"
+    html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg",
+    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg",
+    html_root_url = "https://docs.rs/crypto-common/0.1.1"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]
 
 #[cfg(feature = "std")]
 extern crate std;
+
+#[cfg(feature = "rand_core")]
+pub use rand_core;
 
 use core::fmt;
 use generic_array::{typenum::Unsigned, ArrayLength, GenericArray};

--- a/digest/CHANGELOG.md
+++ b/digest/CHANGELOG.md
@@ -1,4 +1,4 @@
-    # Changelog
+# Changelog
 
 All notable changes to this project will be documented in this file.
 

--- a/digest/CHANGELOG.md
+++ b/digest/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Changelog
+    # Changelog
 
 All notable changes to this project will be documented in this file.
 
@@ -8,12 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## 0.10.1 (2021-12-14)
 ### Added
 - `Update::chain` and `Digest::new_with_prefix` methods. ([#846])
+- `Mac::generate_key` method. ([#847])
 
 ### Fixed
 - Doc cfg attribute for CtOutput and MacError. ([#842])
+- Expose `KeyInit::generate_key` method in docs. ([#847])
 
 [#842]: https://github.com/RustCrypto/traits/pull/842
 [#846]: https://github.com/RustCrypto/traits/pull/846
+[#847]: https://github.com/RustCrypto/traits/pull/847
 
 ## 0.10.0 (2021-12-07)
 ### Changed

--- a/digest/Cargo.toml
+++ b/digest/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "digest"
 description = "Traits for cryptographic hash functions"
-version = "0.10.0"
+version = "0.10.1" # Also update html_root_url in lib.rs when bumping this
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
@@ -13,7 +13,7 @@ categories = ["cryptography", "no-std"]
 
 [dependencies]
 generic-array = "0.14"
-crypto-common = { version = "0.1", path = "../crypto-common" }
+crypto-common = { version = "0.1.1", path = "../crypto-common" }
 
 block-buffer = { version = "0.10", optional = true }
 subtle = { version = "=2.4", default-features = false, optional = true }
@@ -23,6 +23,7 @@ blobby = { version = "0.3", optional = true }
 default = ["core-api"]
 core-api = ["block-buffer"] # Enable Core API traits
 mac = ["subtle"] # Enable MAC traits
+rand_core = ["crypto-common/rand_core"] # Enable random key generation methods
 alloc = []
 std = ["alloc", "crypto-common/std"]
 dev = ["blobby"]

--- a/digest/src/lib.rs
+++ b/digest/src/lib.rs
@@ -27,8 +27,9 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![forbid(unsafe_code)]
 #![doc(
-    html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
-    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg"
+    html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg",
+    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg",
+    html_root_url = "https://docs.rs/digest/0.10.1"
 )]
 #![warn(missing_docs, rust_2018_idioms)]
 
@@ -38,6 +39,9 @@ extern crate alloc;
 
 #[cfg(feature = "std")]
 extern crate std;
+
+#[cfg(feature = "rand_core")]
+pub use crypto_common::rand_core;
 
 #[cfg(feature = "alloc")]
 use alloc::boxed::Box;

--- a/digest/src/mac.rs
+++ b/digest/src/mac.rs
@@ -23,7 +23,7 @@ pub trait Mac: KeySizeUser + OutputSizeUser + Sized {
     /// Generate random key using the provided [`CryptoRng`].
     #[cfg(feature = "rand_core")]
     #[cfg_attr(docsrs, doc(cfg(feature = "rand_core")))]
-    fn generate_key(mut rng: impl CryptoRng + RngCore) -> Key<Self>;
+    fn generate_key(rng: impl CryptoRng + RngCore) -> Key<Self>;
 
     /// Create new value from variable size key.
     fn new_from_slice(key: &[u8]) -> Result<Self, InvalidLength>;
@@ -162,7 +162,7 @@ impl<T: KeyInit + Update + FixedOutput + MacMarker> Mac for T {
     #[cfg_attr(docsrs, doc(cfg(feature = "rand_core")))]
     #[inline]
     fn generate_key(rng: impl CryptoRng + RngCore) -> Key<Self> {
-        KeyInit::generate_key(rng)
+        <T as KeyInit>::generate_key(rng)
     }
 }
 


### PR DESCRIPTION
Properly exposes docs for random key/IV generation methods, re-exports `rand_core`, and adds `Mac::generate_key` method which wraps `KeyInit::generate_key`.