### PR TITLE
elliptic-curve: activate `bits`, `hash2curve`, `voprf` on docs.rs

### DIFF
--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -60,5 +60,5 @@ std = ["alloc", "rand_core/std"]
 voprf = ["digest"]
 
 [package.metadata.docs.rs]
-features = ["arithmetic", "ecdh", "jwk", "pem", "std"]
+features = ["bits", "ecdh", "hash2curve", "jwk", "pem", "std", "voprf"]
 rustdoc-args = ["--cfg", "docsrs"]


### PR DESCRIPTION
Expands the list of features that appear in rustdoc documentation published to https://docs.rs/elliptic-curve/ to include all of the newly added features which shipped in v0.11.8.

We'll need to publish a v0.11.9 in order for this to render.