### PR TITLE
universal-hash v0.5

### DIFF
--- a/.github/workflows/universal-hash.yml
+++ b/.github/workflows/universal-hash.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.41.0 # MSRV
+          - 1.56.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -50,7 +50,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.41.0 # MSRV
+          - 1.56.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,21 +128,21 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 [[package]]
 name = "cipher"
 version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1873270f8f7942c191139cb8a40fd228da6c3fd2fc376d7e92d47aa14aeb59e"
 dependencies = [
- "blobby",
  "crypto-common 0.1.3",
  "inout",
- "zeroize",
 ]
 
 [[package]]
 name = "cipher"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1873270f8f7942c191139cb8a40fd228da6c3fd2fc376d7e92d47aa14aeb59e"
+version = "0.4.4"
 dependencies = [
- "crypto-common 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "blobby",
+ "crypto-common 0.1.4",
  "inout",
+ "zeroize",
 ]
 
 [[package]]
@@ -171,7 +171,7 @@ name = "crypto"
 version = "0.4.0-pre"
 dependencies = [
  "aead",
- "cipher 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cipher 0.4.3",
  "crypto-mac",
  "digest 0.10.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "elliptic-curve 0.12.0-pre.1",
@@ -207,19 +207,19 @@ dependencies = [
 [[package]]
 name = "crypto-common"
 version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57952ca27b5e3606ff4dd79b0020231aaf9d6aa76dc05fd30137538c50bd3ce8"
 dependencies = [
  "generic-array",
- "rand_core",
  "typenum",
 ]
 
 [[package]]
 name = "crypto-common"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57952ca27b5e3606ff4dd79b0020231aaf9d6aa76dc05fd30137538c50bd3ce8"
+version = "0.1.4"
 dependencies = [
  "generic-array",
+ "rand_core",
  "typenum",
 ]
 
@@ -267,7 +267,7 @@ version = "0.10.3"
 dependencies = [
  "blobby",
  "block-buffer 0.10.2",
- "crypto-common 0.1.3",
+ "crypto-common 0.1.4",
  "subtle",
 ]
 
@@ -278,7 +278,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
 dependencies = [
  "block-buffer 0.10.2",
- "crypto-common 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crypto-common 0.1.3",
 ]
 
 [[package]]
@@ -919,9 +919,9 @@ checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
 name = "universal-hash"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
- "generic-array",
+ "crypto-common 0.1.4",
  "subtle",
 ]
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # RustCrypto: Traits
 
-[![Project Chat][chat-image]][chat-link] [![dependency status][deps-image]][deps-link] ![Apache2/MIT licensed][license-image]
+[![Project Chat][chat-image]][chat-link]
+[![dependency status][deps-image]][deps-link]
+![Apache2/MIT licensed][license-image]
 
 Collection of traits which describe functionality of cryptographic primitives.
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Collection of traits which describe functionality of cryptographic primitives.
 | [`kem`]             | [Key encapsulation mechanism] | [![crates.io](https://img.shields.io/crates/v/kem.svg)](https://crates.io/crates/kem) | [![Documentation](https://docs.rs/kem/badge.svg)](https://docs.rs/kem) | ![MSRV 1.56][msrv-1.56] |
 | [`password-hash`]   | [Password hashing]            | [![crates.io](https://img.shields.io/crates/v/password-hash.svg)](https://crates.io/crates/password-hash) | [![Documentation](https://docs.rs/password-hash/badge.svg)](https://docs.rs/password-hash) | ![MSRV 1.57][msrv-1.57] |
 | [`signature`]       | [Digital signature]           | [![crates.io](https://img.shields.io/crates/v/signature.svg)](https://crates.io/crates/signature) | [![Documentation](https://docs.rs/signature/badge.svg)](https://docs.rs/signature) | ![MSRV 1.41][msrv-1.41] |
-| [`universal‑hash`]  | [Universal hash function]     | [![crates.io](https://img.shields.io/crates/v/universal-hash.svg)](https://crates.io/crates/universal-hash) | [![Documentation](https://docs.rs/universal-hash/badge.svg)](https://docs.rs/universal-hash) | ![MSRV 1.41][msrv-1.41] |
+| [`universal‑hash`]  | [Universal hash function]     | [![crates.io](https://img.shields.io/crates/v/universal-hash.svg)](https://crates.io/crates/universal-hash) | [![Documentation](https://docs.rs/universal-hash/badge.svg)](https://docs.rs/universal-hash) | ![MSRV 1.56][msrv-1.56] |
 
 ### Additional Crates
 

--- a/cipher/Cargo.toml
+++ b/cipher/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cipher"
 description = "Traits for describing block ciphers and stream ciphers"
-version = "0.4.3" # Also update html_root_url in lib.rs when bumping this
+version = "0.4.4" # Also update html_root_url in lib.rs when bumping this
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
@@ -13,7 +13,7 @@ keywords = ["crypto", "block-cipher", "stream-cipher", "trait"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-crypto-common = { version = "0.1.3", path = "../crypto-common" }
+crypto-common = { version = "0.1.4", path = "../crypto-common" }
 inout = "0.1"
 
 # optional dependencies

--- a/cipher/src/lib.rs
+++ b/cipher/src/lib.rs
@@ -10,7 +10,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg",
-    html_root_url = "https://docs.rs/cipher/0.4.3"
+    html_root_url = "https://docs.rs/cipher/0.4.4"
 )]
 #![warn(missing_docs, rust_2018_idioms)]
 
@@ -51,21 +51,11 @@ pub use crypto_common::{
     generic_array,
     typenum::{self, consts},
     AlgorithmName, Block, InnerIvInit, InvalidLength, Iv, IvSizeUser, Key, KeyInit, KeyIvInit,
-    KeySizeUser,
+    KeySizeUser, ParBlocks, ParBlocksSizeUser,
 };
-use generic_array::{ArrayLength, GenericArray};
 
 /// Trait for loading current IV state.
 pub trait IvState: IvSizeUser {
     /// Returns current IV state.
     fn iv_state(&self) -> Iv<Self>;
 }
-
-/// Types which process blocks in parallel.
-pub trait ParBlocksSizeUser: BlockSizeUser {
-    /// Number of blocks which can be processed in parallel.
-    type ParBlocksSize: ArrayLength<Block<Self>>;
-}
-
-/// Parallel blocks on which [`ParBlocksSizeUser`] implementors operate.
-pub type ParBlocks<T> = GenericArray<Block<T>, <T as ParBlocksSizeUser>::ParBlocksSize>;

--- a/crypto-common/Cargo.toml
+++ b/crypto-common/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "crypto-common"
 description = "Common cryptographic traits"
-version = "0.1.3" # Also update html_root_url in lib.rs when bumping this
+version = "0.1.4" # Also update html_root_url in lib.rs when bumping this
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/crypto-common/src/lib.rs
+++ b/crypto-common/src/lib.rs
@@ -5,7 +5,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg",
-    html_root_url = "https://docs.rs/crypto-common/0.1.3"
+    html_root_url = "https://docs.rs/crypto-common/0.1.4"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]
@@ -26,6 +26,8 @@ use rand_core::{CryptoRng, RngCore};
 
 /// Block on which [`BlockSizeUser`] implementors operate.
 pub type Block<B> = GenericArray<u8, <B as BlockSizeUser>::BlockSize>;
+/// Parallel blocks on which [`ParBlocksSizeUser`] implementors operate.
+pub type ParBlocks<T> = GenericArray<Block<T>, <T as ParBlocksSizeUser>::ParBlocksSize>;
 /// Output array of [`OutputSizeUser`] implementors.
 pub type Output<T> = GenericArray<u8, <T as OutputSizeUser>::OutputSize>;
 /// Key used by [`KeySizeUser`] implementors.
@@ -50,6 +52,12 @@ impl<T: BlockSizeUser> BlockSizeUser for &T {
 
 impl<T: BlockSizeUser> BlockSizeUser for &mut T {
     type BlockSize = T::BlockSize;
+}
+
+/// Types which can process blocks in parallel.
+pub trait ParBlocksSizeUser: BlockSizeUser {
+    /// Number of blocks which can be processed in parallel.
+    type ParBlocksSize: ArrayLength<Block<Self>>;
 }
 
 /// Types which return data with the given size.

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -22,7 +22,7 @@ elliptic-curve = { version = "0.12.0-pre", optional = true, path = "../elliptic-
 mac = { version = "0.11", package = "crypto-mac", optional = true }
 password-hash = { version = "0.4", optional = true, path = "../password-hash" }
 signature = { version = "1.5", optional = true, default-features = false, path = "../signature" }
-universal-hash = { version = "0.4", optional = true, path = "../universal-hash" }
+universal-hash = { version = "0.5", optional = true, path = "../universal-hash" }
 
 [features]
 std = [

--- a/universal-hash/Cargo.toml
+++ b/universal-hash/Cargo.toml
@@ -1,22 +1,24 @@
 [package]
 name = "universal-hash"
-version = "0.4.1" # Also update html_root_url in lib.rs when bumping this
+version = "0.5.0" # Also update html_root_url in lib.rs when bumping this
+description = "Trait for universal hash functions"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
-description = "Trait for universal hash functions"
+edition = "2021"
+rust-version = "1.56"
+readme = "README.md"
 documentation = "https://docs.rs/universal-hash"
 repository = "https://github.com/RustCrypto/traits"
 keywords = ["crypto", "mac"]
 categories = ["cryptography", "no-std"]
-readme = "README.md"
-edition = "2018"
 
 [dependencies]
-generic-array = "0.14"
+crypto-common = { version = "0.1.4", path = "../crypto-common" }
 subtle = { version = "=2.4", default-features = false }
 
 [features]
-std = []
+std = ["crypto-common/std"]
 
 [package.metadata.docs.rs]
 all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/universal-hash/README.md
+++ b/universal-hash/README.md
@@ -15,7 +15,7 @@ See [RustCrypto/universal-hashes] for implementations which use this trait.
 
 ## Minimum Supported Rust Version
 
-Rust **1.41** or higher.
+Rust **1.56** or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be
 done with a minor version bump.
@@ -47,7 +47,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/universal-hash/badge.svg
 [docs-link]: https://docs.rs/universal-hash/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.41+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.56+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260051-universal-hashes
 [build-image]: https://github.com/RustCrypto/traits/workflows/universal-hash/badge.svg?branch=master&event=push

--- a/universal-hash/src/lib.rs
+++ b/universal-hash/src/lib.rs
@@ -18,46 +18,91 @@
 //! [Universal Hash Functions]: https://en.wikipedia.org/wiki/Universal_hashing
 
 #![no_std]
-#![forbid(unsafe_code)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
-    html_root_url = "https://docs.rs/universal-hash/0.4.1"
+    html_root_url = "https://docs.rs/universal-hash/0.5.0"
 )]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![warn(missing_docs, rust_2018_idioms)]
 
 #[cfg(feature = "std")]
 extern crate std;
 
-pub use generic_array::{self, typenum::consts};
+pub use crypto_common::{
+    self,
+    generic_array,
+    typenum::{self, consts},
+    KeyInit, Key, Block, ParBlocks,
+};
 
-use generic_array::typenum::Unsigned;
-use generic_array::{ArrayLength, GenericArray};
-use subtle::{Choice, ConstantTimeEq};
+use typenum::Unsigned;
+use generic_array::{GenericArray, ArrayLength};
+use crypto_common::{BlockSizeUser, ParBlocksSizeUser};
+use subtle::ConstantTimeEq;
+use core::slice;
 
-/// Keys to a [`UniversalHash`].
-pub type Key<U> = GenericArray<u8, <U as NewUniversalHash>::KeySize>;
+/// Trait implemented by UHF backends.
+pub trait UhfBackend: ParBlocksSizeUser {
+    /// Process single block.
+    fn proc_block(&mut self, block: &Block<Self>);
 
-/// Blocks are inputs to a [`UniversalHash`].
-pub type Block<U> = GenericArray<u8, <U as UniversalHash>::BlockSize>;
+    /// Process several blocks in parallel.
+    #[inline(always)]
+    fn proc_par_blocks(&mut self, blocks: &ParBlocks<Self>) {
+        for block in blocks {
+            self.proc_block(block);
+        }
+    }
+}
 
-/// Instantiate a [`UniversalHash`] algorithm.
-pub trait NewUniversalHash: Sized {
-    /// Size of the key for the universal hash function.
-    type KeySize: ArrayLength<u8>;
-
-    /// Instantiate a universal hash function with the given key.
-    fn new(key: &Key<Self>) -> Self;
+/// Trait for [`UhfBackend`] users.
+///
+/// This trait is used to define rank-2 closures.
+pub trait UhfClosure: BlockSizeUser {
+    /// Execute closure with the provided block cipher backend.
+    fn call<B: UhfBackend<BlockSize = Self::BlockSize>>(self, backend: &mut B);
 }
 
 /// The [`UniversalHash`] trait defines a generic interface for universal hash
 /// functions.
-pub trait UniversalHash: Clone {
-    /// Size of the inputs to and outputs from the universal hash function
-    type BlockSize: ArrayLength<u8>;
+pub trait UniversalHash: BlockSizeUser + Sized {
+    /// Update hash function state using the provided rank-2 closure.
+    fn update_with_backend(&mut self, f: impl UhfClosure<BlockSize = Self::BlockSize>);
 
-    /// Input a block into the universal hash function
-    fn update(&mut self, block: &Block<Self>);
+    /// Update hash function state with the provided block.
+    #[inline]
+    fn update(&mut self, blocks: &[Block<Self>]) {
+        struct Ctx<'a, BS: ArrayLength<u8>> {
+            blocks: &'a [Block<Self>],
+        }
+
+        impl<'a, BS: ArrayLength<u8>> BlockSizeUser for Ctx<'a, BS> {
+            type BlockSize = BS;
+        }
+
+        impl<'a, BS: ArrayLength<u8>> UhfClosure for Ctx<'a, BS> {
+            #[inline(always)]
+            fn call<B: UhfBackend<BlockSize = BS>>(self, backend: &mut B) {
+                let pb = B::ParBlocksSize::USIZE;
+                if pb > 1 {
+                    let (par_blocks, tail) = to_blocks(self.blocks);
+                    for par_block in par_blocks {
+                        backend.proc_par_blocks(par_block);
+                    }
+                    for block in tail {
+                        backend.proc_block(block);
+                    }
+                } else {
+                    for block in self.blocks {
+                        backend.proc_block(block);
+                    }
+                }
+            }
+        }
+
+        self.update_with_backend(Ctx { blocks });
+    }
 
     /// Input data into the universal hash function. If the length of the
     /// data is not a multiple of the block size, the remaining data is
@@ -66,18 +111,14 @@ pub trait UniversalHash: Clone {
     /// This approach is frequently used by AEAD modes which use
     /// Message Authentication Codes (MACs) based on universal hashing.
     fn update_padded(&mut self, data: &[u8]) {
-        let mut chunks = data.chunks_exact(Self::BlockSize::to_usize());
+        let (blocks, tail) = to_blocks(data);
 
-        for chunk in &mut chunks {
-            self.update(GenericArray::from_slice(chunk));
-        }
+        self.update(blocks);
 
-        let rem = chunks.remainder();
-
-        if !rem.is_empty() {
+        if !tail.is_empty() {
             let mut padded_block = GenericArray::default();
-            padded_block[..rem.len()].copy_from_slice(rem);
-            self.update(&padded_block);
+            padded_block[..tail.len()].copy_from_slice(tail);
+            self.update(slice::from_ref(&padded_block));
         }
     }
 
@@ -85,89 +126,23 @@ pub trait UniversalHash: Clone {
     fn reset(&mut self);
 
     /// Obtain the [`Output`] of a [`UniversalHash`] function and consume it.
-    fn finalize(self) -> Output<Self>;
+    fn finalize(self) -> Block<Self>;
 
     /// Obtain the [`Output`] of a [`UniversalHash`] computation and reset it back
     /// to its initial state.
-    fn finalize_reset(&mut self) -> Output<Self> {
-        let res = self.clone().finalize();
-        self.reset();
-        res
-    }
+    fn finalize_reset(&mut self) -> Block<Self>;
 
     /// Verify the [`UniversalHash`] of the processed input matches a given [`Output`].
     /// This is useful when constructing Message Authentication Codes (MACs)
     /// from universal hash functions.
     fn verify(self, other: &Block<Self>) -> Result<(), Error> {
-        if self.finalize() == other.into() {
+        if self.finalize().ct_eq(other).unwrap_u8() == 1 {
             Ok(())
         } else {
             Err(Error)
         }
     }
 }
-
-/// Outputs of universal hash functions which are a thin wrapper around a
-/// byte array. Provides a safe [`Eq`] implementation that runs in constant time,
-/// which is useful for implementing Message Authentication Codes (MACs) based
-/// on universal hashing.
-#[derive(Clone)]
-pub struct Output<U: UniversalHash> {
-    bytes: GenericArray<u8, U::BlockSize>,
-}
-
-impl<U> Output<U>
-where
-    U: UniversalHash,
-{
-    /// Create a new [`Output`] block.
-    pub fn new(bytes: Block<U>) -> Output<U> {
-        Output { bytes }
-    }
-
-    /// Get the inner [`GenericArray`] this type wraps
-    pub fn into_bytes(self) -> Block<U> {
-        self.bytes
-    }
-}
-
-impl<U> From<Block<U>> for Output<U>
-where
-    U: UniversalHash,
-{
-    fn from(bytes: Block<U>) -> Self {
-        Output { bytes }
-    }
-}
-
-impl<'a, U> From<&'a Block<U>> for Output<U>
-where
-    U: UniversalHash,
-{
-    fn from(bytes: &'a Block<U>) -> Self {
-        bytes.clone().into()
-    }
-}
-
-impl<U> ConstantTimeEq for Output<U>
-where
-    U: UniversalHash,
-{
-    fn ct_eq(&self, other: &Self) -> Choice {
-        self.bytes.ct_eq(&other.bytes)
-    }
-}
-
-impl<U> PartialEq for Output<U>
-where
-    U: UniversalHash,
-{
-    fn eq(&self, x: &Output<U>) -> bool {
-        self.ct_eq(x).unwrap_u8() == 1
-    }
-}
-
-impl<U: UniversalHash> Eq for Output<U> {}
 
 /// Error type for when the [`Output`] of a [`UniversalHash`]
 /// is not equal to the expected value.
@@ -182,3 +157,16 @@ impl core::fmt::Display for Error {
 
 #[cfg(feature = "std")]
 impl std::error::Error for Error {}
+
+/// Split message into slice of blocks and leftover tail.
+// TODO: replace with `slice::as_chunks` on migration to const generics
+#[inline(always)]
+fn to_blocks<T, N: ArrayLength<T>>(data: &[T]) -> (&[GenericArray<T, N>], &[T]) {
+    let nb = data.len() / N::USIZE;
+    let (left, right) = data.split_at(nb * N::USIZE);
+    let p = left.as_ptr() as *const GenericArray<T, N>;
+    // SAFETY: we guarantee that `blocks` does not point outside of `data`
+    // and `p` is valid for reads
+    let blocks = unsafe { slice::from_raw_parts(p, nb) };
+    (blocks, right)
+}

--- a/universal-hash/src/lib.rs
+++ b/universal-hash/src/lib.rs
@@ -109,6 +109,7 @@ pub trait UniversalHash: BlockSizeUser + Sized {
     ///
     /// This approach is frequently used by AEAD modes which use
     /// Message Authentication Codes (MACs) based on universal hashing.
+    #[inline]
     fn update_padded(&mut self, data: &[u8]) {
         let (blocks, tail) = to_blocks(data);
 
@@ -129,6 +130,7 @@ pub trait UniversalHash: BlockSizeUser + Sized {
     ///
     /// This is useful when constructing Message Authentication Codes (MACs)
     /// from universal hash functions.
+    #[inline]
     fn verify(self, expected: &Block<Self>) -> Result<(), Error> {
         if self.finalize().ct_eq(expected).unwrap_u8() == 1 {
             Ok(())
@@ -144,6 +146,7 @@ pub trait UniversalHash: BlockSizeUser + Sized {
 pub struct Error;
 
 impl core::fmt::Display for Error {
+    #[inline]
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.write_str("UHF output mismatch")
     }

--- a/universal-hash/src/lib.rs
+++ b/universal-hash/src/lib.rs
@@ -59,7 +59,7 @@ pub trait UhfBackend: ParBlocksSizeUser {
 ///
 /// This trait is used to define rank-2 closures.
 pub trait UhfClosure: BlockSizeUser {
-    /// Execute closure with the provided block cipher backend.
+    /// Execute closure with the provided UHF backend.
     fn call<B: UhfBackend<BlockSize = Self::BlockSize>>(self, backend: &mut B);
 }
 
@@ -121,14 +121,8 @@ pub trait UniversalHash: BlockSizeUser + Sized {
         }
     }
 
-    /// Reset [`UniversalHash`] instance.
-    fn reset(&mut self);
-
     /// Retrieve result and consume hasher instance.
     fn finalize(self) -> Block<Self>;
-
-    /// Retrieve result and reset hasher instance to its initial state.
-    fn finalize_reset(&mut self) -> Block<Self>;
 
     /// Verify the [`UniversalHash`] of the processed input matches
     /// a given `expected` value.


### PR DESCRIPTION
The new API uses approach of emulating rank-2 closures previously introduced in cipher v0.4.

Also moves `ParBlocksSizeUser` and `ParBlocks` from `cipher` to `crypto-common`.