### PR TITLE
elliptic-curve v0.11.6

### DIFF
--- a/crypto/Cargo.lock
+++ b/crypto/Cargo.lock
@@ -113,7 +113,7 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.11.5"
+version = "0.11.6"
 dependencies = [
  "crypto-bigint",
  "der",

--- a/elliptic-curve/CHANGELOG.md
+++ b/elliptic-curve/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.11.6 (2021-12-20)
+### Added
+- Type conversions chart ([#852])
+
+[#852]: https://github.com/RustCrypto/traits/pull/852
+
 ## 0.11.5 (2021-12-05)
 ### Changed
 - Revised `LinearCombination` trait ([#835])

--- a/elliptic-curve/Cargo.lock
+++ b/elliptic-curve/Cargo.lock
@@ -56,7 +56,7 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.11.5"
+version = "0.11.6"
 dependencies = [
  "base64ct",
  "crypto-bigint",

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elliptic-curve"
-version = "0.11.5" # Also update html_root_url in lib.rs when bumping this
+version = "0.11.6" # Also update html_root_url in lib.rs when bumping this
 description = """
 General purpose Elliptic Curve Cryptography (ECC) support, including types
 and traits for representing various elliptic curve forms, scalars, points,

--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -1,3 +1,12 @@
+#![no_std]
+#![cfg_attr(docsrs, feature(doc_cfg))]
+#![forbid(unsafe_code, clippy::unwrap_used)]
+#![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
+    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
+    html_root_url = "https://docs.rs/elliptic-curve/0.11.6"
+)]
 #![doc = include_str!("../README.md")]
 
 //! ## Usage
@@ -45,16 +54,6 @@
 //! [`p256`]: https://github.com/RustCrypto/elliptic-curves/tree/master/p256
 //! [`p384`]: https://github.com/RustCrypto/elliptic-curves/tree/master/p384
 //! [`ecdsa`]: https://github.com/RustCrypto/signatures/tree/master/ecdsa
-
-#![no_std]
-#![cfg_attr(docsrs, feature(doc_cfg))]
-#![forbid(unsafe_code, clippy::unwrap_used)]
-#![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
-#![doc(
-    html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
-    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
-    html_root_url = "https://docs.rs/elliptic-curve/0.11.5"
-)]
 
 #[cfg(feature = "alloc")]
 #[allow(unused_imports)]


### PR DESCRIPTION
### Added
- Type conversions chart ([#852])

[#852]: https://github.com/RustCrypto/traits/pull/852