### PR TITLE
elliptic-curve: make `NonZeroScalar::invert` infallible

### DIFF
--- a/elliptic-curve/src/ops.rs
+++ b/elliptic-curve/src/ops.rs
@@ -3,10 +3,9 @@
 pub use core::ops::{Add, AddAssign, Mul, Neg, Sub, SubAssign};
 
 use crypto_bigint::{ArrayEncoding, ByteArray, Integer};
-use subtle::CtOption;
 
 #[cfg(feature = "arithmetic")]
-use group::Group;
+use {group::Group, subtle::CtOption};
 
 #[cfg(feature = "digest")]
 use digest::{core_api::BlockSizeUser, Digest, FixedOutput, Reset};
@@ -17,12 +16,12 @@ pub trait Invert {
     type Output;
 
     /// Invert a field element.
-    fn invert(&self) -> CtOption<Self::Output>;
+    fn invert(&self) -> Self::Output;
 }
 
 #[cfg(feature = "arithmetic")]
 impl<F: ff::Field> Invert for F {
-    type Output = F;
+    type Output = CtOption<F>;
 
     fn invert(&self) -> CtOption<F> {
         ff::Field::invert(self)

--- a/elliptic-curve/src/scalar/nonzero.rs
+++ b/elliptic-curve/src/scalar/nonzero.rs
@@ -170,11 +170,13 @@ impl<C> Invert for NonZeroScalar<C>
 where
     C: Curve + ScalarArithmetic,
 {
-    type Output = Scalar<C>;
+    type Output = Self;
 
-    /// Perform a scalar inversion
-    fn invert(&self) -> CtOption<Self::Output> {
-        ff::Field::invert(&self.scalar)
+    fn invert(&self) -> Self {
+        Self {
+            // This will always succeed since `scalar` will never be 0
+            scalar: ff::Field::invert(&self.scalar).unwrap(),
+        }
     }
 }
 


### PR DESCRIPTION
Because `NonZeroScalar` means we'll never divide by 0, it's possible to make the implementation infallible.

To accomplish this, `CtOption` is removed from the `Invert` trait's signature, and used as the result type for scalars that are potentially zero as part of the blanket impl of `Invert`.

Fixes RustCrypto/elliptic-curves#499