### PR TITLE
elliptic-curve v0.11.12

### DIFF
--- a/elliptic-curve/CHANGELOG.md
+++ b/elliptic-curve/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.11.12 (2022-01-30)
+### Changed
+- Disable `bits` feature on docs.rs due to nightly breakage
+
 ## 0.11.11 (2022-01-30)
 - No changes; triggering a docs.rs rebuild
 

--- a/elliptic-curve/CHANGELOG.md
+++ b/elliptic-curve/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.11.11 (2022-01-30)
+- No changes; triggering a docs.rs rebuild
+
 ## 0.11.10 (2022-01-27)
 ### Changed
 - Revert [#884] to support a wider range of `zeroize` versions.

--- a/elliptic-curve/CHANGELOG.md
+++ b/elliptic-curve/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.11.10 (2022-01-27)
+### Changed
+- Revert [#884] to support a wider range of `zeroize` versions.
+
 ## 0.11.9 (2022-01-17)
 ### Changed
 - Activate `bits`, `hash2curve`, and `voprf` features on docs.rs ([#891])

--- a/elliptic-curve/Cargo.lock
+++ b/elliptic-curve/Cargo.lock
@@ -96,7 +96,7 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.11.11"
+version = "0.11.12"
 dependencies = [
  "base16ct",
  "base64ct",

--- a/elliptic-curve/Cargo.lock
+++ b/elliptic-curve/Cargo.lock
@@ -96,7 +96,7 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.11.9"
+version = "0.11.10"
 dependencies = [
  "base16ct",
  "base64ct",

--- a/elliptic-curve/Cargo.lock
+++ b/elliptic-curve/Cargo.lock
@@ -96,7 +96,7 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.11.10"
+version = "0.11.11"
 dependencies = [
  "base16ct",
  "base64ct",

--- a/elliptic-curve/Cargo.lock
+++ b/elliptic-curve/Cargo.lock
@@ -344,6 +344,6 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.5.0"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc222aec311c323c717f56060324f32b82da1ce1dd81d9a09aa6a9030bfe08db"
+checksum = "d68d9dcec5f9b43a30d38c49f91dfedfaac384cb8f085faca366c26207dd1619"

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elliptic-curve"
-version = "0.11.10" # Also update html_root_url in lib.rs when bumping this
+version = "0.11.11" # Also update html_root_url in lib.rs when bumping this
 description = """
 General purpose Elliptic Curve Cryptography (ECC) support, including types
 and traits for representing various elliptic curve forms, scalars, points,

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -26,7 +26,7 @@ der = { version = "0.5", default-features = false, features = ["oid"] }
 generic-array = { version = "0.14", default-features = false }
 rand_core = { version = "0.6", default-features = false }
 subtle = { version = "2", default-features = false }
-zeroize = { version = "1.5", default-features = false }
+zeroize = { version = "1", default-features = false }
 
 # optional dependencies
 base64ct = { version = "1", optional = true, default-features = false }

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elliptic-curve"
-version = "0.11.9" # Also update html_root_url in lib.rs when bumping this
+version = "0.11.10" # Also update html_root_url in lib.rs when bumping this
 description = """
 General purpose Elliptic Curve Cryptography (ECC) support, including types
 and traits for representing various elliptic curve forms, scalars, points,

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elliptic-curve"
-version = "0.11.11" # Also update html_root_url in lib.rs when bumping this
+version = "0.11.12" # Also update html_root_url in lib.rs when bumping this
 description = """
 General purpose Elliptic Curve Cryptography (ECC) support, including types
 and traits for representing various elliptic curve forms, scalars, points,
@@ -60,5 +60,5 @@ std = ["alloc", "rand_core/std"]
 voprf = ["digest"]
 
 [package.metadata.docs.rs]
-features = ["bits", "ecdh", "hash2curve", "jwk", "pem", "std", "voprf"]
+features = ["ecdh", "hash2curve", "jwk", "pem", "std", "voprf"]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/elliptic-curve/src/ecdh.rs
+++ b/elliptic-curve/src/ecdh.rs
@@ -33,7 +33,7 @@ use crate::{
 use core::borrow::Borrow;
 use group::Curve as _;
 use rand_core::{CryptoRng, RngCore};
-use zeroize::{Zeroize, ZeroizeOnDrop};
+use zeroize::Zeroize;
 
 /// Low-level Elliptic Curve Diffie-Hellman (ECDH) function.
 ///
@@ -138,8 +138,6 @@ where
     }
 }
 
-impl<C> ZeroizeOnDrop for EphemeralSecret<C> where C: Curve + ProjectiveArithmetic {}
-
 impl<C> Drop for EphemeralSecret<C>
 where
     C: Curve + ProjectiveArithmetic,
@@ -209,8 +207,6 @@ impl<C: Curve> Zeroize for SharedSecret<C> {
         self.secret_bytes.zeroize()
     }
 }
-
-impl<C: Curve> ZeroizeOnDrop for SharedSecret<C> {}
 
 impl<C: Curve> Drop for SharedSecret<C> {
     fn drop(&mut self) {

--- a/elliptic-curve/src/jwk.rs
+++ b/elliptic-curve/src/jwk.rs
@@ -20,7 +20,7 @@ use core::{
     str::{self, FromStr},
 };
 use serde::{de, ser, Deserialize, Serialize};
-use zeroize::{Zeroize, ZeroizeOnDrop};
+use zeroize::Zeroize;
 
 #[cfg(feature = "arithmetic")]
 use crate::{
@@ -344,8 +344,6 @@ impl PartialEq for JwkEcKey {
 }
 
 impl Eq for JwkEcKey {}
-
-impl ZeroizeOnDrop for JwkEcKey {}
 
 impl Drop for JwkEcKey {
     fn drop(&mut self) {

--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -5,7 +5,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
-    html_root_url = "https://docs.rs/elliptic-curve/0.11.10"
+    html_root_url = "https://docs.rs/elliptic-curve/0.11.11"
 )]
 #![doc = include_str!("../README.md")]
 

--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -5,7 +5,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
-    html_root_url = "https://docs.rs/elliptic-curve/0.11.11"
+    html_root_url = "https://docs.rs/elliptic-curve/0.11.12"
 )]
 #![doc = include_str!("../README.md")]
 

--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -5,7 +5,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
-    html_root_url = "https://docs.rs/elliptic-curve/0.11.9"
+    html_root_url = "https://docs.rs/elliptic-curve/0.11.10"
 )]
 #![doc = include_str!("../README.md")]
 

--- a/elliptic-curve/src/secret_key.rs
+++ b/elliptic-curve/src/secret_key.rs
@@ -15,7 +15,7 @@ use core::fmt::{self, Debug};
 use crypto_bigint::Encoding;
 use generic_array::GenericArray;
 use subtle::{Choice, ConstantTimeEq};
-use zeroize::{Zeroize, ZeroizeOnDrop};
+use zeroize::Zeroize;
 
 #[cfg(all(feature = "alloc", feature = "arithmetic"))]
 use {
@@ -324,8 +324,6 @@ where
         write!(f, "SecretKey<{:?}>{{ ... }}", C::default())
     }
 }
-
-impl<C> ZeroizeOnDrop for SecretKey<C> where C: Curve {}
 
 impl<C> Drop for SecretKey<C>
 where


### PR DESCRIPTION
This release disables the `bits` feature on https://docs.rs because the doc builds are failing due to a nightly breakage:

https://docs.rs/crate/elliptic-curve/0.11.11/builds/501817

Locally I've confirmed the docs build successfully if the `bits` feature is not enabled, so this should hopefully be sufficient to get the docs building again.

This PR won't be merged: I've opened it for posterity to test will be tagged `elliptic-curve-v0.11.12`.