### PR TITLE
elliptic-curve: make `ExpandMsg` fallible

### DIFF
--- a/elliptic-curve/src/hash2field.rs
+++ b/elliptic-curve/src/hash2field.rs
@@ -5,6 +5,8 @@ mod expand_msg_xof;
 pub use expand_msg::*;
 pub use expand_msg_xmd::*;
 pub use expand_msg_xof::*;
+
+use crate::Result;
 use generic_array::{typenum::Unsigned, ArrayLength, GenericArray};
 
 /// The trait for helping to convert to a scalar
@@ -18,16 +20,17 @@ pub trait FromOkm {
 
 /// Convert an arbitrary byte sequence according to
 /// <https://tools.ietf.org/html/draft-irtf-cfrg-hash-to-curve-11#section-5.3>
-pub fn hash_to_field<E, T>(data: &[u8], domain: &'static [u8], out: &mut [T])
+pub fn hash_to_field<E, T>(data: &[u8], domain: &'static [u8], out: &mut [T]) -> Result<()>
 where
     E: ExpandMsg,
     T: FromOkm + Default,
 {
     let len_in_bytes = T::Length::to_usize() * out.len();
     let mut tmp = GenericArray::<u8, <T as FromOkm>::Length>::default();
-    let mut expander = E::expand_message(data, domain, len_in_bytes);
+    let mut expander = E::expand_message(data, domain, len_in_bytes)?;
     for o in out.iter_mut() {
         expander.fill_bytes(&mut tmp);
         *o = T::from_okm(&tmp);
     }
+    Ok(())
 }

--- a/elliptic-curve/src/hash2field/expand_msg.rs
+++ b/elliptic-curve/src/hash2field/expand_msg.rs
@@ -1,3 +1,4 @@
+use crate::Result;
 use digest::{Digest, ExtendableOutputDirty, Update, XofReader};
 use generic_array::{ArrayLength, GenericArray};
 
@@ -7,11 +8,11 @@ const OVERSIZE_DST_SALT: &[u8] = b"H2C-OVERSIZE-DST-";
 const MAX_DST_LEN: usize = 255;
 
 /// Trait for types implementing expand_message interface for hash_to_field
-pub trait ExpandMsg {
+pub trait ExpandMsg: Sized {
     /// Expands `msg` to the required number of bytes
     /// Returns an expander that can be used to call `read` until enough
     /// bytes have been consumed
-    fn expand_message(msg: &[u8], dst: &'static [u8], len_in_bytes: usize) -> Self;
+    fn expand_message(msg: &[u8], dst: &'static [u8], len_in_bytes: usize) -> Result<Self>;
 
     /// Fill the array with the expanded bytes
     fn fill_bytes(&mut self, okm: &mut [u8]);

--- a/elliptic-curve/src/hash2field/expand_msg_xof.rs
+++ b/elliptic-curve/src/hash2field/expand_msg_xof.rs
@@ -1,5 +1,5 @@
 use super::ExpandMsg;
-use crate::hash2field::Domain;
+use crate::{hash2field::Domain, Result};
 use digest::{ExtendableOutput, ExtendableOutputDirty, Update, XofReader};
 use generic_array::typenum::U32;
 
@@ -16,7 +16,7 @@ impl<HashT> ExpandMsg for ExpandMsgXof<HashT>
 where
     HashT: Default + ExtendableOutput + ExtendableOutputDirty + Update,
 {
-    fn expand_message(msg: &[u8], dst: &'static [u8], len_in_bytes: usize) -> Self {
+    fn expand_message(msg: &[u8], dst: &'static [u8], len_in_bytes: usize) -> Result<Self> {
         let domain = Domain::<U32>::xof::<HashT>(dst);
         let reader = HashT::default()
             .chain(msg)
@@ -24,7 +24,7 @@ where
             .chain(domain.data())
             .chain([domain.len() as u8])
             .finalize_xof();
-        Self { reader }
+        Ok(Self { reader })
     }
 
     fn fill_bytes(&mut self, okm: &mut [u8]) {


### PR DESCRIPTION
As noted on #865 there are some potential overflow problems constructing the messages used for expansion, particularly around input lengths.

This commit changes `ExpandMsg::expand_message`, and all of its transitive callers, to be fallible in order to handle these cases.

cc @mikelodder7 @daxpedda