### PR TITLE
cipher: do not enable the alloc feature by default

### DIFF
--- a/cipher/CHANGELOG.md
+++ b/cipher/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.4.2 (2022-02-16)
+## 0.4.3 (2022-02-22)
+### Fixed
+- Do not enable the `alloc` feature by default ([#953])
+
+[#953]: https://github.com/RustCrypto/traits/pull/953
+
+## 0.4.2 (2022-02-16) [YANKED]
 ### Fixed
 - Rename `BlockDecryptMut::decrypt_padded_vec` to `decrypt_padded_vec_mut` for consistency with other methods ([#941])
 

--- a/cipher/Cargo.lock
+++ b/cipher/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "cipher"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "blobby",
  "crypto-common",

--- a/cipher/Cargo.toml
+++ b/cipher/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cipher"
 description = "Traits for describing block ciphers and stream ciphers"
-version = "0.4.2" # Also update html_root_url in lib.rs when bumping this
+version = "0.4.3" # Also update html_root_url in lib.rs when bumping this
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
@@ -25,7 +25,6 @@ blobby = { version = "0.3", optional = true }
 zeroize = { version = "1.5", optional = true, default-features = false }
 
 [features]
-default = ["alloc"]
 alloc = []
 std = ["alloc", "crypto-common/std", "inout/std"]
 block-padding = ["inout/block-padding"]

--- a/cipher/src/lib.rs
+++ b/cipher/src/lib.rs
@@ -10,7 +10,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg",
-    html_root_url = "https://docs.rs/cipher/0.4.2"
+    html_root_url = "https://docs.rs/cipher/0.4.3"
 )]
 #![warn(missing_docs, rust_2018_idioms)]
 


### PR DESCRIPTION
The fact that this feature is enabled by default was an oversight.

Unfortunately, it's again a breaking change. It can affect only users of the allocating padded encrypt/decrypt methods. The `p12` crate which hit the previous breaking change [explicitly enables](https://github.com/hjiayz/p12/blob/master/Cargo.toml#L28), so this PR should not cause any issues for it.