### PR TITLE
password-hash: leverage `const_panic`; MSRV 1.57

### DIFF
--- a/.github/workflows/crypto.yml
+++ b/.github/workflows/crypto.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.56.0 # MSRV
+          - 1.57.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -43,7 +43,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.56.0 # MSRV
+          - 1.57.0 # MSRV
           - stable
     steps:
     - uses: actions/checkout@v1
@@ -63,7 +63,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.56.0
+          toolchain: 1.57.0
           components: clippy
           override: true
           profile: minimal

--- a/.github/workflows/password-hash.yml
+++ b/.github/workflows/password-hash.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.47.0 # MSRV
+          - 1.57.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -44,7 +44,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.47.0 # MSRV
+          - 1.57.0 # MSRV
           - stable
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/checkout@v1
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: 1.56.0
+        toolchain: 1.57.0
         components: clippy
         override: true
         profile: minimal

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -199,7 +199,7 @@ dependencies = [
 
 [[package]]
 name = "password-hash"
-version = "0.3.2"
+version = "0.4.0-pre"
 dependencies = [
  "base64ct",
  "rand_core",

--- a/crypto/Cargo.lock
+++ b/crypto/Cargo.lock
@@ -183,7 +183,7 @@ checksum = "fbe5e23404da5b4f555ef85ebed98fb4083e55a00c317800bc2a50ede9f3d219"
 
 [[package]]
 name = "password-hash"
-version = "0.3.2"
+version = "0.4.0-pre"
 dependencies = [
  "base64ct",
  "rand_core",

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["crypto", "encryption", "rustcrypto"]
 categories = ["cryptography", "no-std"]
 readme = "README.md"
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.57"
 
 # Hack to allow this crate to coexist with pre-2021 edition crates
 [workspace]
@@ -24,7 +24,7 @@ cipher = { version = "0.3", optional = true }
 digest = { version = "0.10", optional = true }
 elliptic-curve = { version = "0.12.0-pre", optional = true, path = "../elliptic-curve" }
 mac = { version = "0.11", package = "crypto-mac", optional = true }
-password-hash = { version = "0.3", optional = true, path = "../password-hash" }
+password-hash = { version = "=0.4.0-pre", optional = true, path = "../password-hash" }
 signature = { version = "1.5", optional = true, default-features = false, path = "../signature" }
 universal-hash = { version = "0.4", optional = true, path = "../universal-hash" }
 

--- a/crypto/README.md
+++ b/crypto/README.md
@@ -14,7 +14,7 @@ access compatible versions of all traits from the Rust Crypto project.
 
 ## Minimum Supported Rust Version
 
-Rust **1.56** or higher.
+Rust **1.57** or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be
 done with a minor version bump.
@@ -46,7 +46,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/crypto/badge.svg
 [docs-link]: https://docs.rs/crypto/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.56+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.57+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260050-Traits
 [build-image]: https://github.com/RustCrypto/traits/workflows/crypto/badge.svg?branch=master&event=push

--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -1,3 +1,12 @@
+#![no_std]
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
+    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
+    html_root_url = "https://docs.rs/crypto/0.4.0-pre"
+)]
+#![forbid(unsafe_code)]
+#![warn(rust_2018_idioms)]
+
 //! Facade crate for [RustCrypto Traits][1], providing a single place to
 //! access compatible versions of all traits from the Rust Crypto project.
 //!
@@ -34,15 +43,6 @@
 //!
 //! [1]: https://github.com/RustCrypto/traits
 //! [2]: https://github.com/RustCrypto
-
-#![no_std]
-#![doc(
-    html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
-    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
-    html_root_url = "https://docs.rs/crypto/0.4.0-pre"
-)]
-#![forbid(unsafe_code)]
-#![warn(rust_2018_idioms)]
 
 #[cfg(feature = "aead")]
 pub use aead;

--- a/password-hash/Cargo.toml
+++ b/password-hash/Cargo.toml
@@ -5,7 +5,7 @@ Traits which describe the functionality of password hashing algorithms,
 as well as a `no_std`-friendly implementation of the PHC string format
 (a well-defined subset of the Modular Crypt Format a.k.a. MCF)
 """
-version = "0.3.2" # Also update html_root_url in lib.rs when bumping this
+version = "0.4.0-pre" # Also update html_root_url in lib.rs when bumping this
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/password-hash/README.md
+++ b/password-hash/README.md
@@ -20,7 +20,7 @@ these traits.
 
 ## Minimum Supported Rust Version
 
-Rust **1.47** or higher.
+Rust **1.57** or higher.
 
 Minimum supported Rust version may be changed in the future, but it will be
 accompanied by a minor version bump.
@@ -52,7 +52,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/password-hash/badge.svg
 [docs-link]: https://docs.rs/password-hash/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.47+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.57+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260046-password-hashes
 [build-image]: https://github.com/RustCrypto/traits/workflows/password-hash/badge.svg?branch=master&event=push

--- a/password-hash/src/ident.rs
+++ b/password-hash/src/ident.rs
@@ -60,23 +60,14 @@ impl<'a> Ident<'a> {
     pub const fn new(s: &'a str) -> Self {
         let input = s.as_bytes();
 
-        /// Constant panicking assertion.
-        // TODO(tarcieri): use const panic when stable.
-        // See: https://github.com/rust-lang/rust/issues/51999
-        macro_rules! const_assert {
-            ($bool:expr, $msg:expr) => {
-                [$msg][!$bool as usize]
-            };
-        }
-
-        const_assert!(!input.is_empty(), "PHC ident string can't be empty");
-        const_assert!(input.len() <= Self::MAX_LENGTH, "PHC ident string too long");
+        assert!(!input.is_empty(), "PHC ident string can't be empty");
+        assert!(input.len() <= Self::MAX_LENGTH, "PHC ident string too long");
 
         macro_rules! validate_chars {
             ($($pos:expr),+) => {
                 $(
                     if $pos < input.len() {
-                        const_assert!(
+                        assert!(
                             is_char_valid(input[$pos]),
                             "invalid character in PHC string ident"
                         );

--- a/password-hash/src/lib.rs
+++ b/password-hash/src/lib.rs
@@ -39,7 +39,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
-    html_root_url = "https://docs.rs/password-hash/0.3.2"
+    html_root_url = "https://docs.rs/password-hash/0.4.0-pre"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, unused_lifetimes)]


### PR DESCRIPTION
Leverages the newly stabilized support for panicking in const contexts to replace the hack `const_assert!` macro.

After this, it will also be trivial to bump to the 2021 edition.