### PR TITLE
elliptic-curve: make `ToCompactEncodedPoint` return `CtOption`

### DIFF
--- a/elliptic-curve/src/sec1.rs
+++ b/elliptic-curve/src/sec1.rs
@@ -49,7 +49,7 @@ where
 {
     /// Serialize this value as a SEC1 [`EncodedPoint`], optionally applying
     /// point compression.
-    fn to_compact_encoded_point(&self) -> Option<EncodedPoint<C>>;
+    fn to_compact_encoded_point(&self) -> CtOption<EncodedPoint<C>>;
 }
 
 /// Validate that the given [`EncodedPoint`] represents the encoded public key


### PR DESCRIPTION
This is more consistent with the `ToEncodedPoint` trait.