### PR TITLE
password-hash: remove `base64ct` version restrictions

### DIFF
--- a/password-hash/Cargo.lock
+++ b/password-hash/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "base64ct"
-version = "1.0.1"
+version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a32fd6af2b5827bce66c29053ba0e7c42b9dcab01835835058558c10851a46b"
+checksum = "874f8444adcb4952a8bc51305c8be95c8ec8237bb0d2e78d2e039f771f8828a0"
 
 [[package]]
 name = "cfg-if"

--- a/password-hash/Cargo.toml
+++ b/password-hash/Cargo.toml
@@ -21,7 +21,7 @@ rust-version = "1.57"
 members = ["."]
 
 [dependencies]
-base64ct = ">=1, <1.1.0"
+base64ct = "1"
 subtle = { version = ">=2, <2.5", default-features = false }
 
 # optional features


### PR DESCRIPTION
These were in place to prevent MSRV-related breakages.

Now that `password-hash` has been bumped to a higher MSRV than `base64ct`, it's no longer needed.