### PR TITLE
password-hash: make `Ident::new` fallible; add `Ident::new_unwrap`

### DIFF
--- a/password-hash/src/params.rs
+++ b/password-hash/src/params.rs
@@ -261,8 +261,15 @@ impl<'a> Iterator for Iter<'a> {
 
     fn next(&mut self) -> Option<Pair<'a>> {
         let mut param = self.inner.as_mut()?.next()?.split(PAIR_DELIMITER);
-        let name = Ident::new(param.next().expect(INVARIANT_VIOLATED_MSG));
-        let value = Value::try_from(param.next().expect(INVARIANT_VIOLATED_MSG))
+
+        let name = param
+            .next()
+            .and_then(|id| Ident::try_from(id).ok())
+            .expect(INVARIANT_VIOLATED_MSG);
+
+        let value = param
+            .next()
+            .and_then(|value| Value::try_from(value).ok())
             .expect(INVARIANT_VIOLATED_MSG);
 
         debug_assert_eq!(param.next(), None);
@@ -351,7 +358,7 @@ mod tests {
 
     #[test]
     fn duplicate_names() {
-        let name = Ident::new("a");
+        let name = Ident::new("a").unwrap();
         let mut params = ParamsString::new();
         params.add_decimal(name, 1).unwrap();
 
@@ -363,9 +370,9 @@ mod tests {
     fn from_iter() {
         let params = ParamsString::from_iter(
             [
-                (Ident::new("a"), Value::try_from("1").unwrap()),
-                (Ident::new("b"), Value::try_from("2").unwrap()),
-                (Ident::new("c"), Value::try_from("3").unwrap()),
+                (Ident::new("a").unwrap(), Value::try_from("1").unwrap()),
+                (Ident::new("b").unwrap(), Value::try_from("2").unwrap()),
+                (Ident::new("c").unwrap(), Value::try_from("3").unwrap()),
             ]
             .iter()
             .cloned(),
@@ -387,7 +394,7 @@ mod tests {
         let mut i = params.iter();
 
         for (name, value) in &[("a", "1"), ("b", "2"), ("c", "3")] {
-            let name = Ident::new(name);
+            let name = Ident::new(name).unwrap();
             let value = Value::try_from(*value).unwrap();
             assert_eq!(i.next(), Some((name, value)));
         }

--- a/password-hash/tests/hashing.rs
+++ b/password-hash/tests/hashing.rs
@@ -4,7 +4,7 @@ pub use password_hash::{
     Decimal, Error, Ident, Output, ParamsString, PasswordHash, PasswordHasher, Result, Salt,
 };
 
-const ALG: Ident = Ident::new("example");
+const ALG: Ident = Ident::new_unwrap("example");
 
 /// Stub password hashing function for testing.
 pub struct StubPasswordHasher;

--- a/password-hash/tests/password_hash.rs
+++ b/password-hash/tests/password_hash.rs
@@ -6,7 +6,7 @@
 
 use password_hash::{Ident, ParamsString, PasswordHash, Salt};
 
-const EXAMPLE_ALGORITHM: Ident = Ident::new("argon2d");
+const EXAMPLE_ALGORITHM: Ident = Ident::new_unwrap("argon2d");
 const EXAMPLE_SALT: &str = "saltsaltsaltsaltsalt";
 const EXAMPLE_HASH: &[u8] = &[
     0x85, 0xab, 0x21, 0x85, 0xab, 0x21, 0x85, 0xab, 0x21, 0x85, 0xab, 0x21, 0x85, 0xab, 0x21, 0x85,

--- a/password-hash/tests/test_vectors.rs
+++ b/password-hash/tests/test_vectors.rs
@@ -11,7 +11,7 @@ const SCRYPT_HASH: &str =
 #[test]
 fn argon2id() {
     let ph = PasswordHash::new(ARGON2D_HASH).unwrap();
-    assert_eq!(ph.algorithm, Ident::new("argon2d"));
+    assert_eq!(ph.algorithm, Ident::new("argon2d").unwrap());
     assert_eq!(ph.version, Some(19));
     assert_eq!(ph.params.iter().count(), 3);
     assert_eq!(ph.params.get_decimal("m").unwrap(), 512);
@@ -25,7 +25,7 @@ fn argon2id() {
 #[test]
 fn bcrypt() {
     let ph = PasswordHash::new(BCRYPT_HASH).unwrap();
-    assert_eq!(ph.algorithm, Ident::new("2b"));
+    assert_eq!(ph.algorithm, Ident::new("2b").unwrap());
     assert_eq!(ph.version, None);
     assert_eq!(ph.params.len(), 0);
     assert_eq!(ph.salt.unwrap().to_string(), "MTIzNA");
@@ -39,7 +39,7 @@ fn bcrypt() {
 #[test]
 fn scrypt() {
     let ph = PasswordHash::new(SCRYPT_HASH).unwrap();
-    assert_eq!(ph.algorithm, Ident::new("scrypt"));
+    assert_eq!(ph.algorithm, Ident::new("scrypt").unwrap());
     assert_eq!(ph.version, None);
     assert_eq!(ph.params.len(), 0);
     assert_eq!(ph.salt.unwrap().to_string(), "epIxT/h6HbbwHaehFnh/bw");


### PR DESCRIPTION
Unifies the `const fn` implementation of `Ident::new` and `TryFrom`, with the former now able to return a result thanks to const panic.

Since `Debug` isn't const-friendly yet and therefore `Result::unwrap` cannot be used in const contexts, adds a `::new_unwrap` function as a stopgap. It performs some pattern matching and uses const panic to handle the `Err` case.