### PR TITLE
Fix minimal versions build by using typenum 1.14 or higher

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,14 +70,6 @@ dependencies = [
 [[package]]
 name = "crypto-common"
 version = "0.1.2"
-dependencies = [
- "generic-array",
- "rand_core",
-]
-
-[[package]]
-name = "crypto-common"
-version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4600d695eb3f6ce1cd44e6e291adceb2cc3ab12f20a33777ecd0bf6eba34e06"
 dependencies = [
@@ -85,13 +77,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "digest"
-version = "0.10.2"
+name = "crypto-common"
+version = "0.1.3"
 dependencies = [
- "blobby",
- "block-buffer",
- "crypto-common 0.1.2",
- "subtle",
+ "generic-array",
+ "rand_core",
+ "typenum",
 ]
 
 [[package]]
@@ -101,7 +92,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cb780dce4f9a8f5c087362b3a4595936b2019e7c8b30f2c3e9a7e94e6ae9837"
 dependencies = [
  "block-buffer",
- "crypto-common 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crypto-common 0.1.2",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.3"
+dependencies = [
+ "blobby",
+ "block-buffer",
+ "crypto-common 0.1.3",
+ "subtle",
 ]
 
 [[package]]
@@ -166,9 +167,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e74d72e0f9b65b5b4ca49a346af3976df0f9c61d550727f349ecd559f251a26c"
+checksum = "06e509672465a0504304aa87f9f176f2b2b716ed8fb105ebe5c02dc6dce96a94"
 
 [[package]]
 name = "lock_api"
@@ -226,14 +227,14 @@ checksum = "99c3bd8169c58782adad9290a9af5939994036b76187f7b4f0e6de91dbbfc0ec"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "digest 0.10.2",
 ]
 
 [[package]]
 name = "signature"
 version = "1.5.0"
 dependencies = [
- "digest 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "digest 0.10.2",
  "hex-literal",
  "rand_core",
  "sha2",

--- a/cipher/CHANGELOG.md
+++ b/cipher/CHANGELOG.md
@@ -5,13 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## UNRELEASED
+## 0.4.1 (2022-02-16)
 ### Added
 - Allocating padded encrypt/decrypt ([#936])
 
+### Fixed
+- Minimal versions build ([#940])
+
+[#940]: https://github.com/RustCrypto/traits/pull/940
 [#936]: https://github.com/RustCrypto/traits/pull/936
 
-## 0.3.0 (2022-02-10)
+## 0.4.0 (2022-02-10)
 ### Changed
 - Major rework of traits. Core functionality of block and stream ciphers
 is defined using rank-2 closures with convinience methods built on top of

--- a/cipher/Cargo.lock
+++ b/cipher/Cargo.lock
@@ -29,10 +29,11 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "generic-array",
  "rand_core",
+ "typenum",
 ]
 
 [[package]]

--- a/cipher/Cargo.toml
+++ b/cipher/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cipher"
 description = "Traits for describing block ciphers and stream ciphers"
-version = "0.4.0" # Also update html_root_url in lib.rs when bumping this
+version = "0.4.1" # Also update html_root_url in lib.rs when bumping this
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
@@ -17,7 +17,7 @@ categories = ["cryptography", "no-std"]
 members = ["."]
 
 [dependencies]
-crypto-common = { version = "0.1.2", path = "../crypto-common" }
+crypto-common = { version = "0.1.3", path = "../crypto-common" }
 inout = "0.1"
 
 # optional dependencies

--- a/cipher/src/lib.rs
+++ b/cipher/src/lib.rs
@@ -10,7 +10,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg",
-    html_root_url = "https://docs.rs/cipher/0.4.0"
+    html_root_url = "https://docs.rs/cipher/0.4.1"
 )]
 #![warn(missing_docs, rust_2018_idioms)]
 

--- a/crypto-common/CHANGELOG.md
+++ b/crypto-common/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.3 (2022-02-16)
+### Fixed
+- Minimal versions build ([#940])
+
+[#940]: https://github.com/RustCrypto/traits/pull/940
+
 ## 0.1.2 (2022-02-10)
 ### Added
 - Re-export `generic-array` and `typenum`. Enable `more_lengths` feature on

--- a/crypto-common/Cargo.toml
+++ b/crypto-common/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "crypto-common"
 description = "Common cryptographic traits"
-version = "0.1.2" # Also update html_root_url in lib.rs when bumping this
+version = "0.1.3" # Also update html_root_url in lib.rs when bumping this
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
@@ -14,6 +14,8 @@ categories = ["cryptography", "no-std"]
 [dependencies]
 generic-array = { version = "0.14.4", features = ["more_lengths"] }
 rand_core = { version = "0.6", optional = true }
+# earlier versions of typenum don't satisfy the 'static bound on U* types
+typenum = "1.14"
 
 [features]
 std = []

--- a/crypto-common/src/lib.rs
+++ b/crypto-common/src/lib.rs
@@ -5,7 +5,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg",
-    html_root_url = "https://docs.rs/crypto-common/0.1.1"
+    html_root_url = "https://docs.rs/crypto-common/0.1.3"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]

--- a/digest/CHANGELOG.md
+++ b/digest/CHANGELOG.md
@@ -5,9 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.10.3 (2022-02-16)
+### Fixed
+- Minimal versions build ([#940])
+
+[#940]: https://github.com/RustCrypto/traits/pull/940
+
 ## 0.10.2 (2022-02-10)
 ### Changed
-- Relaxed bounds on the `Mac` trait ([#849])
+- Relax bounds on the `Mac` trait ([#849])
 
 [#849]: https://github.com/RustCrypto/traits/pull/849
 

--- a/digest/Cargo.toml
+++ b/digest/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "digest"
 description = "Traits for cryptographic hash functions"
-version = "0.10.2" # Also update html_root_url in lib.rs when bumping this
+version = "0.10.3" # Also update html_root_url in lib.rs when bumping this
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
@@ -12,7 +12,7 @@ keywords = ["digest", "crypto", "hash"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-crypto-common = { version = "0.1.2", path = "../crypto-common" }
+crypto-common = { version = "0.1.3", path = "../crypto-common" }
 
 block-buffer = { version = "0.10", optional = true }
 subtle = { version = "=2.4", default-features = false, optional = true }

--- a/digest/src/lib.rs
+++ b/digest/src/lib.rs
@@ -28,7 +28,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg",
-    html_root_url = "https://docs.rs/digest/0.10.2"
+    html_root_url = "https://docs.rs/digest/0.10.3"
 )]
 #![warn(missing_docs, rust_2018_idioms)]
 

--- a/elliptic-curve/Cargo.lock
+++ b/elliptic-curve/Cargo.lock
@@ -190,9 +190,9 @@ checksum = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
 
 [[package]]
 name = "libc"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e74d72e0f9b65b5b4ca49a346af3976df0f9c61d550727f349ecd559f251a26c"
+checksum = "06e509672465a0504304aa87f9f176f2b2b716ed8fb105ebe5c02dc6dce96a94"
 
 [[package]]
 name = "pem-rfc7468"
@@ -256,9 +256,9 @@ checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
 
 [[package]]
 name = "serde_json"
-version = "1.0.78"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d23c1ba4cf0efd44be32017709280b32d1cea5c3f1275c3b6d9e8bc54f758085"
+checksum = "8e8d9fa5c3b304765ce1fd9c4c8a3de2c8db365a5b91be52f186efc675681d95"
 dependencies = [
  "itoa",
  "ryu",

--- a/kem/Cargo.lock
+++ b/kem/Cargo.lock
@@ -243,9 +243,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
+checksum = "418d37c8b1d42553c93648be529cb70f920d3baf8ef469b74b9638df426e0b4c"
 dependencies = [
  "cfg-if",
  "libc",
@@ -344,9 +344,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.112"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b03d17f364a3a042d5e5d46b053bbbf82c92c9430c592dd4c064dc6ee997125"
+checksum = "06e509672465a0504304aa87f9f176f2b2b716ed8fb105ebe5c02dc6dce96a94"
 
 [[package]]
 name = "opaque-debug"
@@ -472,23 +472,22 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47aa80447ce4daf1717500037052af176af5d38cc3e571d9ec1c7353fc10c87d"
+checksum = "864d3e96a899863136fc6e99f3d7cae289dafe43bf2c5ac19b70df7210c0a145"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "rand"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha",
  "rand_core 0.6.3",
- "rand_hc",
 ]
 
 [[package]]
@@ -517,19 +516,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_hc"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
-dependencies = [
- "rand_core 0.6.3",
-]
-
-[[package]]
 name = "serde"
-version = "1.0.132"
+version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b9875c23cf305cd1fd7eb77234cbb705f21ea6a72c637a5c6db5fe4b8e7f008"
+checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
 dependencies = [
  "serde_derive",
 ]
@@ -545,9 +535,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.132"
+version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc0db5cb2556c0e558887d9bbdcf6ac4471e83ff66cf696e5419024d1606276"
+checksum = "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -556,9 +546,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b69f9a4c9740d74c5baa3fd2e547f9525fa8088a8a958e0ca2409a514e33f5fa"
+checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
 dependencies = [
  "block-buffer",
  "cfg-if",
@@ -594,9 +584,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.84"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecb2e6da8ee5eb9a61068762a32fa9619cc591ceb055b3687f4cd4051ec2e06b"
+checksum = "8a65b3f4ffa0092e9887669db0eae07941f023991ab58ea44da8fe8e2d511c6b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -689,9 +679,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize_derive"
-version = "1.2.2"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65f1a51723ec88c66d5d1fe80c841f17f63587d6691901d66be9bec6c3b51f73"
+checksum = "81e8f13fef10b63c06356d65d416b070798ddabcadc10d3ece0c5be9b3c7eddb"
 dependencies = [
  "proc-macro2",
  "quote",


### PR DESCRIPTION
Relevant to #162 

Fixing the `kem` crate would be more difficult. With min versions it even manages to pull `libc v0.1` (sic!). It looks like there are issues in its dependencies which are outside of our org.