### PR TITLE
elliptic-curve: use the `base16ct` crate

### DIFF
--- a/elliptic-curve/Cargo.lock
+++ b/elliptic-curve/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "base16ct"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ecf0f8400afa4e4e3654e950d5717c0c626ffbaf218d80cccd86abd609529ed"
+
+[[package]]
 name = "base64ct"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -92,6 +98,7 @@ dependencies = [
 name = "elliptic-curve"
 version = "0.11.7"
 dependencies = [
+ "base16ct",
  "base64ct",
  "crypto-bigint",
  "der",

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -20,6 +20,7 @@ rust-version = "1.56"
 members = ["."]
 
 [dependencies]
+base16ct = "0.1"
 crypto-bigint = { version = "0.3", default-features = false, features = ["rand_core", "generic-array", "zeroize"] }
 der = { version = "0.5", default-features = false, features = ["oid"] }
 generic-array = { version = "0.14", default-features = false }

--- a/elliptic-curve/src/error.rs
+++ b/elliptic-curve/src/error.rs
@@ -18,6 +18,12 @@ impl Display for Error {
     }
 }
 
+impl From<base16ct::Error> for Error {
+    fn from(_: base16ct::Error) -> Error {
+        Error
+    }
+}
+
 #[cfg(feature = "pkcs8")]
 impl From<pkcs8::Error> for Error {
     fn from(_: pkcs8::Error) -> Error {


### PR DESCRIPTION
Uses the new `base16ct` crate for hex decoding.

The encoder is still implemented in a non-constant-time manner. The functionality to encode to a `fmt::Formatter` needs to be upstreamed into the `base16ct` crate.