### PR TITLE
Fix compilation with `serde` without `pem`

### DIFF
--- a/.github/workflows/elliptic-curve.yml
+++ b/.github/workflows/elliptic-curve.yml
@@ -50,6 +50,7 @@ jobs:
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features pkcs8
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features sec1
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features serde
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features alloc,serde
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features voprf
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features pkcs8,sec1
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features pem,pkcs8,sec1

--- a/elliptic-curve/src/public_key.rs
+++ b/elliptic-curve/src/public_key.rs
@@ -31,7 +31,7 @@ use {
 #[cfg(any(feature = "jwk", feature = "pem"))]
 use alloc::string::{String, ToString};
 
-#[cfg(all(feature = "pem", feature = "serde"))]
+#[cfg(all(feature = "alloc", feature = "serde"))]
 use serde::{de, ser, Deserialize, Serialize};
 
 /// Elliptic curve public keys.


### PR DESCRIPTION
I'm surprised this is implemented as it is, you can't actually use Serde with `PublicKey` without `alloc`. In any case, this is still necessary to make this even compile.