### PR TITLE
elliptic-curve: v0.11.11 changelog entry

### DIFF
--- a/elliptic-curve/CHANGELOG.md
+++ b/elliptic-curve/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.11.11 (2022-01-30)
+- No changes; triggering a docs.rs rebuild
+
 ## 0.11.10 (2022-01-27)
 ### Changed
 - Revert [#884] to support a wider range of `zeroize` versions ([#923])


### PR DESCRIPTION
It looks like the docs.rs build for v0.11.10 failed due to nightly bugs:

https://docs.rs/crate/elliptic-curve/0.11.10/builds/500473

This adds a changelog entry for a v0.11.11 release, which is unchanged from v0.11.10, but released again to trigger a new docs.rs build.

The `master` branch is already the v0.12 prerelease series, so this commit doesn't contain a full release.