### PR TITLE
elliptic-curve: hash2curve rustdoc improvements

### DIFF
--- a/elliptic-curve/src/hash2curve.rs
+++ b/elliptic-curve/src/hash2curve.rs
@@ -1,11 +1,10 @@
-/// Traits for handling hash to curve
+//! Traits for hashing byte sequences to curve points.
+//!
+//! <https://datatracker.ietf.org/doc/draft-irtf-cfrg-hash-to-curve>
+
 mod group_digest;
-/// Traits for mapping an isogeny to another curve
-/// <https://datatracker.ietf.org/doc/draft-irtf-cfrg-hash-to-curve>
 mod isogeny;
-/// Traits for mapping field elements to points on the curve
 mod map2curve;
-/// Optimized simplified Shallue-van de Woestijne-Ulas methods
 mod osswu;
 
 pub use group_digest::*;

--- a/elliptic-curve/src/hash2curve/group_digest.rs
+++ b/elliptic-curve/src/hash2curve/group_digest.rs
@@ -1,3 +1,5 @@
+//! Traits for handling hash to curve.
+
 use super::MapToCurve;
 use crate::{
     hash2field::{hash_to_field, ExpandMsg, FromOkm},
@@ -12,25 +14,26 @@ pub trait GroupDigest {
     /// The resulting group element
     type Output: CofactorGroup<Subgroup = Self::Output>;
 
-    /// Computes the hash to curve routine according to
-    /// <https://www.ietf.org/archive/id/draft-irtf-cfrg-hash-to-curve-13.html>
-    /// which says
-    /// Uniform encoding from byte strings to points in G.
-    /// That is, the distribution of its output is statistically close
-    /// to uniform in G.
-    /// This function is suitable for most applications requiring a random
-    /// oracle returning points in G assuming a cryptographically secure
-    /// hash function is used.
+    /// Computes the hash to curve routine.
     ///
-    /// Examples
+    /// From <https://www.ietf.org/archive/id/draft-irtf-cfrg-hash-to-curve-13.html>:
     ///
-    /// Using a fixed size hash function
+    /// > Uniform encoding from byte strings to points in G.
+    /// > That is, the distribution of its output is statistically close
+    /// > to uniform in G.
+    /// > This function is suitable for most applications requiring a random
+    /// > oracle returning points in G assuming a cryptographically secure
+    /// > hash function is used.
+    ///
+    /// # Examples
+    ///
+    /// ## Using a fixed size hash function
     ///
     /// ```ignore
     /// let pt = ProjectivePoint::hash_from_bytes::<hash2field::ExpandMsgXmd<sha2::Sha256>>(b"test data", b"CURVE_XMD:SHA-256_SSWU_RO_");
     /// ```
     ///
-    /// Using an extendable output function
+    /// ## Using an extendable output function
     ///
     /// ```ignore
     /// let pt = ProjectivePoint::hash_from_bytes::<hash2field::ExpandMsgXof<sha3::Shake256>>(b"test data", b"CURVE_XOF:SHAKE-256_SSWU_RO_");
@@ -54,14 +57,15 @@ pub trait GroupDigest {
         Ok(q0.clear_cofactor() + q1.clear_cofactor())
     }
 
-    /// Computes the encode to curve routine according to
-    /// <https://www.ietf.org/archive/id/draft-irtf-cfrg-hash-to-curve-13.html>
-    /// which says
-    /// Nonuniform encoding from byte strings to
-    /// points in G. That is, the distribution of its output is not
-    /// uniformly random in G: the set of possible outputs of
-    /// encode_to_curve is only a fraction of the points in G, and some
-    /// points in this set are more likely to be output than others.
+    /// Computes the encode to curve routine.
+    ///
+    /// From <https://www.ietf.org/archive/id/draft-irtf-cfrg-hash-to-curve-13.html>:
+    ///
+    /// > Nonuniform encoding from byte strings to
+    /// > points in G. That is, the distribution of its output is not
+    /// > uniformly random in G: the set of possible outputs of
+    /// > encode_to_curve is only a fraction of the points in G, and some
+    /// > points in this set are more likely to be output than others.
     fn encode_from_bytes<X: ExpandMsg>(msg: &[u8], dst: &'static [u8]) -> Result<Self::Output> {
         let mut u = [Self::FieldElement::default()];
         hash_to_field::<X, _>(msg, dst, &mut u)?;

--- a/elliptic-curve/src/hash2curve/isogeny.rs
+++ b/elliptic-curve/src/hash2curve/isogeny.rs
@@ -1,3 +1,7 @@
+//! Traits for mapping an isogeny to another curve
+//!
+//! <https://datatracker.ietf.org/doc/draft-irtf-cfrg-hash-to-curve>
+
 use core::ops::{AddAssign, Mul};
 use ff::Field;
 use generic_array::{typenum::Unsigned, ArrayLength, GenericArray};
@@ -14,7 +18,7 @@ pub struct IsogenyCoefficients<F: Field + AddAssign + Mul<Output = F>> {
     pub yden: &'static [F],
 }
 
-/// The Isogeny methods to map to another curve
+/// The [`Isogeny`] methods to map to another curve.
 pub trait Isogeny: Field + AddAssign + Mul<Output = Self> {
     /// The maximum number of coefficients
     type Degree: ArrayLength<Self>;

--- a/elliptic-curve/src/hash2curve/map2curve.rs
+++ b/elliptic-curve/src/hash2curve/map2curve.rs
@@ -1,3 +1,5 @@
+//! Traits for mapping field elements to points on the curve.
+
 /// Trait for converting field elements into a point
 /// via a mapping method like Simplified Shallue-van de Woestijne-Ulas
 /// or Elligator

--- a/elliptic-curve/src/hash2curve/osswu.rs
+++ b/elliptic-curve/src/hash2curve/osswu.rs
@@ -1,3 +1,7 @@
+//! Optimized simplified Shallue-van de Woestijne-Ulas methods.
+//!
+//! <https://eprint.iacr.org/2009/340.pdf>
+
 use ff::Field;
 use subtle::Choice;
 
@@ -34,7 +38,7 @@ pub trait OsswuMap: Field + Sgn0 {
     /// should be for isogeny where A≠0 and B≠0.
     const PARAMS: OsswuMapParams<Self>;
 
-    /// Convert this field element into an affine point on the ellliptic curve
+    /// Convert this field element into an affine point on the elliptic curve
     /// returning (X, Y). For Weierstrass curves having A==0 or B==0
     /// the result is a point on an isogeny.
     fn osswu(&self) -> (Self, Self) {

--- a/elliptic-curve/src/hash2field.rs
+++ b/elliptic-curve/src/hash2field.rs
@@ -1,3 +1,7 @@
+//! Traits for hashing to field elements.
+//!
+//! <https://datatracker.ietf.org/doc/draft-irtf-cfrg-hash-to-curve>
+
 mod expand_msg;
 
 pub use expand_msg::{xmd::*, xof::*, *};
@@ -5,16 +9,17 @@ pub use expand_msg::{xmd::*, xof::*, *};
 use crate::Result;
 use generic_array::{typenum::Unsigned, ArrayLength, GenericArray};
 
-/// The trait for helping to convert to a scalar
+/// The trait for helping to convert to a field element.
 pub trait FromOkm {
-    /// The number of bytes needed to convert to a scalar
+    /// The number of bytes needed to convert to a field element.
     type Length: ArrayLength<u8>;
 
-    /// Convert a byte sequence into a scalar
+    /// Convert a byte sequence into a field element.
     fn from_okm(data: &GenericArray<u8, Self::Length>) -> Self;
 }
 
-/// Convert an arbitrary byte sequence according to
+/// Convert an arbitrary byte sequence into a field element.
+///
 /// <https://tools.ietf.org/html/draft-irtf-cfrg-hash-to-curve-11#section-5.3>
 pub fn hash_to_field<E, T>(data: &[u8], domain: &'static [u8], out: &mut [T]) -> Result<()>
 where

--- a/elliptic-curve/src/hash2field/expand_msg.rs
+++ b/elliptic-curve/src/hash2field/expand_msg.rs
@@ -1,3 +1,5 @@
+//! `expand_message` interface `for hash_to_field`.
+
 pub(super) mod xmd;
 pub(super) mod xof;
 
@@ -11,9 +13,10 @@ const OVERSIZE_DST_SALT: &[u8] = b"H2C-OVERSIZE-DST-";
 /// Maximum domain separation tag length
 const MAX_DST_LEN: usize = 255;
 
-/// Trait for types implementing expand_message interface for hash_to_field
+/// Trait for types implementing expand_message interface for `hash_to_field`.
 pub trait ExpandMsg: Sized {
-    /// Expands `msg` to the required number of bytes
+    /// Expands `msg` to the required number of bytes.
+    ///
     /// Returns an expander that can be used to call `read` until enough
     /// bytes have been consumed
     fn expand_message(msg: &[u8], dst: &'static [u8], len_in_bytes: usize) -> Result<Self>;

--- a/elliptic-curve/src/hash2field/expand_msg/xmd.rs
+++ b/elliptic-curve/src/hash2field/expand_msg/xmd.rs
@@ -1,3 +1,5 @@
+//! `expand_message_xmd` based on a hash function.
+
 use super::{Domain, ExpandMsg};
 use crate::{Error, Result};
 use digest::{
@@ -8,7 +10,7 @@ use digest::{
     BlockInput, Digest,
 };
 
-/// Placeholder type for implementing expand_message_xmd based on a hash function
+/// Placeholder type for implementing `expand_message_xmd` based on a hash function
 pub struct ExpandMsgXmd<HashT>
 where
     HashT: Digest + BlockInput,

--- a/elliptic-curve/src/hash2field/expand_msg/xof.rs
+++ b/elliptic-curve/src/hash2field/expand_msg/xof.rs
@@ -1,9 +1,11 @@
+//! `expand_message_xof` for the `ExpandMsg` trait
+
 use super::ExpandMsg;
 use crate::{hash2field::Domain, Error, Result};
 use digest::{ExtendableOutput, Update, XofReader};
 use generic_array::typenum::U32;
 
-/// Placeholder type for implementing expand_message_xof based on an extendable output function
+/// Placeholder type for implementing `expand_message_xof` based on an extendable output function
 pub struct ExpandMsgXof<HashT>
 where
     HashT: Default + ExtendableOutput + Update,
@@ -11,7 +13,7 @@ where
     reader: <HashT as ExtendableOutput>::Reader,
 }
 
-/// ExpandMsgXof implements expand_message_xof for the ExpandMsg trait
+/// ExpandMsgXof implements `expand_message_xof` for the [`ExpandMsg`] trait
 impl<HashT> ExpandMsg for ExpandMsgXof<HashT>
 where
     HashT: Default + ExtendableOutput + Update,

--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -94,12 +94,10 @@ pub mod ecdh;
 #[cfg(feature = "jwk")]
 mod jwk;
 
-/// Traits for hashing to field elements
 #[cfg(feature = "hash2curve")]
 #[doc(hidden)]
 pub mod hash2field;
 
-/// Traits for hashing byte sequences to curve points
 #[cfg(feature = "hash2curve")]
 #[cfg_attr(docsrs, doc(cfg(feature = "hash2curve")))]
 pub mod hash2curve;


### PR DESCRIPTION
- Moves doc comments on `mod <modname>` into toplevel module comments. These have the same effect, but also self-document the module you are looking at, and are more amenable to rich top-of-module documentation. It's also consistent with the rest of the existing rustdoc in the RustCrypto project.
- Breaks apart the rustdoc "headline" from the rest of the comments for better formatting on the HTML rendering.
- Uses backticks and [`TypeName`] syntax to linkify type names where appropriate.