### PR TITLE
elliptic-curve v0.11.7

### DIFF
--- a/elliptic-curve/CHANGELOG.md
+++ b/elliptic-curve/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.11.7 (2021-01-14)
+### Added
+- Initial hash-to-field support ([#854], [#855], [#871], [#874])
+- Initial hash-to-curve support ([#865], [#876])
+- Impl `Mul` for `NonZeroScalar` * `NonZeroScalar` ([#857], [#862])
+- `Reduce::from_*e_digest_reduced` ([#869])
+- `VoprfParameters` trait ([#878])
+
+[#854]: https://github.com/RustCrypto/traits/pull/854
+[#855]: https://github.com/RustCrypto/traits/pull/855
+[#857]: https://github.com/RustCrypto/traits/pull/857
+[#862]: https://github.com/RustCrypto/traits/pull/862
+[#865]: https://github.com/RustCrypto/traits/pull/865
+[#869]: https://github.com/RustCrypto/traits/pull/869
+[#871]: https://github.com/RustCrypto/traits/pull/871
+[#874]: https://github.com/RustCrypto/traits/pull/874
+[#876]: https://github.com/RustCrypto/traits/pull/876
+[#878]: https://github.com/RustCrypto/traits/pull/878
+
 ## 0.11.6 (2021-12-20)
 ### Added
 - Type conversions chart ([#852])

--- a/elliptic-curve/Cargo.lock
+++ b/elliptic-curve/Cargo.lock
@@ -90,7 +90,7 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.11.6"
+version = "0.11.7"
 dependencies = [
  "base64ct",
  "crypto-bigint",

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elliptic-curve"
-version = "0.11.6" # Also update html_root_url in lib.rs when bumping this
+version = "0.11.7" # Also update html_root_url in lib.rs when bumping this
 description = """
 General purpose Elliptic Curve Cryptography (ECC) support, including types
 and traits for representing various elliptic curve forms, scalars, points,

--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -5,7 +5,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
-    html_root_url = "https://docs.rs/elliptic-curve/0.11.6"
+    html_root_url = "https://docs.rs/elliptic-curve/0.11.7"
 )]
 #![doc = include_str!("../README.md")]
 


### PR DESCRIPTION
### Added
- Initial hash-to-field support ([#854], [#855], [#871], [#874])
- Initial hash-to-curve support ([#865], [#876])
- Impl `Mul` for `NonZeroScalar` * `NonZeroScalar` ([#857], [#862])
- `Reduce::from_*e_digest_reduced` ([#869])
- `VoprfParameters` trait ([#878])

[#854]: https://github.com/RustCrypto/traits/pull/854
[#855]: https://github.com/RustCrypto/traits/pull/855
[#857]: https://github.com/RustCrypto/traits/pull/857
[#862]: https://github.com/RustCrypto/traits/pull/862
[#865]: https://github.com/RustCrypto/traits/pull/865
[#869]: https://github.com/RustCrypto/traits/pull/869
[#871]: https://github.com/RustCrypto/traits/pull/871
[#874]: https://github.com/RustCrypto/traits/pull/874
[#876]: https://github.com/RustCrypto/traits/pull/876
[#878]: https://github.com/RustCrypto/traits/pull/878