### PR TITLE
aead: add optional support for `BytesMut` as a `Buffer`

### DIFF
--- a/.github/workflows/aead.yml
+++ b/.github/workflows/aead.yml
@@ -38,6 +38,7 @@ jobs:
           override: true
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features alloc
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features bytes
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features rand_core
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features stream
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,6 +7,7 @@ name = "aead"
 version = "0.4.3"
 dependencies = [
  "blobby",
+ "bytes",
  "generic-array",
  "heapless",
  "rand_core",
@@ -51,6 +52,12 @@ name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+
+[[package]]
+name = "bytes"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 
 [[package]]
 name = "cfg-if"

--- a/aead/Cargo.toml
+++ b/aead/Cargo.toml
@@ -19,6 +19,7 @@ generic-array = { version = "0.14", default-features = false }
 
 # optional dependencies
 blobby = { version = "0.3", optional = true }
+bytes = { version = "1", optional = true, default-features = false }
 heapless = { version = "0.7", optional = true, default-features = false }
 rand_core = { version = "0.6", optional = true }
 

--- a/aead/src/lib.rs
+++ b/aead/src/lib.rs
@@ -39,6 +39,10 @@ pub mod stream;
 
 pub use generic_array::{self, typenum::consts};
 
+#[cfg(feature = "bytes")]
+#[cfg_attr(docsrs, doc(cfg(feature = "bytes")))]
+pub use bytes;
+
 #[cfg(feature = "heapless")]
 #[cfg_attr(docsrs, doc(cfg(feature = "heapless")))]
 pub use heapless;
@@ -52,6 +56,9 @@ use generic_array::{typenum::Unsigned, ArrayLength, GenericArray};
 
 #[cfg(feature = "alloc")]
 use alloc::vec::Vec;
+
+#[cfg(feature = "bytes")]
+use bytes::BytesMut;
 
 #[cfg(feature = "rand_core")]
 use rand_core::{CryptoRng, RngCore};
@@ -503,6 +510,26 @@ impl Buffer for Vec<u8> {
 
     fn truncate(&mut self, len: usize) {
         Vec::truncate(self, len);
+    }
+}
+
+#[cfg(feature = "bytes")]
+impl Buffer for BytesMut {
+    fn len(&self) -> usize {
+        BytesMut::len(self)
+    }
+
+    fn is_empty(&self) -> bool {
+        BytesMut::is_empty(self)
+    }
+
+    fn extend_from_slice(&mut self, other: &[u8]) -> Result<()> {
+        BytesMut::extend_from_slice(self, other);
+        Ok(())
+    }
+
+    fn truncate(&mut self, len: usize) {
+        BytesMut::truncate(self, len);
     }
 }
 


### PR DESCRIPTION
Continuation of #837.

Allows using `bytes::BytesMut` as an `aead::Buffer`.