### PR TITLE
cipher: rename BlockDecryptMut::decrypt_padded_vec to decrypt_padded_vec_mut

### DIFF
--- a/cipher/CHANGELOG.md
+++ b/cipher/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.4.1 (2022-02-16)
+## 0.4.2 (2022-02-16)
+### Fixed
+- Rename `BlockDecryptMut::decrypt_padded_vec` to `decrypt_padded_vec_mut` for consistency with other methods ([#941])
+
+[#941]: https://github.com/RustCrypto/traits/pull/941
+
+## 0.4.1 (2022-02-16) [YANKED]
 ### Added
 - Allocating padded encrypt/decrypt ([#936])
 

--- a/cipher/Cargo.lock
+++ b/cipher/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "cipher"
-version = "0.4.0"
+version = "0.4.2"
 dependencies = [
  "blobby",
  "crypto-common",

--- a/cipher/Cargo.toml
+++ b/cipher/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cipher"
 description = "Traits for describing block ciphers and stream ciphers"
-version = "0.4.1" # Also update html_root_url in lib.rs when bumping this
+version = "0.4.2" # Also update html_root_url in lib.rs when bumping this
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/cipher/src/block.rs
+++ b/cipher/src/block.rs
@@ -555,7 +555,7 @@ pub trait BlockDecryptMut: BlockSizeUser + Sized {
     #[cfg(all(feature = "block-padding", feature = "alloc"))]
     #[cfg_attr(docsrs, doc(cfg(all(feature = "block-padding", feature = "alloc"))))]
     #[inline]
-    fn decrypt_padded_vec<P: Padding<Self::BlockSize>>(
+    fn decrypt_padded_vec_mut<P: Padding<Self::BlockSize>>(
         self,
         buf: &[u8],
     ) -> Result<Vec<u8>, UnpadError> {

--- a/cipher/src/lib.rs
+++ b/cipher/src/lib.rs
@@ -10,7 +10,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg",
-    html_root_url = "https://docs.rs/cipher/0.4.1"
+    html_root_url = "https://docs.rs/cipher/0.4.2"
 )]
 #![warn(missing_docs, rust_2018_idioms)]
 


### PR DESCRIPTION
It's a breaking change, but the method was introduced in today's release, so hopefully it will not affect anyone. I plan to yank `cipher v0.4.1` to prevent further confusion.