### PR TITLE
elliptic-curve: use `base16ct::HexDisplay`

### DIFF
--- a/elliptic-curve/Cargo.lock
+++ b/elliptic-curve/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "base16ct"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ecf0f8400afa4e4e3654e950d5717c0c626ffbaf218d80cccd86abd609529ed"
+checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
 
 [[package]]
 name = "base64ct"

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -20,7 +20,7 @@ rust-version = "1.56"
 members = ["."]
 
 [dependencies]
-base16ct = "0.1"
+base16ct = "0.1.1"
 crypto-bigint = { version = "0.3", default-features = false, features = ["rand_core", "generic-array", "zeroize"] }
 der = { version = "0.5", default-features = false, features = ["oid"] }
 generic-array = { version = "0.14", default-features = false }

--- a/elliptic-curve/src/hex.rs
+++ b/elliptic-curve/src/hex.rs
@@ -1,25 +1,7 @@
 //! Hexadecimal encoding helpers
 
 use crate::{Error, Result};
-use core::{fmt, str};
-
-/// Write the provided slice to the formatter as lower case hexadecimal
-#[inline]
-pub(crate) fn write_lower(slice: &[u8], formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-    for byte in slice {
-        write!(formatter, "{:02x}", byte)?;
-    }
-    Ok(())
-}
-
-/// Write the provided slice to the formatter as upper case hexadecimal
-#[inline]
-pub(crate) fn write_upper(slice: &[u8], formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-    for byte in slice {
-        write!(formatter, "{:02X}", byte)?;
-    }
-    Ok(())
-}
+use core::str;
 
 /// Decode the provided hexadecimal string into the provided buffer.
 ///
@@ -34,26 +16,10 @@ pub(crate) fn decode(hex: &str, out: &mut [u8]) -> Result<()> {
 
 #[cfg(all(test, feature = "std"))]
 mod tests {
-    use core::fmt;
     use hex_literal::hex;
 
     const EXAMPLE_DATA: &[u8] = &hex!("0123456789ABCDEF");
     const EXAMPLE_HEX_LOWER: &str = "0123456789abcdef";
-    const EXAMPLE_HEX_UPPER: &str = "0123456789ABCDEF";
-
-    struct Wrapper<'a>(&'a [u8]);
-
-    impl fmt::LowerHex for Wrapper<'_> {
-        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-            super::write_lower(self.0, f)
-        }
-    }
-
-    impl fmt::UpperHex for Wrapper<'_> {
-        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-            super::write_upper(self.0, f)
-        }
-    }
 
     #[test]
     fn decode_lower() {
@@ -79,15 +45,5 @@ mod tests {
     fn decode_rejects_too_long() {
         let mut buf = [0u8; 7];
         assert!(super::decode(EXAMPLE_HEX_LOWER, &mut buf).is_err());
-    }
-
-    #[test]
-    fn encode_lower() {
-        assert_eq!(format!("{:x}", Wrapper(EXAMPLE_DATA)), EXAMPLE_HEX_LOWER);
-    }
-
-    #[test]
-    fn encode_upper() {
-        assert_eq!(format!("{:X}", Wrapper(EXAMPLE_DATA)), EXAMPLE_HEX_UPPER);
     }
 }

--- a/elliptic-curve/src/scalar/core.rs
+++ b/elliptic-curve/src/scalar/core.rs
@@ -10,6 +10,7 @@ use crate::{
     },
     Curve, Error, FieldBytes, IsHigh, Result,
 };
+use base16ct::HexDisplay;
 use core::{
     cmp::Ordering,
     fmt,
@@ -376,7 +377,7 @@ where
     C: Curve,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        hex::write_lower(&self.to_be_bytes(), f)
+        write!(f, "{:x}", HexDisplay(&self.to_be_bytes()))
     }
 }
 
@@ -385,7 +386,7 @@ where
     C: Curve,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        hex::write_upper(&self.to_be_bytes(), f)
+        write!(f, "{:X}", HexDisplay(&self.to_be_bytes()))
     }
 }
 

--- a/elliptic-curve/src/scalar/nonzero.rs
+++ b/elliptic-curve/src/scalar/nonzero.rs
@@ -8,6 +8,7 @@ use crate::{
     Curve, Error, FieldBytes, IsHigh, PrimeCurve, Result, Scalar, ScalarArithmetic, ScalarCore,
     SecretKey,
 };
+use base16ct::HexDisplay;
 use core::{
     fmt,
     ops::{Deref, Mul, Neg},
@@ -298,7 +299,7 @@ where
     C: Curve + ScalarArithmetic,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        hex::write_lower(&self.to_repr(), f)
+        write!(f, "{:x}", HexDisplay(&self.to_repr()))
     }
 }
 
@@ -307,7 +308,7 @@ where
     C: Curve + ScalarArithmetic,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        hex::write_upper(&self.to_repr(), f)
+        write!(f, "{:}", HexDisplay(&self.to_repr()))
     }
 }
 


### PR DESCRIPTION
Uses a constant time-ish implementation of a hexadecimal display formatter to replace what was previously in the `hex` module.