### PR TITLE
elliptic-curve v0.11.8

### DIFF
--- a/crypto/Cargo.lock
+++ b/crypto/Cargo.lock
@@ -11,6 +11,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base16ct"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
+
+[[package]]
 name = "base64ct"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -113,8 +119,9 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.11.6"
+version = "0.11.8"
 dependencies = [
+ "base16ct",
  "crypto-bigint",
  "der",
  "ff",
@@ -264,6 +271,6 @@ checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "zeroize"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d68d9dcec5f9b43a30d38c49f91dfedfaac384cb8f085faca366c26207dd1619"
+checksum = "cc222aec311c323c717f56060324f32b82da1ce1dd81d9a09aa6a9030bfe08db"

--- a/elliptic-curve/CHANGELOG.md
+++ b/elliptic-curve/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.11.8 (2021-01-15)
+### Added
+- Impl `ZeroizeOnDrop` on appropriate items ([#884])
+
+### Changed
+- Use the `base16ct` crate for hex serialization ([#886], [#887], [#888])
+
+[#884]: https://github.com/RustCrypto/traits/pull/884
+[#886]: https://github.com/RustCrypto/traits/pull/886
+[#887]: https://github.com/RustCrypto/traits/pull/887
+[#888]: https://github.com/RustCrypto/traits/pull/888
+
 ## 0.11.7 (2021-01-14)
 ### Added
 - Initial hash-to-field support ([#854], [#855], [#871], [#874])

--- a/elliptic-curve/Cargo.lock
+++ b/elliptic-curve/Cargo.lock
@@ -96,7 +96,7 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.11.7"
+version = "0.11.8"
 dependencies = [
  "base16ct",
  "base64ct",

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elliptic-curve"
-version = "0.11.7" # Also update html_root_url in lib.rs when bumping this
+version = "0.11.8" # Also update html_root_url in lib.rs when bumping this
 description = """
 General purpose Elliptic Curve Cryptography (ECC) support, including types
 and traits for representing various elliptic curve forms, scalars, points,

--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -5,7 +5,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
-    html_root_url = "https://docs.rs/elliptic-curve/0.11.7"
+    html_root_url = "https://docs.rs/elliptic-curve/0.11.8"
 )]
 #![doc = include_str!("../README.md")]
 


### PR DESCRIPTION
### Added
- Impl `ZeroizeOnDrop` on appropriate items ([#884])

### Changed
- Use the `base16ct` crate for hex serialization ([#886], [#887], [#888])

[#884]: https://github.com/RustCrypto/traits/pull/884
[#886]: https://github.com/RustCrypto/traits/pull/886
[#887]: https://github.com/RustCrypto/traits/pull/887
[#888]: https://github.com/RustCrypto/traits/pull/888