### PR TITLE
digest: bump `generic-array` dependency to v0.14.4

### DIFF
--- a/digest/Cargo.toml
+++ b/digest/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["digest", "crypto", "hash"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-generic-array = "0.14"
+generic-array = "0.14.4"
 crypto-common = { version = "0.1.1", path = "../crypto-common" }
 
 block-buffer = { version = "0.10", optional = true }


### PR DESCRIPTION
`generic-array` v0.14.4 uses `typenum` v1.12.0, which makes `Unsigned`(which `ArrayLength` implies) imply `Default`, which, in turn, is required for `CoreWrapper` to to implement `Digest`.

This is needed to make upstream crates which uses `Digest` implementation of `CoreWrappper` (such as `hmac`) to successfully build with `-Z minimal-versions`.