### PR TITLE
`ExpandMsg` improvements

### DIFF
--- a/elliptic-curve/Cargo.lock
+++ b/elliptic-curve/Cargo.lock
@@ -21,6 +21,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1d36a02058e76b040de25a4464ba1c80935655595b661505c8b39b664828b95"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -31,6 +40,15 @@ name = "const-oid"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4c78c047431fee22c1a7bb92e00ad095a02a983affe4d8a72e2a2c62c1b94f3"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95059428f66df56b63431fdb4e1947ed2190586af5c5a8a8b71122bdf5a7f469"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "crypto-bigint"
@@ -45,6 +63,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d6b536309245c849479fba3da410962a43ed8e51c26b729208ec0ac2798d0"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "der"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -56,10 +83,12 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.9.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+checksum = "b697d66081d42af4fba142d56918a3cb21dc8eb63372c6b85d14f44fb9c5979b"
 dependencies = [
+ "block-buffer",
+ "crypto-common",
  "generic-array",
 ]
 
@@ -80,6 +109,7 @@ dependencies = [
  "sec1",
  "serde",
  "serde_json",
+ "sha2",
  "subtle",
  "zeroize",
 ]
@@ -220,6 +250,17 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99c3bd8169c58782adad9290a9af5939994036b76187f7b4f0e6de91dbbfc0ec"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -29,7 +29,7 @@ zeroize = { version = "1", default-features = false }
 
 # optional dependencies
 base64ct = { version = "1", optional = true, default-features = false }
-digest = { version = "0.9", optional = true, default-features = false }
+digest = { version = "0.10", optional = true }
 ff = { version = "0.11", optional = true, default-features = false }
 group = { version = "0.11", optional = true, default-features = false }
 hex-literal = { version = "0.3", optional = true }
@@ -40,6 +40,7 @@ serde_json = { version = "1", optional = true, default-features = false, feature
 
 [dev-dependencies]
 hex-literal = "0.3"
+sha2 = "0.10"
 
 [features]
 default = ["arithmetic"]

--- a/elliptic-curve/src/hash2curve/group_digest.rs
+++ b/elliptic-curve/src/hash2curve/group_digest.rs
@@ -40,7 +40,7 @@ pub trait GroupDigest {
     /// let pt = ProjectivePoint::hash_from_bytes::<hash2field::ExpandMsgXof<sha3::Shake256>>(b"test data", b"CURVE_XOF:SHAKE-256_SSWU_RO_");
     /// ```
     ///
-    fn hash_from_bytes<X>(msg: &[u8], dst: &'static [u8]) -> Self::Output
+    fn hash_from_bytes<X>(msg: &[u8], dst: &[u8]) -> Self::Output
     where
         X: ExpandMsg<Prod<<Self::FieldElement as FromOkm>::Length, U2>>,
         <Self::FieldElement as FromOkm>::Length: Mul<U2>,
@@ -70,7 +70,7 @@ pub trait GroupDigest {
     /// uniformly random in G: the set of possible outputs of
     /// encode_to_curve is only a fraction of the points in G, and some
     /// points in this set are more likely to be output than others.
-    fn encode_from_bytes<X>(msg: &[u8], dst: &'static [u8]) -> Self::Output
+    fn encode_from_bytes<X>(msg: &[u8], dst: &[u8]) -> Self::Output
     where
         X: ExpandMsg<Prod<<Self::FieldElement as FromOkm>::Length, U1>>,
         <Self::FieldElement as FromOkm>::Length: Mul<U1>,

--- a/elliptic-curve/src/hash2curve/group_digest.rs
+++ b/elliptic-curve/src/hash2curve/group_digest.rs
@@ -2,10 +2,8 @@ use core::ops::Mul;
 
 use super::MapToCurve;
 use crate::hash2field::{hash_to_field, ExpandMsg, FromOkm};
-use generic_array::{
-    typenum::{Prod, U1, U2},
-    ArrayLength,
-};
+use generic_array::typenum::{Prod, U1, U2};
+use generic_array::ArrayLength;
 use group::cofactor::CofactorGroup;
 
 /// Adds hashing arbitrary byte sequences to a valid group element

--- a/elliptic-curve/src/hash2curve/group_digest.rs
+++ b/elliptic-curve/src/hash2curve/group_digest.rs
@@ -1,5 +1,11 @@
+use core::ops::Mul;
+
 use super::MapToCurve;
 use crate::hash2field::{hash_to_field, ExpandMsg, FromOkm};
+use generic_array::{
+    typenum::{Prod, U1, U2},
+    ArrayLength,
+};
 use group::cofactor::CofactorGroup;
 
 /// Adds hashing arbitrary byte sequences to a valid group element
@@ -34,9 +40,13 @@ pub trait GroupDigest {
     /// let pt = ProjectivePoint::hash_from_bytes::<hash2field::ExpandMsgXof<sha3::Shake256>>(b"test data", b"CURVE_XOF:SHAKE-256_SSWU_RO_");
     /// ```
     ///
-    fn hash_from_bytes<X: ExpandMsg>(msg: &[u8], dst: &'static [u8]) -> Self::Output {
-        let mut u = [Self::FieldElement::default(), Self::FieldElement::default()];
-        hash_to_field::<X, _>(msg, dst, &mut u);
+    fn hash_from_bytes<X>(msg: &[u8], dst: &'static [u8]) -> Self::Output
+    where
+        X: ExpandMsg<Prod<<Self::FieldElement as FromOkm>::Length, U2>>,
+        <Self::FieldElement as FromOkm>::Length: Mul<U2>,
+        Prod<<Self::FieldElement as FromOkm>::Length, U2>: ArrayLength<u8>,
+    {
+        let u = hash_to_field::<X, _, U2>(msg, dst);
         let q0 = Self::Output::map_to_curve(u[0]);
         let q1 = Self::Output::map_to_curve(u[1]);
         // Ideally we could add and then clear cofactor once
@@ -60,9 +70,13 @@ pub trait GroupDigest {
     /// uniformly random in G: the set of possible outputs of
     /// encode_to_curve is only a fraction of the points in G, and some
     /// points in this set are more likely to be output than others.
-    fn encode_from_bytes<X: ExpandMsg>(msg: &[u8], dst: &'static [u8]) -> Self::Output {
-        let mut u = [Self::FieldElement::default()];
-        hash_to_field::<X, _>(msg, dst, &mut u);
+    fn encode_from_bytes<X>(msg: &[u8], dst: &'static [u8]) -> Self::Output
+    where
+        X: ExpandMsg<Prod<<Self::FieldElement as FromOkm>::Length, U1>>,
+        <Self::FieldElement as FromOkm>::Length: Mul<U1>,
+        Prod<<Self::FieldElement as FromOkm>::Length, U1>: ArrayLength<u8>,
+    {
+        let u = hash_to_field::<X, _, U1>(msg, dst);
         let q0 = Self::Output::map_to_curve(u[0]);
         q0.clear_cofactor()
     }

--- a/elliptic-curve/src/hash2field.rs
+++ b/elliptic-curve/src/hash2field.rs
@@ -2,10 +2,13 @@ mod expand_msg;
 mod expand_msg_xmd;
 mod expand_msg_xof;
 
+use core::ops::Mul;
+
 pub use expand_msg::*;
 pub use expand_msg_xmd::*;
 pub use expand_msg_xof::*;
-use generic_array::{typenum::Unsigned, ArrayLength, GenericArray};
+use generic_array::{ArrayLength, GenericArray};
+use generic_array::typenum::Prod;
 
 /// The trait for helping to convert to a scalar
 pub trait FromOkm {
@@ -18,16 +21,22 @@ pub trait FromOkm {
 
 /// Convert an arbitrary byte sequence according to
 /// <https://tools.ietf.org/html/draft-irtf-cfrg-hash-to-curve-11#section-5.3>
-pub fn hash_to_field<E, T>(data: &[u8], domain: &'static [u8], out: &mut [T])
+pub fn hash_to_field<E, T, O: ArrayLength<T>>(
+    data: &[u8],
+    domain: &'static [u8],
+) -> GenericArray<T, O>
 where
-    E: ExpandMsg,
+    E: ExpandMsg<Prod<T::Length, O>>,
     T: FromOkm + Default,
+    T::Length: Mul<O>,
+    Prod<T::Length, O>: ArrayLength<u8>,
 {
-    let len_in_bytes = T::Length::to_usize() * out.len();
     let mut tmp = GenericArray::<u8, <T as FromOkm>::Length>::default();
-    let mut expander = E::expand_message(data, domain, len_in_bytes);
+    let mut expander = E::expand_message(data, domain);
+    let mut out = GenericArray::default();
     for o in out.iter_mut() {
         expander.fill_bytes(&mut tmp);
         *o = T::from_okm(&tmp);
     }
+    out
 }

--- a/elliptic-curve/src/hash2field.rs
+++ b/elliptic-curve/src/hash2field.rs
@@ -7,7 +7,7 @@ use core::ops::Mul;
 pub use expand_msg::*;
 pub use expand_msg_xmd::*;
 pub use expand_msg_xof::*;
-use generic_array::typenum::Prod;
+use generic_array::typenum::{Prod, Unsigned};
 use generic_array::{ArrayLength, GenericArray};
 
 /// The trait for helping to convert to a scalar
@@ -21,22 +21,18 @@ pub trait FromOkm {
 
 /// Convert an arbitrary byte sequence according to
 /// <https://tools.ietf.org/html/draft-irtf-cfrg-hash-to-curve-11#section-5.3>
-pub fn hash_to_field<E, T, O: ArrayLength<T>>(
-    data: &[u8],
-    domain: &'static [u8],
-) -> GenericArray<T, O>
+pub fn hash_to_field<E, T, O: ArrayLength<T>>(data: &[u8], domain: &[u8]) -> GenericArray<T, O>
 where
     E: ExpandMsg<Prod<T::Length, O>>,
     T: FromOkm + Default,
     T::Length: Mul<O>,
     Prod<T::Length, O>: ArrayLength<u8>,
 {
-    let mut tmp = GenericArray::<u8, <T as FromOkm>::Length>::default();
-    let mut expander = E::expand_message(data, domain);
-    let mut out = GenericArray::default();
-    for o in out.iter_mut() {
-        expander.fill_bytes(&mut tmp);
-        *o = T::from_okm(&tmp);
-    }
-    out
+    let uniform_bytes = E::expand_message(data, domain);
+
+    uniform_bytes
+        .chunks_exact(T::Length::to_usize())
+        .map(GenericArray::from_slice)
+        .map(T::from_okm)
+        .collect()
 }

--- a/elliptic-curve/src/hash2field.rs
+++ b/elliptic-curve/src/hash2field.rs
@@ -7,8 +7,8 @@ use core::ops::Mul;
 pub use expand_msg::*;
 pub use expand_msg_xmd::*;
 pub use expand_msg_xof::*;
-use generic_array::{ArrayLength, GenericArray};
 use generic_array::typenum::Prod;
+use generic_array::{ArrayLength, GenericArray};
 
 /// The trait for helping to convert to a scalar
 pub trait FromOkm {

--- a/elliptic-curve/src/hash2field/expand_msg.rs
+++ b/elliptic-curve/src/hash2field/expand_msg.rs
@@ -9,13 +9,8 @@ const MAX_DST_LEN: usize = 255;
 
 /// Trait for types implementing expand_message interface for hash_to_field
 pub trait ExpandMsg<L: ArrayLength<u8>> {
-    /// Expands `msg` to the required number of bytes
-    /// Returns an expander that can be used to call `read` until enough
-    /// bytes have been consumed
-    fn expand_message(msg: &[u8], dst: &'static [u8]) -> Self;
-
-    /// Fill the array with the expanded bytes
-    fn fill_bytes(&mut self, okm: &mut [u8]);
+    /// Expands `msg` to the required number of bytes in `L`
+    fn expand_message(msg: &[u8], dst: &[u8]) -> GenericArray<u8, L>;
 }
 
 /// The domain separation tag
@@ -23,21 +18,21 @@ pub trait ExpandMsg<L: ArrayLength<u8>> {
 /// Implements [section 5.4.3 of `draft-irtf-cfrg-hash-to-curve-13`][dst].
 ///
 /// [dst]: https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-hash-to-curve-13#section-5.4.3
-pub(crate) enum Domain<L>
+pub(crate) enum Domain<'a, L>
 where
     L: ArrayLength<u8> + IsLessOrEqual<U256>,
 {
     /// > 255
     Hashed(GenericArray<u8, L>),
     /// <= 255
-    Array(&'static [u8]),
+    Array(&'a [u8]),
 }
 
-impl<L> Domain<L>
+impl<'a, L> Domain<'a, L>
 where
     L: ArrayLength<u8> + IsLessOrEqual<U256>,
 {
-    pub fn xof<X>(dst: &'static [u8]) -> Self
+    pub fn xof<X>(dst: &'a [u8]) -> Self
     where
         X: Default + ExtendableOutputDirty + Update,
     {
@@ -54,7 +49,7 @@ where
         }
     }
 
-    pub fn xmd<X>(dst: &'static [u8]) -> Self
+    pub fn xmd<X>(dst: &'a [u8]) -> Self
     where
         X: Digest<OutputSize = L>,
     {

--- a/elliptic-curve/src/hash2field/expand_msg.rs
+++ b/elliptic-curve/src/hash2field/expand_msg.rs
@@ -1,4 +1,4 @@
-use digest::{Digest, ExtendableOutputDirty, Update, XofReader};
+use digest::{Digest, ExtendableOutput, Update, XofReader};
 use generic_array::typenum::{IsLessOrEqual, U256};
 use generic_array::{ArrayLength, GenericArray};
 
@@ -34,14 +34,14 @@ where
 {
     pub fn xof<X>(dst: &'a [u8]) -> Self
     where
-        X: Default + ExtendableOutputDirty + Update,
+        X: Default + ExtendableOutput + Update,
     {
         if dst.len() > MAX_DST_LEN {
             let mut data = GenericArray::<u8, L>::default();
             X::default()
                 .chain(OVERSIZE_DST_SALT)
                 .chain(dst)
-                .finalize_xof_dirty()
+                .finalize_xof()
                 .read(&mut data);
             Self::Hashed(data)
         } else {
@@ -51,7 +51,7 @@ where
 
     pub fn xmd<X>(dst: &'a [u8]) -> Self
     where
-        X: Digest<OutputSize = L>,
+        X: Digest<OutputSize = L> + Update,
     {
         if dst.len() > MAX_DST_LEN {
             Self::Hashed(X::new().chain(OVERSIZE_DST_SALT).chain(dst).finalize())

--- a/elliptic-curve/src/hash2field/expand_msg.rs
+++ b/elliptic-curve/src/hash2field/expand_msg.rs
@@ -7,11 +7,11 @@ const OVERSIZE_DST_SALT: &[u8] = b"H2C-OVERSIZE-DST-";
 const MAX_DST_LEN: usize = 255;
 
 /// Trait for types implementing expand_message interface for hash_to_field
-pub trait ExpandMsg {
+pub trait ExpandMsg<L: ArrayLength<u8>> {
     /// Expands `msg` to the required number of bytes
     /// Returns an expander that can be used to call `read` until enough
     /// bytes have been consumed
-    fn expand_message(msg: &[u8], dst: &'static [u8], len_in_bytes: usize) -> Self;
+    fn expand_message(msg: &[u8], dst: &'static [u8]) -> Self;
 
     /// Fill the array with the expanded bytes
     fn fill_bytes(&mut self, okm: &mut [u8]);

--- a/elliptic-curve/src/hash2field/expand_msg_xmd.rs
+++ b/elliptic-curve/src/hash2field/expand_msg_xmd.rs
@@ -2,7 +2,8 @@ use core::marker::PhantomData;
 use core::ops::Mul;
 
 use super::{Domain, ExpandMsg};
-use digest::{BlockInput, Digest};
+use digest::core_api::BlockSizeUser;
+use digest::{Digest, Update};
 use generic_array::typenum::{IsLess, IsLessOrEqual, NonZero, Prod, Unsigned, U255, U256, U65536};
 use generic_array::{ArrayLength, GenericArray};
 use subtle::{Choice, ConditionallySelectable};
@@ -10,14 +11,14 @@ use subtle::{Choice, ConditionallySelectable};
 /// Placeholder type for implementing expand_message_xmd based on a hash function
 pub struct ExpandMsgXmd<HashT>(PhantomData<HashT>)
 where
-    HashT: Digest + BlockInput,
+    HashT: Digest + BlockSizeUser + Update,
     HashT::OutputSize: IsLessOrEqual<U256>,
     HashT::OutputSize: IsLessOrEqual<HashT::BlockSize>;
 
 /// ExpandMsgXmd implements expand_message_xmd for the ExpandMsg trait
 impl<HashT, L> ExpandMsg<L> for ExpandMsgXmd<HashT>
 where
-    HashT: Digest + BlockInput,
+    HashT: Digest + BlockSizeUser + Update,
     L: ArrayLength<u8>,
     U255: Mul<HashT::OutputSize>,
     // If `len_in_bytes` is bigger then 256, length of the `DST` will depend on

--- a/elliptic-curve/src/hash2field/expand_msg_xmd.rs
+++ b/elliptic-curve/src/hash2field/expand_msg_xmd.rs
@@ -14,7 +14,7 @@ use generic_array::{typenum::Prod, ArrayLength};
 pub struct ExpandMsgXmd<HashT>
 where
     HashT: Digest + BlockInput,
-    HashT::OutputSize: IsLess<U256>,
+    HashT::OutputSize: IsLessOrEqual<U256>,
     HashT::OutputSize: IsLessOrEqual<HashT::BlockSize>,
 {
     b_0: GenericArray<u8, HashT::OutputSize>,
@@ -28,7 +28,7 @@ where
 impl<HashT> ExpandMsgXmd<HashT>
 where
     HashT: Digest + BlockInput,
-    HashT::OutputSize: IsLess<U256>,
+    HashT::OutputSize: IsLessOrEqual<U256>,
     HashT::OutputSize: IsLessOrEqual<HashT::BlockSize>,
 {
     fn next(&mut self) -> bool {
@@ -59,7 +59,7 @@ where
 impl<HashT, L> ExpandMsg<L> for ExpandMsgXmd<HashT>
 where
     HashT: Digest + BlockInput,
-    HashT::OutputSize: IsLess<U256>,
+    HashT::OutputSize: IsLessOrEqual<U256>,
     HashT::OutputSize: IsLessOrEqual<HashT::BlockSize>,
     L: ArrayLength<u8> + IsLess<U65536>,
     U255: Mul<HashT::OutputSize>,

--- a/elliptic-curve/src/hash2field/expand_msg_xmd.rs
+++ b/elliptic-curve/src/hash2field/expand_msg_xmd.rs
@@ -1,14 +1,9 @@
 use core::ops::Mul;
 
 use super::{Domain, ExpandMsg};
-use digest::{
-    generic_array::{
-        typenum::{IsLess, IsLessOrEqual, Unsigned, U255, U256, U65536},
-        GenericArray,
-    },
-    BlockInput, Digest,
-};
-use generic_array::{typenum::Prod, ArrayLength};
+use digest::{BlockInput, Digest};
+use generic_array::typenum::{IsLess, IsLessOrEqual, NonZero, Prod, Unsigned, U255, U256, U65536};
+use generic_array::{ArrayLength, GenericArray};
 
 /// Placeholder type for implementing expand_message_xmd based on a hash function
 pub struct ExpandMsgXmd<HashT>
@@ -61,7 +56,7 @@ where
     HashT: Digest + BlockInput,
     HashT::OutputSize: IsLessOrEqual<U256>,
     HashT::OutputSize: IsLessOrEqual<HashT::BlockSize>,
-    L: ArrayLength<u8> + IsLess<U65536>,
+    L: ArrayLength<u8> + IsLess<U65536> + NonZero,
     U255: Mul<HashT::OutputSize>,
     L: IsLess<Prod<U255, HashT::OutputSize>>,
 {

--- a/elliptic-curve/src/hash2field/expand_msg_xmd.rs
+++ b/elliptic-curve/src/hash2field/expand_msg_xmd.rs
@@ -15,9 +15,9 @@ where
     b_0: GenericArray<u8, HashT::OutputSize>,
     b_vals: GenericArray<u8, HashT::OutputSize>,
     domain: Domain<HashT::OutputSize>,
-    index: usize,
+    index: u8,
     offset: usize,
-    ell: usize,
+    ell: u8,
 }
 
 impl<HashT> ExpandMsgXmd<HashT>
@@ -39,9 +39,9 @@ where
                 .for_each(|(j, (b0val, bi1val))| tmp[j] = b0val ^ bi1val);
             self.b_vals = HashT::new()
                 .chain(tmp)
-                .chain([self.index as u8])
+                .chain([self.index])
                 .chain(self.domain.data())
-                .chain([self.domain.len() as u8])
+                .chain([self.domain.len()])
                 .finalize();
             true
         } else {
@@ -68,8 +68,9 @@ where
     L: NonZero + IsLess<Prod<U255, HashT::OutputSize>> + IsLess<U65536>,
 {
     fn expand_message(msg: &[u8], dst: &'static [u8]) -> Self {
-        let b_in_bytes = HashT::OutputSize::to_usize();
-        let ell = (L::to_usize() + b_in_bytes - 1) / b_in_bytes;
+        let b_in_bytes = HashT::OutputSize::to_u16();
+        // Can't overflow because enforced on a type level.
+        let ell = ((L::to_u16() + b_in_bytes - 1) / b_in_bytes) as u8;
         // Enforced on the type level
         // if ell > 255 {
         //     panic!("ell was too big in expand_message_xmd");
@@ -83,14 +84,14 @@ where
                 [l[0], l[1], 0u8]
             })
             .chain(domain.data())
-            .chain([domain.len() as u8])
+            .chain([domain.len()])
             .finalize();
 
         let b_vals = HashT::new()
             .chain(&b_0[..])
             .chain([1u8])
             .chain(domain.data())
-            .chain([domain.len() as u8])
+            .chain([domain.len()])
             .finalize();
 
         Self {

--- a/elliptic-curve/src/hash2field/expand_msg_xmd.rs
+++ b/elliptic-curve/src/hash2field/expand_msg_xmd.rs
@@ -79,10 +79,8 @@ where
         let b_0 = HashT::new()
             .chain(GenericArray::<u8, HashT::BlockSize>::default())
             .chain(msg)
-            .chain({
-                let l = L::to_u16().to_be_bytes();
-                [l[0], l[1], 0u8]
-            })
+            .chain(L::to_u16().to_be_bytes())
+            .chain([0])
             .chain(domain.data())
             .chain([domain.len()])
             .finalize();

--- a/elliptic-curve/src/hash2field/expand_msg_xof.rs
+++ b/elliptic-curve/src/hash2field/expand_msg_xof.rs
@@ -1,7 +1,7 @@
 use super::ExpandMsg;
 use crate::hash2field::Domain;
 use digest::{ExtendableOutput, ExtendableOutputDirty, FixedOutput, Update, XofReader};
-use generic_array::typenum::{IsLessOrEqual, U256, U32, U65536};
+use generic_array::typenum::{IsLessOrEqual, NonZero, U256, U32, U65536};
 use generic_array::ArrayLength;
 
 /// Placeholder type for implementing expand_message_xof based on an extendable output function
@@ -18,7 +18,7 @@ impl<HashT, L> ExpandMsg<L> for ExpandMsgXof<HashT>
 where
     HashT: Default + ExtendableOutput + ExtendableOutputDirty + FixedOutput + Update,
     HashT::OutputSize: IsLessOrEqual<U256>,
-    L: ArrayLength<u8> + IsLessOrEqual<U65536>,
+    L: ArrayLength<u8> + IsLessOrEqual<U65536> + NonZero,
 {
     fn expand_message(msg: &[u8], dst: &'static [u8]) -> Self {
         let domain = Domain::<U32>::xof::<HashT>(dst);

--- a/elliptic-curve/src/hash2field/expand_msg_xof.rs
+++ b/elliptic-curve/src/hash2field/expand_msg_xof.rs
@@ -2,19 +2,19 @@ use core::marker::PhantomData;
 
 use super::ExpandMsg;
 use crate::hash2field::Domain;
-use digest::{ExtendableOutput, ExtendableOutputDirty, FixedOutput, Update, XofReader};
+use digest::{ExtendableOutput, Update, XofReader};
 use generic_array::typenum::{IsLessOrEqual, NonZero, U32, U65536};
 use generic_array::{ArrayLength, GenericArray};
 
 /// Placeholder type for implementing expand_message_xof based on an extendable output function
 pub struct ExpandMsgXof<HashT>(PhantomData<HashT>)
 where
-    HashT: Default + ExtendableOutput + ExtendableOutputDirty + FixedOutput + Update;
+    HashT: Default + ExtendableOutput + Update;
 
 /// ExpandMsgXof implements expand_message_xof for the ExpandMsg trait
 impl<HashT, L> ExpandMsg<L> for ExpandMsgXof<HashT>
 where
-    HashT: Default + ExtendableOutput + ExtendableOutputDirty + FixedOutput + Update,
+    HashT: Default + ExtendableOutput + Update,
     L: ArrayLength<u8>,
     // Constraint set by `expand_message_xof`:
     // https://www.ietf.org/archive/id/draft-irtf-cfrg-hash-to-curve-13.html#section-5.4.2-5

--- a/elliptic-curve/src/hash2field/expand_msg_xof.rs
+++ b/elliptic-curve/src/hash2field/expand_msg_xof.rs
@@ -32,7 +32,7 @@ where
             .chain(msg)
             .chain(L::to_u16().to_be_bytes())
             .chain(domain.data())
-            .chain([domain.len() as u8])
+            .chain([domain.len()])
             .finalize_xof();
         Self { reader }
     }

--- a/elliptic-curve/src/hash2field/expand_msg_xof.rs
+++ b/elliptic-curve/src/hash2field/expand_msg_xof.rs
@@ -1,16 +1,15 @@
+use core::marker::PhantomData;
+
 use super::ExpandMsg;
 use crate::hash2field::Domain;
 use digest::{ExtendableOutput, ExtendableOutputDirty, FixedOutput, Update, XofReader};
 use generic_array::typenum::{IsLessOrEqual, NonZero, U32, U65536};
-use generic_array::ArrayLength;
+use generic_array::{ArrayLength, GenericArray};
 
 /// Placeholder type for implementing expand_message_xof based on an extendable output function
-pub struct ExpandMsgXof<HashT>
+pub struct ExpandMsgXof<HashT>(PhantomData<HashT>)
 where
-    HashT: Default + ExtendableOutput + ExtendableOutputDirty + FixedOutput + Update,
-{
-    reader: <HashT as ExtendableOutput>::Reader,
-}
+    HashT: Default + ExtendableOutput + ExtendableOutputDirty + FixedOutput + Update;
 
 /// ExpandMsgXof implements expand_message_xof for the ExpandMsg trait
 impl<HashT, L> ExpandMsg<L> for ExpandMsgXof<HashT>
@@ -21,18 +20,16 @@ where
     // https://www.ietf.org/archive/id/draft-irtf-cfrg-hash-to-curve-13.html#section-5.4.2-5
     L: NonZero + IsLessOrEqual<U65536>,
 {
-    fn expand_message(msg: &[u8], dst: &'static [u8]) -> Self {
+    fn expand_message(msg: &[u8], dst: &[u8]) -> GenericArray<u8, L> {
         let domain = Domain::<U32>::xof::<HashT>(dst);
-        let reader = HashT::default()
+        let mut reader = HashT::default()
             .chain(msg)
             .chain(L::to_u16().to_be_bytes())
             .chain(domain.data())
             .chain([domain.len()])
             .finalize_xof();
-        Self { reader }
-    }
-
-    fn fill_bytes(&mut self, okm: &mut [u8]) {
-        self.reader.read(okm);
+        let mut buf = GenericArray::default();
+        reader.read(&mut buf);
+        buf
     }
 }

--- a/elliptic-curve/src/hash2field/expand_msg_xof.rs
+++ b/elliptic-curve/src/hash2field/expand_msg_xof.rs
@@ -1,7 +1,8 @@
 use super::ExpandMsg;
 use crate::hash2field::Domain;
 use digest::{ExtendableOutput, ExtendableOutputDirty, Update, XofReader};
-use generic_array::{typenum::U32, ArrayLength};
+use generic_array::typenum::{IsLessOrEqual, U32, U65536};
+use generic_array::ArrayLength;
 
 /// Placeholder type for implementing expand_message_xof based on an extendable output function
 pub struct ExpandMsgXof<HashT>
@@ -15,13 +16,13 @@ where
 impl<HashT, L> ExpandMsg<L> for ExpandMsgXof<HashT>
 where
     HashT: Default + ExtendableOutput + ExtendableOutputDirty + Update,
-    L: ArrayLength<u8>,
+    L: ArrayLength<u8> + IsLessOrEqual<U65536>,
 {
     fn expand_message(msg: &[u8], dst: &'static [u8]) -> Self {
         let domain = Domain::<U32>::xof::<HashT>(dst);
         let reader = HashT::default()
             .chain(msg)
-            .chain([(L::to_usize() >> 8) as u8, L::to_usize() as u8])
+            .chain(L::to_u16().to_be_bytes())
             .chain(domain.data())
             .chain([domain.len() as u8])
             .finalize_xof();

--- a/elliptic-curve/src/hash2field/expand_msg_xof.rs
+++ b/elliptic-curve/src/hash2field/expand_msg_xof.rs
@@ -1,14 +1,13 @@
 use super::ExpandMsg;
 use crate::hash2field::Domain;
 use digest::{ExtendableOutput, ExtendableOutputDirty, FixedOutput, Update, XofReader};
-use generic_array::typenum::{IsLessOrEqual, NonZero, U256, U32, U65536};
+use generic_array::typenum::{IsLessOrEqual, NonZero, U32, U65536};
 use generic_array::ArrayLength;
 
 /// Placeholder type for implementing expand_message_xof based on an extendable output function
 pub struct ExpandMsgXof<HashT>
 where
     HashT: Default + ExtendableOutput + ExtendableOutputDirty + FixedOutput + Update,
-    HashT::OutputSize: IsLessOrEqual<U256>,
 {
     reader: <HashT as ExtendableOutput>::Reader,
 }
@@ -18,10 +17,6 @@ impl<HashT, L> ExpandMsg<L> for ExpandMsgXof<HashT>
 where
     HashT: Default + ExtendableOutput + ExtendableOutputDirty + FixedOutput + Update,
     L: ArrayLength<u8>,
-    // If `len_in_bytes` is bigger then 256, length of the `DST` will depend on
-    // the output size of the hash, which is still not allowed to be bigger then 256:
-    // https://www.ietf.org/archive/id/draft-irtf-cfrg-hash-to-curve-13.html#section-5.4.2-5
-    HashT::OutputSize: IsLessOrEqual<U256>,
     // Constraint set by `expand_message_xof`:
     // https://www.ietf.org/archive/id/draft-irtf-cfrg-hash-to-curve-13.html#section-5.4.2-5
     L: NonZero + IsLessOrEqual<U65536>,

--- a/elliptic-curve/src/hash2field/expand_msg_xof.rs
+++ b/elliptic-curve/src/hash2field/expand_msg_xof.rs
@@ -1,13 +1,14 @@
 use super::ExpandMsg;
 use crate::hash2field::Domain;
-use digest::{ExtendableOutput, ExtendableOutputDirty, Update, XofReader};
-use generic_array::typenum::{IsLessOrEqual, U32, U65536};
+use digest::{ExtendableOutput, ExtendableOutputDirty, FixedOutput, Update, XofReader};
+use generic_array::typenum::{IsLessOrEqual, U256, U32, U65536};
 use generic_array::ArrayLength;
 
 /// Placeholder type for implementing expand_message_xof based on an extendable output function
 pub struct ExpandMsgXof<HashT>
 where
-    HashT: Default + ExtendableOutput + ExtendableOutputDirty + Update,
+    HashT: Default + ExtendableOutput + ExtendableOutputDirty + FixedOutput + Update,
+    HashT::OutputSize: IsLessOrEqual<U256>,
 {
     reader: <HashT as ExtendableOutput>::Reader,
 }
@@ -15,7 +16,8 @@ where
 /// ExpandMsgXof implements expand_message_xof for the ExpandMsg trait
 impl<HashT, L> ExpandMsg<L> for ExpandMsgXof<HashT>
 where
-    HashT: Default + ExtendableOutput + ExtendableOutputDirty + Update,
+    HashT: Default + ExtendableOutput + ExtendableOutputDirty + FixedOutput + Update,
+    HashT::OutputSize: IsLessOrEqual<U256>,
     L: ArrayLength<u8> + IsLessOrEqual<U65536>,
 {
     fn expand_message(msg: &[u8], dst: &'static [u8]) -> Self {

--- a/elliptic-curve/src/hash2field/expand_msg_xof.rs
+++ b/elliptic-curve/src/hash2field/expand_msg_xof.rs
@@ -17,8 +17,14 @@ where
 impl<HashT, L> ExpandMsg<L> for ExpandMsgXof<HashT>
 where
     HashT: Default + ExtendableOutput + ExtendableOutputDirty + FixedOutput + Update,
+    L: ArrayLength<u8>,
+    // If `len_in_bytes` is bigger then 256, length of the `DST` will depend on
+    // the output size of the hash, which is still not allowed to be bigger then 256:
+    // https://www.ietf.org/archive/id/draft-irtf-cfrg-hash-to-curve-13.html#section-5.4.2-5
     HashT::OutputSize: IsLessOrEqual<U256>,
-    L: ArrayLength<u8> + IsLessOrEqual<U65536> + NonZero,
+    // Constraint set by `expand_message_xof`:
+    // https://www.ietf.org/archive/id/draft-irtf-cfrg-hash-to-curve-13.html#section-5.4.2-5
+    L: NonZero + IsLessOrEqual<U65536>,
 {
     fn expand_message(msg: &[u8], dst: &'static [u8]) -> Self {
         let domain = Domain::<U32>::xof::<HashT>(dst);

--- a/elliptic-curve/src/ops.rs
+++ b/elliptic-curve/src/ops.rs
@@ -9,7 +9,7 @@ use subtle::CtOption;
 use group::Group;
 
 #[cfg(feature = "digest")]
-use digest::{BlockInput, Digest, FixedOutput, Reset, Update};
+use digest::{Digest, FixedOutput, Reset, Update};
 
 /// Perform an inversion on a field element (i.e. base field element or scalar)
 pub trait Invert {
@@ -67,7 +67,7 @@ pub trait Reduce<UInt: Integer + ArrayEncoding>: Sized {
     #[cfg_attr(docsrs, doc(cfg(feature = "digest")))]
     fn from_be_digest_reduced<D>(digest: D) -> Self
     where
-        D: FixedOutput<OutputSize = UInt::ByteSize> + BlockInput + Clone + Default + Reset + Update,
+        D: FixedOutput<OutputSize = UInt::ByteSize> + Digest + Clone + Default + Reset + Update,
     {
         Self::from_be_bytes_reduced(digest.finalize())
     }
@@ -78,7 +78,7 @@ pub trait Reduce<UInt: Integer + ArrayEncoding>: Sized {
     #[cfg_attr(docsrs, doc(cfg(feature = "digest")))]
     fn from_le_digest_reduced<D>(digest: D) -> Self
     where
-        D: FixedOutput<OutputSize = UInt::ByteSize> + BlockInput + Clone + Default + Reset + Update,
+        D: FixedOutput<OutputSize = UInt::ByteSize> + Digest + Clone + Default + Reset + Update,
     {
         Self::from_le_bytes_reduced(digest.finalize())
     }


### PR DESCRIPTION
Builds on #872.

- "Simplify" `ExpandMsg` to one method and remove `'static` constraint for DST.
- Update to digest 0.10.