### PR TITLE
elliptic-curve: add hex `serde` (de)serializer for `PublicKey`

### DIFF
--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -42,7 +42,7 @@ sha3 = "0.10"
 
 [features]
 default = ["arithmetic"]
-alloc = ["der/alloc", "sec1/alloc", "zeroize/alloc"] # todo: use weak activation for `group`/`sec1` alloc when available
+alloc = ["base16ct/alloc", "der/alloc", "sec1/alloc", "zeroize/alloc"] # todo: use weak activation for `group`/`sec1` alloc when available
 arithmetic = ["ff", "group"]
 bits = ["arithmetic", "ff/bits"]
 dev = ["arithmetic", "hex-literal", "pem", "pkcs8"]


### PR DESCRIPTION
This commit changes the `Serializer` and `Deserializer` impls on the `PublicKey` type to work more like the ones on other types in this crate and its downstream dependencies:

- Use binary DER serialization with binary formats (what it does today)
- Use an upper-case hex serialization of the DER in conjunction with "human readable" formats

Though richer formats exist for this use case (such as `JwkEcKey` which is an existing implementation of JWK), hex-serialized DER is relatively common and easy to work with, and can be decoded easily with online tools such as https://lapo.it/asn1js/

Note that the `Deserialize` impl for `PublicKey` never worked with human-readable formats as it was attempting to deserialize to `&[u8]`, which doesn't work with formats like JSON or TOML because they need an intermediate decoding step and therefore require deserialization to `Vec<u8>`. So this isn't a breaking change from the `Deserialize` side.

Fixes RustCrypto/elliptic-curves#536