### PR TITLE
elliptic-curve v0.11.9

### DIFF
--- a/crypto/Cargo.lock
+++ b/crypto/Cargo.lock
@@ -119,7 +119,7 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.11.8"
+version = "0.11.9"
 dependencies = [
  "base16ct",
  "crypto-bigint",

--- a/elliptic-curve/CHANGELOG.md
+++ b/elliptic-curve/CHANGELOG.md
@@ -4,7 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.11.8 (2021-01-15)
+## 0.11.9 (2022-01-17)
+### Changed
+- Activate `bits`, `hash2curve`, and `voprf` features on docs.rs ([#891])
+
+[#891]: https://github.com/RustCrypto/traits/pull/891
+
+## 0.11.8 (2022-01-15)
 ### Added
 - Impl `ZeroizeOnDrop` on appropriate items ([#884])
 
@@ -16,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#887]: https://github.com/RustCrypto/traits/pull/887
 [#888]: https://github.com/RustCrypto/traits/pull/888
 
-## 0.11.7 (2021-01-14)
+## 0.11.7 (2022-01-14)
 ### Added
 - Initial hash-to-field support ([#854], [#855], [#871], [#874])
 - Initial hash-to-curve support ([#865], [#876])

--- a/elliptic-curve/Cargo.lock
+++ b/elliptic-curve/Cargo.lock
@@ -96,7 +96,7 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.11.8"
+version = "0.11.9"
 dependencies = [
  "base16ct",
  "base64ct",

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elliptic-curve"
-version = "0.11.8" # Also update html_root_url in lib.rs when bumping this
+version = "0.11.9" # Also update html_root_url in lib.rs when bumping this
 description = """
 General purpose Elliptic Curve Cryptography (ECC) support, including types
 and traits for representing various elliptic curve forms, scalars, points,

--- a/elliptic-curve/LICENSE-MIT
+++ b/elliptic-curve/LICENSE-MIT
@@ -1,4 +1,4 @@
-Copyright (c) 2020 RustCrypto Developers
+Copyright (c) 2020-2022 RustCrypto Developers
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated

--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -5,7 +5,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
-    html_root_url = "https://docs.rs/elliptic-curve/0.11.8"
+    html_root_url = "https://docs.rs/elliptic-curve/0.11.9"
 )]
 #![doc = include_str!("../README.md")]
 


### PR DESCRIPTION
### Changed
- Activate `bits`, `hash2curve`, and `voprf` features on docs.rs ([#891])

[#891]: https://github.com/RustCrypto/traits/pull/891