### PR TITLE
elliptic-curve: remove `Zeroize` impl from `ecdh::SharedSecret`

### DIFF
--- a/elliptic-curve/src/ecdh.rs
+++ b/elliptic-curve/src/ecdh.rs
@@ -204,16 +204,10 @@ impl<C: Curve> From<FieldBytes<C>> for SharedSecret<C> {
     }
 }
 
-impl<C: Curve> Zeroize for SharedSecret<C> {
-    fn zeroize(&mut self) {
-        self.secret_bytes.zeroize()
-    }
-}
-
 impl<C: Curve> ZeroizeOnDrop for SharedSecret<C> {}
 
 impl<C: Curve> Drop for SharedSecret<C> {
     fn drop(&mut self) {
-        self.zeroize();
+        self.secret_bytes.zeroize()
     }
 }


### PR DESCRIPTION
The purpose of zeroization is to clear the bytes of the shared secret on drop.

However, before this commit `SharedSecret` also had a `Zeroize` impl which could be called before `Drop`.

Used incorrectly, this could potentially erase the shared secret data, which could potentially lead to bugs where that data is used to derive e.g. encryption keys after being zeroed.

This commit removes the `Zeroize` impl to prevent this. Data is still zeroed on drop and it still impls the `ZeroizeOnDrop` trait.