### PR TITLE
elliptic-curve: add v0.11.12 changelog entry

### DIFF
--- a/elliptic-curve/CHANGELOG.md
+++ b/elliptic-curve/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.11.12 (2022-01-30)
+### Changed
+- Disable `bits` feature on docs.rs due to nightly breakage ([#927])
+
+[#927]: https://github.com/RustCrypto/traits/pull/927
+
 ## 0.11.11 (2022-01-30)
 - No changes; triggering a docs.rs rebuild
 


### PR DESCRIPTION
This was released in #927, and disabled the `bits` feature on docs.rs to work around a nightly breakage building the docs there.

Since `master` is already the v0.12 prerelease series, this commit merely documents the release.