### PR TITLE
kem: minor fixups

### DIFF
--- a/kem/Cargo.lock
+++ b/kem/Cargo.lock
@@ -330,7 +330,7 @@ dependencies = [
 
 [[package]]
 name = "kem"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "generic-array",
  "hpke",

--- a/kem/Cargo.toml
+++ b/kem/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name          = "kem"
 description   = "Traits for key encapsulation mechanisms"
-version       = "0.1.0"
+version       = "0.0.0"
 authors       = ["RustCrypto Developers"]
 license       = "Apache-2.0 OR MIT"
 documentation = "https://docs.rs/kem"
@@ -10,6 +10,7 @@ readme        = "README.md"
 edition       = "2021"
 keywords      = ["crypto"]
 categories    = ["cryptography", "no-std"]
+rust-version  = "1.56"
 
 # Hack to allow this crate to coexist with pre-2021 edition crates
 [workspace]

--- a/kem/README.md
+++ b/kem/README.md
@@ -51,7 +51,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/kem/badge.svg
 [docs-link]: https://docs.rs/kem/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.41+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.56+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260048-signatures
 [build-image]: https://github.com/RustCrypto/traits/workflows/kem/badge.svg?branch=master&event=push


### PR DESCRIPTION
- Bump `version` down to 0.0.0 as it hasn't been released
- Add `rust-version` to Cargo.toml
- Fix MSRV badge in README.md

cc @rozbb