### PR TITLE
Fix compilation

### DIFF
--- a/cipher/src/block.rs
+++ b/cipher/src/block.rs
@@ -527,11 +527,11 @@ impl<Alg: BlockDecrypt> BlockDecrypt for &Alg {
 }
 
 /// Closure used in methods which operate over separate blocks.
-struct BlockCtx<'inp, 'out, BS: ArrayLength<u8>> {
+struct BlockCtx<'inp, 'out, BS: 'static + ArrayLength<u8>> {
     block: InOut<'inp, 'out, Block<Self>>,
 }
 
-impl<'inp, 'out, BS: ArrayLength<u8>> BlockSizeUser for BlockCtx<'inp, 'out, BS> {
+impl<'inp, 'out, BS: 'static + ArrayLength<u8>> BlockSizeUser for BlockCtx<'inp, 'out, BS> {
     type BlockSize = BS;
 }
 
@@ -543,11 +543,11 @@ impl<'inp, 'out, BS: ArrayLength<u8>> BlockClosure for BlockCtx<'inp, 'out, BS> 
 }
 
 /// Closure used in methods which operate over slice of blocks.
-struct BlocksCtx<'inp, 'out, BS: ArrayLength<u8>> {
+struct BlocksCtx<'inp, 'out, BS: 'static + ArrayLength<u8>> {
     blocks: InOutBuf<'inp, 'out, Block<Self>>,
 }
 
-impl<'inp, 'out, BS: ArrayLength<u8>> BlockSizeUser for BlocksCtx<'inp, 'out, BS> {
+impl<'inp, 'out, BS: 'static + ArrayLength<u8>> BlockSizeUser for BlocksCtx<'inp, 'out, BS> {
     type BlockSize = BS;
 }
 

--- a/cipher/src/stream_core.rs
+++ b/cipher/src/stream_core.rs
@@ -211,10 +211,10 @@ fn into_chunks<T, N: ArrayLength<T>>(buf: &mut [T]) -> (&mut [GenericArray<T, N>
     }
 }
 
-struct WriteBlockCtx<'a, BS: ArrayLength<u8>> {
+struct WriteBlockCtx<'a, BS: 'static + ArrayLength<u8>> {
     block: &'a mut Block<Self>,
 }
-impl<'a, BS: ArrayLength<u8>> BlockSizeUser for WriteBlockCtx<'a, BS> {
+impl<'a, BS: 'static + ArrayLength<u8>> BlockSizeUser for WriteBlockCtx<'a, BS> {
     type BlockSize = BS;
 }
 impl<'a, BS: ArrayLength<u8>> StreamClosure for WriteBlockCtx<'a, BS> {
@@ -224,10 +224,10 @@ impl<'a, BS: ArrayLength<u8>> StreamClosure for WriteBlockCtx<'a, BS> {
     }
 }
 
-struct WriteBlocksCtx<'a, BS: ArrayLength<u8>> {
+struct WriteBlocksCtx<'a, BS: 'static + ArrayLength<u8>> {
     blocks: &'a mut [Block<Self>],
 }
-impl<'a, BS: ArrayLength<u8>> BlockSizeUser for WriteBlocksCtx<'a, BS> {
+impl<'a, BS: 'static + ArrayLength<u8>> BlockSizeUser for WriteBlocksCtx<'a, BS> {
     type BlockSize = BS;
 }
 impl<'a, BS: ArrayLength<u8>> StreamClosure for WriteBlocksCtx<'a, BS> {
@@ -247,11 +247,11 @@ impl<'a, BS: ArrayLength<u8>> StreamClosure for WriteBlocksCtx<'a, BS> {
     }
 }
 
-struct ApplyBlockCtx<'inp, 'out, BS: ArrayLength<u8>> {
+struct ApplyBlockCtx<'inp, 'out, BS: 'static + ArrayLength<u8>> {
     block: InOut<'inp, 'out, Block<Self>>,
 }
 
-impl<'inp, 'out, BS: ArrayLength<u8>> BlockSizeUser for ApplyBlockCtx<'inp, 'out, BS> {
+impl<'inp, 'out, BS: 'static + ArrayLength<u8>> BlockSizeUser for ApplyBlockCtx<'inp, 'out, BS> {
     type BlockSize = BS;
 }
 
@@ -264,11 +264,11 @@ impl<'inp, 'out, BS: ArrayLength<u8>> StreamClosure for ApplyBlockCtx<'inp, 'out
     }
 }
 
-struct ApplyBlocksCtx<'inp, 'out, BS: ArrayLength<u8>> {
+struct ApplyBlocksCtx<'inp, 'out, BS: 'static + ArrayLength<u8>> {
     blocks: InOutBuf<'inp, 'out, Block<Self>>,
 }
 
-impl<'inp, 'out, BS: ArrayLength<u8>> BlockSizeUser for ApplyBlocksCtx<'inp, 'out, BS> {
+impl<'inp, 'out, BS: 'static + ArrayLength<u8>> BlockSizeUser for ApplyBlocksCtx<'inp, 'out, BS> {
     type BlockSize = BS;
 }
 


### PR DESCRIPTION
Downstream users can't have concrete instantiations on these traits. For example [AEADs](https://github.com/RustCrypto/AEADs) don't compile when depending on v0.4.

See https://github.com/RustCrypto/block-ciphers/issues/302.