### PR TITLE
KEM v2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -516,6 +516,7 @@ dependencies = [
  "rand",
  "rand_core",
  "x3dh-ke",
+ "zeroize",
 ]
 
 [[package]]
@@ -978,3 +979,18 @@ name = "zeroize"
 version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7eb5728b8afd3f280a869ce1d4c554ffaed35f45c231fc41bfbd0381bef50317"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f8f187641dad4f680d25c4bfc4225b418165984179f26ca76ec4fb6441d3a17"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]

--- a/kem/Cargo.toml
+++ b/kem/Cargo.toml
@@ -15,6 +15,7 @@ rust-version  = "1.56"
 [dependencies]
 rand_core = "0.6"
 generic-array = "0.14"
+zeroize = { version = "1.5", default-features = false, features = [ "derive" ] }
 
 [dev-dependencies]
 rand = { version = "0.8", features = [ "getrandom" ] }

--- a/kem/Cargo.toml
+++ b/kem/Cargo.toml
@@ -15,7 +15,7 @@ rust-version  = "1.56"
 [dependencies]
 rand_core = "0.6"
 generic-array = "0.14"
-zeroize = { version = "1.5", default-features = false, features = [ "derive" ] }
+zeroize = { version = "1.5", default-features = false }
 
 [dev-dependencies]
 rand = { version = "0.8", features = [ "getrandom" ] }

--- a/kem/Cargo.toml
+++ b/kem/Cargo.toml
@@ -24,12 +24,11 @@ p256 = { version = "0.9", features = [ "ecdsa" ] }
 pqcrypto = { version = "0.15", default-features = false, features = [ "pqcrypto-saber" ] }
 pqcrypto-traits = "0.3"
 
-# TODO(tarcieri): re-enable when `zeroize` compatibility can be resolved
-#[dev-dependencies.hpke]
-#git = "https://github.com/rozbb/rust-hpke"
-#rev = "3c795445f38317d6a0868259caf3e87916548356"
-#default-features = false
-#features = [ "x25519" ]
+[dev-dependencies.hpke]
+git = "https://github.com/rozbb/rust-hpke"
+rev = "9230db267819f5795a47510139f4f1a60688ce82"
+default-features = false
+features = [ "x25519" ]
 
 [features]
 default = []

--- a/kem/src/kem.rs
+++ b/kem/src/kem.rs
@@ -11,10 +11,10 @@ use rand_core::{CryptoRng, RngCore};
 /// essence, a bag of bytes.
 pub trait EncappedKey: AsRef<[u8]> + Debug + Sized {
     /// The size, in bytes, of an encapsulated key.
-    type NEnc: ArrayLength<u8>;
+    type EncappedKeySize: ArrayLength<u8>;
 
     /// The size, in bytes, of the shared secret that this KEM produces.
-    type NSecret: ArrayLength<u8>;
+    type SharedSecretSize: ArrayLength<u8>;
 
     /// Represents the identity key of an encapsulator. This is used in authenticated
     /// decapsulation.
@@ -24,10 +24,10 @@ pub trait EncappedKey: AsRef<[u8]> + Debug + Sized {
     type RecipientPublicKey;
 
     /// Parses an encapsulated key from its byte representation.
-    fn from_bytes(bytes: &GenericArray<u8, Self::NEnc>) -> Result<Self, Error>;
+    fn from_bytes(bytes: &GenericArray<u8, Self::EncappedKeySize>) -> Result<Self, Error>;
 
     /// Borrows a byte slice representing the serialized form of this encapsulated key.
-    fn as_bytes(&self) -> &GenericArray<u8, Self::NEnc> {
+    fn as_bytes(&self) -> &GenericArray<u8, Self::EncappedKeySize> {
         // EncappedKey is already AsRef<[u8]>, so we don't need to do any work. This will panic iff
         // the underlying bytestring is not precisely NEnc bytes long.
         self.as_ref().into()
@@ -36,13 +36,13 @@ pub trait EncappedKey: AsRef<[u8]> + Debug + Sized {
 
 /// The shared secret that results from key exchange.
 #[derive(Zeroize)]
-pub struct SharedSecret<EK: EncappedKey>(GenericArray<u8, EK::NSecret>);
+pub struct SharedSecret<EK: EncappedKey>(GenericArray<u8, EK::SharedSecretSize>);
 
 impl<EK: EncappedKey> ZeroizeOnDrop for SharedSecret<EK> {}
 
 impl<EK: EncappedKey> SharedSecret<EK> {
     /// Constructs a new `SharedSecret` by wrapping the given bytes
-    pub fn new(bytes: GenericArray<u8, EK::NSecret>) -> Self {
+    pub fn new(bytes: GenericArray<u8, EK::SharedSecretSize>) -> Self {
         SharedSecret(bytes)
     }
 

--- a/kem/src/kem.rs
+++ b/kem/src/kem.rs
@@ -1,11 +1,12 @@
 //! KEM Traits
 
 use crate::errors::Error;
-use core::fmt::Debug;
-use generic_array::{ArrayLength, GenericArray};
-use zeroize::{Zeroize, ZeroizeOnDrop};
 
+use core::fmt::Debug;
+
+use generic_array::{ArrayLength, GenericArray};
 use rand_core::{CryptoRng, RngCore};
+use zeroize::{Zeroize, ZeroizeOnDrop};
 
 /// Trait impl'd by concrete types that represent an encapsulated key. This is intended to be, in
 /// essence, a bag of bytes.

--- a/kem/src/kem.rs
+++ b/kem/src/kem.rs
@@ -36,8 +36,14 @@ pub trait EncappedKey: AsRef<[u8]> + Debug + Sized {
 }
 
 /// The shared secret that results from key exchange.
-#[derive(Zeroize)]
 pub struct SharedSecret<EK: EncappedKey>(GenericArray<u8, EK::SharedSecretSize>);
+
+// Zero the secret on drop
+impl<EK: EncappedKey> Drop for SharedSecret<EK> {
+    fn drop(&mut self) {
+        self.0.as_mut_slice().zeroize();
+    }
+}
 
 impl<EK: EncappedKey> ZeroizeOnDrop for SharedSecret<EK> {}
 

--- a/kem/src/kem.rs
+++ b/kem/src/kem.rs
@@ -9,7 +9,10 @@ use rand_core::{CryptoRng, RngCore};
 /// Trait impl'd by concrete types that represent an encapsulated key. This is intended to be, in
 /// essence, a bag of bytes.
 pub trait EncappedKey: AsRef<[u8]> + Debug + Sized {
-    /// The size of the shared secret that this KEM produces
+    /// The size, in bytes, of an encapsulated key.
+    type NEnc: ArrayLength<u8>;
+
+    /// The size, in bytes, of the shared secret that this KEM produces.
     type NSecret: ArrayLength<u8>;
 
     /// Represents the identity key of an encapsulator. This is used in authenticated
@@ -18,14 +21,24 @@ pub trait EncappedKey: AsRef<[u8]> + Debug + Sized {
 
     /// The public key of a decapsulator. This is used in encapsulation.
     type RecipientPublicKey;
+
+    /// Parses an encapsulated key from its byte representation.
+    fn from_bytes(bytes: &GenericArray<u8, Self::NEnc>) -> Result<Self, Error>;
+
+    /// Borrows a byte slice representing the serialized form of this encapsulated key.
+    fn as_bytes(&self) -> &GenericArray<u8, Self::NEnc> {
+        // EncappedKey is already AsRef<[u8]>, so we don't need to do any work. This will panic iff
+        // the underlying bytestring is not precisely NEnc bytes long.
+        self.as_ref().into()
+    }
 }
 
 /// Represents the functionality of a key encapsulator. For unauthenticated encapsulation, `Self`
 /// can be an empty struct. For authenticated encapsulation, `Self` is a private key.
 pub trait Encapsulator<EK: EncappedKey> {
-    /// Attempt to encapsulate a fresh shared secret with the given recipient. The resulting shared
-    /// secret is bound to the identity encoded in `Self` (i.e., authenticated wrt `Self`). If
-    /// `Self` is empty, then this is equivalent to unauthenticated encapsulation. Returns the
+    /// Attempts to encapsulate a fresh shared secret with the given recipient. The resulting
+    /// shared secret is bound to the identity encoded in `Self` (i.e., authenticated wrt `Self`).
+    /// If `Self` is empty, then this is equivalent to unauthenticated encapsulation. Returns the
     /// shared secret and encapsulated key on success, or an error if something went wrong.
     fn try_encap<R: CryptoRng + RngCore>(
         &self,
@@ -34,7 +47,7 @@ pub trait Encapsulator<EK: EncappedKey> {
     ) -> Result<(EK, GenericArray<u8, EK::NSecret>), Error>;
 }
 
-/// Represents the functionality of a key decapsulator, where `Self` is a cryptographic key
+/// Represents the functionality of a key decapsulator, where `Self` is a cryptographic key.
 pub trait Decapsulator<EK: EncappedKey> {
     /// Attempt to decapsulate the given encapsulated key. Returns the shared secret on success, or
     /// an error if something went wrong.
@@ -42,7 +55,7 @@ pub trait Decapsulator<EK: EncappedKey> {
 }
 
 /// Represents the functionality of a authenticated-key decapsulator, where `Self` is a
-/// cryptographic key
+/// cryptographic key.
 pub trait AuthDecapsulator<EK: EncappedKey> {
     /// Attempt to decapsulate the given encapsulated key. The resulting shared secret is bound to
     /// the provided sender identity, thus providing authenticity. Returns the shared secret

--- a/kem/tests/hpke.rs
+++ b/kem/tests/hpke.rs
@@ -26,14 +26,15 @@ struct X25519EncappedKey(
     GenericArray<u8, <<X25519HkdfSha256 as KemTrait>::EncappedKey as HpkeSerializable>::OutputSize>,
 );
 impl EncappedKey for X25519EncappedKey {
-    type NSecret = <X25519HkdfSha256 as KemTrait>::NSecret;
-    type NEnc = <<X25519HkdfSha256 as KemTrait>::PublicKey as HpkeSerializable>::OutputSize;
+    type SharedSecretSize = <X25519HkdfSha256 as KemTrait>::SharedSecretSize;
+    type EncappedKeySize =
+        <<X25519HkdfSha256 as KemTrait>::PublicKey as HpkeSerializable>::OutputSize;
     // In HPKE the only recipient public key is the identity key
     type RecipientPublicKey = X25519PublicKey;
     // The sender's pubkey is the identity too
     type SenderPublicKey = X25519PublicKey;
 
-    fn from_bytes(bytes: &GenericArray<u8, Self::NEnc>) -> Result<Self, Error> {
+    fn from_bytes(bytes: &GenericArray<u8, Self::EncappedKeySize>) -> Result<Self, Error> {
         <X25519HkdfSha256 as KemTrait>::PublicKey::from_bytes(bytes.as_slice()).map_err(|_| Error)
     }
 }

--- a/kem/tests/saber.rs
+++ b/kem/tests/saber.rs
@@ -18,16 +18,16 @@ type SaberPublicKey = PublicKey;
 // The encapped key type is called "Ciphertext" in Rust's pqcrypto. Impl the necessary traits.
 struct SaberEncappedKey(Ciphertext);
 impl EncappedKey for SaberEncappedKey {
-    type NSecret = U32;
+    type SharedSecretSize = U32;
     // FireSaber encapped keys are 1472 bytes;
-    type NEnc = typenum::op!(U1000 + U472);
+    type EncappedKeySize = typenum::op!(U1000 + U472);
 
     // In HPKE the only recipient public key is the identity key
     type RecipientPublicKey = SaberPublicKey;
     // The sender's pubkey is the identity too
     type SenderPublicKey = SaberPrivateKey;
 
-    fn from_bytes(bytes: &GenericArray<u8, Self::NEnc>) -> Result<Self, Error> {
+    fn from_bytes(bytes: &GenericArray<u8, Self::EncappedKeySize>) -> Result<Self, Error> {
         Ciphertext::from_bytes(bytes.as_slice())
             .map(SaberEncappedKey)
             .map_err(|_| Error)

--- a/kem/tests/x3dh.rs
+++ b/kem/tests/x3dh.rs
@@ -47,12 +47,12 @@ type X3DhPubkeyBundle = X3DhPrivkeyBundle;
 #[derive(Debug)]
 struct X3DhEncappedKey([u8; NEnc::USIZE]);
 impl EncappedKey for X3DhEncappedKey {
-    type NSecret = typenum::U32;
-    type NEnc = NEnc;
+    type SharedSecretSize = typenum::U32;
+    type EncappedKeySize = NEnc;
     type SenderPublicKey = X3DhSenderPublicKey;
     type RecipientPublicKey = X3DhPubkeyBundle;
 
-    fn from_bytes(bytes: &GenericArray<u8, Self::NEnc>) -> Result<Self, Error> {
+    fn from_bytes(bytes: &GenericArray<u8, Self::EncappedKeySize>) -> Result<Self, Error> {
         let mut buf = [0u8; NEnc::USIZE];
         buf.copy_from_slice(bytes);
         Ok(X3DhEncappedKey(buf))


### PR DESCRIPTION
I made a few changes to the KEM API

## Deserialization
As discussed over Zulip earlier this year, there should probably be a way to deserialize an encapsulated key sent over the wire.

This breaks a bit with the rest of RustCrypto because it uses `&GenericArray` rather than `&[u8]` for bitstrings. I'm not married to this, but the pros are:
1. It fits the existing API, which already uses a `GenericArray` to describe shared secrets
2. Fixed size arrays make function preconditions clear a first glance, which is good.

## Shared Secrets
Separately, I've also switched the API off of directly returning `GenericArray`s for a shared secret and made it its own `SharedSecret` type. The con is that the values are just a little more opaque. The pros are:
1. Shared secrets are now zeroize-on-drop
2. The type signatures are more concise