### PR TITLE
elliptic-curve: bump version to 0.12 prerelease

### DIFF
--- a/crypto/Cargo.lock
+++ b/crypto/Cargo.lock
@@ -119,7 +119,7 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.11.9"
+version = "0.12.0-pre"
 dependencies = [
  "base16ct",
  "crypto-bigint",

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -22,7 +22,7 @@ members = ["."]
 aead = { version = "0.4", optional = true, path = "../aead" }
 cipher = { version = "0.3", optional = true }
 digest = { version = "0.10", optional = true }
-elliptic-curve = { version = "0.11", optional = true, path = "../elliptic-curve" }
+elliptic-curve = { version = "0.12.0-pre", optional = true, path = "../elliptic-curve" }
 mac = { version = "0.11", package = "crypto-mac", optional = true }
 password-hash = { version = "0.3", optional = true, path = "../password-hash" }
 signature = { version = "1.5", optional = true, default-features = false, path = "../signature" }

--- a/elliptic-curve/Cargo.lock
+++ b/elliptic-curve/Cargo.lock
@@ -100,7 +100,7 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.11.9"
+version = "0.12.0-pre"
 dependencies = [
  "base16ct",
  "base64ct",

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elliptic-curve"
-version = "0.11.9" # Also update html_root_url in lib.rs when bumping this
+version = "0.12.0-pre" # Also update html_root_url in lib.rs when bumping this
 description = """
 General purpose Elliptic Curve Cryptography (ECC) support, including types
 and traits for representing various elliptic curve forms, scalars, points,

--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -5,7 +5,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
-    html_root_url = "https://docs.rs/elliptic-curve/0.11.9"
+    html_root_url = "https://docs.rs/elliptic-curve/0.12.0-pre"
 )]
 #![doc = include_str!("../README.md")]
 


### PR DESCRIPTION
Switching over to making breaking changes again now that #883 is merged.

There are a number of other pent up breaking changes that have been desired which we can now start working on.