### PR TITLE
signature v1.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -258,7 +258,7 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "1.5.0-pre"
+version = "1.5.0"
 dependencies = [
  "digest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex-literal",

--- a/crypto/Cargo.lock
+++ b/crypto/Cargo.lock
@@ -218,7 +218,7 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "1.5.0-pre"
+version = "1.5.0"
 
 [[package]]
 name = "spki"

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -25,7 +25,7 @@ digest = { version = "0.10", optional = true }
 elliptic-curve = { version = "0.11", optional = true, path = "../elliptic-curve" }
 mac = { version = "0.11", package = "crypto-mac", optional = true }
 password-hash = { version = "0.3", optional = true, path = "../password-hash" }
-signature = { version = "=1.5.0-pre", optional = true, default-features = false, path = "../signature" }
+signature = { version = "1.5", optional = true, default-features = false, path = "../signature" }
 universal-hash = { version = "0.4", optional = true, path = "../universal-hash" }
 
 [features]

--- a/signature/CHANGELOG.md
+++ b/signature/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.5.0 (2022-01-04)
+### Changed
+- Bump `digest` dependency to v0.10 ([#850])
+- Bump `signature-derive` dependency to v1.0.0-pre.4 ([#866])
+
+[#850]: https://github.com/RustCrypto/traits/pull/850
+[#866]: https://github.com/RustCrypto/traits/pull/866
+
 ## 1.4.0 (2021-10-20)
 ### Added
 - Re-export `rand_core` when the `rand-preview` feature is enabled ([#683])

--- a/signature/Cargo.toml
+++ b/signature/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name          = "signature"
 description   = "Traits for cryptographic signature algorithms (e.g. ECDSA, Ed25519)"
-version       = "1.5.0-pre" # Also update html_root_url in lib.rs when bumping this
+version       = "1.5.0" # Also update html_root_url in lib.rs when bumping this
 authors       = ["RustCrypto Developers"]
 license       = "Apache-2.0 OR MIT"
 documentation = "https://docs.rs/signature"

--- a/signature/async/Cargo.toml
+++ b/signature/async/Cargo.toml
@@ -13,7 +13,7 @@ categories    = ["cryptography", "no-std"]
 
 [dependencies]
 async-trait = "0.1"
-signature = { version = "=1.5.0-pre", path = ".." }
+signature = { version = "1.5", path = ".." }
 
 [features]
 digest = ["signature/digest-preview"]

--- a/signature/src/lib.rs
+++ b/signature/src/lib.rs
@@ -160,7 +160,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
-    html_root_url = "https://docs.rs/signature/1.4.0"
+    html_root_url = "https://docs.rs/signature/1.5.0"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]


### PR DESCRIPTION
### Changed
- Bump `digest` dependency to v0.10 ([#850])
- Bump `signature-derive` dependency to v1.0.0-pre.4 ([#866])

[#850]: https://github.com/RustCrypto/traits/pull/850
[#866]: https://github.com/RustCrypto/traits/pull/866