### PR TITLE
elliptic-curve: bump `ff` + `group` to v0.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,9 +55,9 @@ dependencies = [
 
 [[package]]
 name = "bitvec"
-version = "0.22.3"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5237f00a8c86130a0cc317830e558b966dd7850d48a953d998c813f01a41b527"
+checksum = "1489fcb93a5bb47da0462ca93ad252ad6af2145cce58d10d46a83931ba9f016b"
 dependencies = [
  "funty",
  "radium",
@@ -318,9 +318,9 @@ dependencies = [
  "crypto-bigint 0.4.0-pre.0",
  "der 0.5.1",
  "digest 0.10.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "ff 0.11.0",
+ "ff 0.12.0",
  "generic-array",
- "group 0.11.0",
+ "group 0.12.0",
  "hex-literal 0.3.4",
  "pem-rfc7468 0.5.1",
  "rand_core",
@@ -345,9 +345,9 @@ dependencies = [
 
 [[package]]
 name = "ff"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2958d04124b9f27f175eaeb9a9f383d026098aa837eadd8ba22c11f13a05b9e"
+checksum = "df689201f395c6b90dfe87127685f8dbfc083a5e779e613575d8bd7314300c3e"
 dependencies = [
  "bitvec",
  "rand_core",
@@ -356,9 +356,9 @@ dependencies = [
 
 [[package]]
 name = "funty"
-version = "1.2.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1847abb9cb65d566acd5942e94aea9c8f547ad02c98e1649326fc0e8910b8b1e"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "generic-array"
@@ -400,11 +400,11 @@ dependencies = [
 
 [[package]]
 name = "group"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc5ac374b108929de78460075f3dc439fa66df9d8fc77e8f12caa5165fcf0c89"
+checksum = "7391856def869c1c81063a03457c676fbcd419709c3dfb33d8d319de484b154d"
 dependencies = [
- "ff 0.11.0",
+ "ff 0.12.0",
  "rand_core",
  "subtle",
 ]
@@ -681,9 +681,9 @@ dependencies = [
 
 [[package]]
 name = "radium"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "643f8f41a8ebc4c5dc4515c82bb8abd397b527fc20fd681b7c011c2aee5d44fb"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -948,9 +948,9 @@ checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wyz"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "129e027ad65ce1453680623c3fb5163cbf7107bfe1aa32257e7d0e63f9ced188"
+checksum = "30b31594f29d27036c383b53b59ed3476874d518f0efb151b27a4c275141390e"
 dependencies = [
  "tap",
 ]

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -27,8 +27,8 @@ zeroize = { version = "1.5", default-features = false }
 # optional dependencies
 base64ct = { version = "1", optional = true, default-features = false }
 digest = { version = "0.10", optional = true }
-ff = { version = "0.11", optional = true, default-features = false }
-group = { version = "0.11", optional = true, default-features = false }
+ff = { version = "0.12", optional = true, default-features = false }
+group = { version = "0.12", optional = true, default-features = false }
 hex-literal = { version = "0.3", optional = true }
 pem-rfc7468 = { version = "0.5", optional = true }
 sec1 = { version = "0.2", optional = true, features = ["subtle", "zeroize"] }


### PR DESCRIPTION
Release notes:

- `ff` v0.12: https://github.com/zkcrypto/ff/blob/main/CHANGELOG.md#0120---2022-05-04
- `group` v0.12: https://github.com/zkcrypto/group/blob/main/CHANGELOG.md#0120---2022-05-04