### PR TITLE
password-hash v0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -552,7 +552,7 @@ dependencies = [
 
 [[package]]
 name = "password-hash"
-version = "0.4.0-pre"
+version = "0.4.0"
 dependencies = [
  "base64ct",
  "rand_core",

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -20,7 +20,7 @@ cipher = { version = "0.4", optional = true }
 digest = { version = "0.10", optional = true }
 elliptic-curve = { version = "0.12.0-pre", optional = true, path = "../elliptic-curve" }
 mac = { version = "0.11", package = "crypto-mac", optional = true }
-password-hash = { version = "=0.4.0-pre", optional = true, path = "../password-hash" }
+password-hash = { version = "0.4", optional = true, path = "../password-hash" }
 signature = { version = "1.5", optional = true, default-features = false, path = "../signature" }
 universal-hash = { version = "0.4", optional = true, path = "../universal-hash" }
 

--- a/password-hash/CHANGELOG.md
+++ b/password-hash/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.0 (2022-03-09)
+### Changed
+- Leverage `const_panic`; MSRV 1.57 ([#896])
+- Rust 2021 edition upgrade ([#897])
+- Make `Ident::new` fallible; add `Ident::new_unwrap` ([#896], [#960])
+
+### Fixed
+- Better `Debug`/`Display` impls for `SaltString` ([#804])
+
+### Removed
+- `base64ct` version restrictions ([#914])
+
+[#804]: https://github.com/RustCrypto/traits/pull/804
+[#896]: https://github.com/RustCrypto/traits/pull/896
+[#897]: https://github.com/RustCrypto/traits/pull/897
+[#897]: https://github.com/RustCrypto/traits/pull/897
+[#914]: https://github.com/RustCrypto/traits/pull/914
+[#960]: https://github.com/RustCrypto/traits/pull/960
+
 ## 0.3.2 (2021-09-15)
 ### Fixed
 - Remove unused lifetimes ([#760])

--- a/password-hash/Cargo.toml
+++ b/password-hash/Cargo.toml
@@ -5,7 +5,7 @@ Traits which describe the functionality of password hashing algorithms,
 as well as a `no_std`-friendly implementation of the PHC string format
 (a well-defined subset of the Modular Crypt Format a.k.a. MCF)
 """
-version = "0.4.0-pre" # Also update html_root_url in lib.rs when bumping this
+version = "0.4.0" # Also update html_root_url in lib.rs when bumping this
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/password-hash/src/lib.rs
+++ b/password-hash/src/lib.rs
@@ -4,7 +4,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
-    html_root_url = "https://docs.rs/password-hash/0.4.0-pre"
+    html_root_url = "https://docs.rs/password-hash/0.4.0"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, unused_lifetimes)]


### PR DESCRIPTION
### Changed
- Leverage `const_panic`; MSRV 1.57 ([#896])
- Rust 2021 edition upgrade ([#897])
- Make `Ident::new` fallible; add `Ident::new_unwrap` ([#896], [#960])

### Fixed
- Better `Debug`/`Display` impls for `SaltString` ([#804])

### Removed
- `base64ct` version restrictions ([#914])

[#804]: https://github.com/RustCrypto/traits/pull/804
[#896]: https://github.com/RustCrypto/traits/pull/896
[#897]: https://github.com/RustCrypto/traits/pull/897
[#897]: https://github.com/RustCrypto/traits/pull/897
[#914]: https://github.com/RustCrypto/traits/pull/914
[#960]: https://github.com/RustCrypto/traits/pull/960