### PR TITLE
elliptic-curve: bump `der` to v0.6.0-pre.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,9 +153,9 @@ checksum = "9d6f2aa4d0537bcc1c74df8755072bd31c1ef1a3a1b85a68e8404a8c353b7b8b"
 
 [[package]]
 name = "const-oid"
-version = "0.7.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4c78c047431fee22c1a7bb92e00ad095a02a983affe4d8a72e2a2c62c1b94f3"
+checksum = "722e23542a15cea1f65d4a1419c4cfd7a26706c70871a13a04238ca3f40f1661"
 
 [[package]]
 name = "cpufeatures"
@@ -244,12 +244,13 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.5.1"
+version = "0.6.0-pre.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6919815d73839e7ad218de758883aae3a257ba6759ce7a9992501efbb53d705c"
+checksum = "0daf09ee3ea2f7e4f5761deb921bd4c4e46861ee4b218349a40eccfa9d7fa6a5"
 dependencies = [
- "const-oid 0.7.1",
- "pem-rfc7468 0.3.1",
+ "const-oid 0.9.0",
+ "pem-rfc7468 0.6.0",
+ "zeroize",
 ]
 
 [[package]]
@@ -316,7 +317,7 @@ dependencies = [
  "base16ct",
  "base64ct",
  "crypto-bigint 0.4.0-pre.0",
- "der 0.5.1",
+ "der 0.6.0-pre.4",
  "digest 0.10.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "ff 0.12.0",
  "generic-array",
@@ -570,18 +571,18 @@ dependencies = [
 
 [[package]]
 name = "pem-rfc7468"
-version = "0.3.1"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01de5d978f34aa4b2296576379fcc416034702fd94117c56ffd8a1a767cefb30"
+checksum = "973e070439aaacda48e5effad187f36d670b7635f7dcb75fa3c6f482d1b5b932"
 dependencies = [
  "base64ct",
 ]
 
 [[package]]
 name = "pem-rfc7468"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "973e070439aaacda48e5effad187f36d670b7635f7dcb75fa3c6f482d1b5b932"
+checksum = "24d159833a9105500e0398934e205e0773f0b27529557134ecfc51c27646adac"
 dependencies = [
  "base64ct",
 ]
@@ -600,13 +601,12 @@ dependencies = [
 
 [[package]]
 name = "pkcs8"
-version = "0.8.0"
+version = "0.9.0-pre.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cabda3fb821068a9a4fab19a683eac3af12edf0f34b94a8be53c4972b8149d0"
+checksum = "648850a9b1320771c90c141a7497552f887081f4d63117c038621222eceb511b"
 dependencies = [
- "der 0.5.1",
- "spki 0.5.4",
- "zeroize",
+ "der 0.6.0-pre.4",
+ "spki 0.6.0-pre.3",
 ]
 
 [[package]]
@@ -729,13 +729,13 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "sec1"
-version = "0.2.1"
+version = "0.3.0-pre.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08da66b8b0965a5555b6bd6639e68ccba85e1e2506f5fbb089e93f8a04e1a2d1"
+checksum = "a064c53858053f909bdc5a83b6a471df77114d97a6c17c48b091905cdbf1f913"
 dependencies = [
- "der 0.5.1",
+ "der 0.6.0-pre.4",
  "generic-array",
- "pkcs8 0.8.0",
+ "pkcs8 0.9.0-pre.2",
  "subtle",
  "zeroize",
 ]
@@ -865,12 +865,12 @@ dependencies = [
 
 [[package]]
 name = "spki"
-version = "0.5.4"
+version = "0.6.0-pre.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d01ac02a6ccf3e07db148d2be087da624fea0221a16152ed01f0496a6b0a27"
+checksum = "dc54500466d9dad8716bc2b0bbb8e72cf2559759efa6c535fb40dcdf249716b3"
 dependencies = [
  "base64ct",
- "der 0.5.1",
+ "der 0.6.0-pre.4",
 ]
 
 [[package]]

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -18,7 +18,7 @@ rust-version = "1.57"
 [dependencies]
 base16ct = "0.1.1"
 crypto-bigint = { version = "=0.4.0-pre.0", default-features = false, features = ["rand_core", "generic-array", "zeroize"] }
-der = { version = "0.5", default-features = false, features = ["oid"] }
+der = { version = "=0.6.0-pre.4", default-features = false, features = ["oid"] }
 generic-array = { version = "0.14", default-features = false }
 rand_core = { version = "0.6", default-features = false }
 subtle = { version = "2", default-features = false }
@@ -31,7 +31,7 @@ ff = { version = "0.12", optional = true, default-features = false }
 group = { version = "0.12", optional = true, default-features = false }
 hex-literal = { version = "0.3", optional = true }
 pem-rfc7468 = { version = "0.5", optional = true }
-sec1 = { version = "0.2", optional = true, features = ["subtle", "zeroize"] }
+sec1 = { version = "=0.3.0-pre.2", optional = true, features = ["subtle", "zeroize"] }
 serde = { version = "1", optional = true, default-features = false }
 serde_json = { version = "1", optional = true, default-features = false, features = ["alloc"] }
 

--- a/elliptic-curve/src/dev.rs
+++ b/elliptic-curve/src/dev.rs
@@ -87,7 +87,7 @@ impl ScalarArithmetic for MockCurve {
 
 impl AlgorithmParameters for MockCurve {
     /// OID for NIST P-256
-    const OID: pkcs8::ObjectIdentifier = pkcs8::ObjectIdentifier::new("1.2.840.10045.3.1.7");
+    const OID: pkcs8::ObjectIdentifier = pkcs8::ObjectIdentifier::new_unwrap("1.2.840.10045.3.1.7");
 }
 
 #[cfg(feature = "jwk")]

--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -146,7 +146,7 @@ use generic_array::GenericArray;
 #[cfg(feature = "pkcs8")]
 #[cfg_attr(docsrs, doc(cfg(feature = "pkcs8")))]
 pub const ALGORITHM_OID: pkcs8::ObjectIdentifier =
-    pkcs8::ObjectIdentifier::new("1.2.840.10045.2.1");
+    pkcs8::ObjectIdentifier::new_unwrap("1.2.840.10045.2.1");
 
 /// Elliptic curve.
 ///

--- a/elliptic-curve/src/public_key.rs
+++ b/elliptic-curve/src/public_key.rs
@@ -312,7 +312,7 @@ where
     AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
     FieldSize<C>: ModulusSize,
 {
-    fn to_public_key_der(&self) -> pkcs8::spki::Result<pkcs8::PublicKeyDocument> {
+    fn to_public_key_der(&self) -> pkcs8::spki::Result<der::Document> {
         let public_key_bytes = self.to_encoded_point(false);
 
         pkcs8::SubjectPublicKeyInfo {

--- a/elliptic-curve/src/secret_key.rs
+++ b/elliptic-curve/src/secret_key.rs
@@ -24,7 +24,7 @@ use {
         AffinePoint,
     },
     alloc::vec::Vec,
-    der::Encodable,
+    der::Encode,
     zeroize::Zeroizing,
 };
 

--- a/elliptic-curve/src/secret_key/pkcs8.rs
+++ b/elliptic-curve/src/secret_key/pkcs8.rs
@@ -6,7 +6,7 @@ use crate::{
     sec1::{ModulusSize, ValidatePublicKey},
     AlgorithmParameters, Curve, FieldSize, ALGORITHM_OID,
 };
-use der::Decodable;
+use der::Decode;
 use sec1::EcPrivateKey;
 
 // Imports for the `EncodePrivateKey` impl
@@ -65,9 +65,10 @@ where
     AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
     FieldSize<C>: ModulusSize,
 {
-    fn to_pkcs8_der(&self) -> pkcs8::Result<pkcs8::PrivateKeyDocument> {
+    fn to_pkcs8_der(&self) -> pkcs8::Result<der::SecretDocument> {
         let ec_private_key = self.to_sec1_der()?;
-        pkcs8::PrivateKeyInfo::new(C::algorithm_identifier(), &ec_private_key).to_der()
+        let pkcs8_key = pkcs8::PrivateKeyInfo::new(C::algorithm_identifier(), &ec_private_key);
+        Ok(der::SecretDocument::encode_msg(&pkcs8_key)?)
     }
 }
 

--- a/elliptic-curve/tests/pkcs8.rs
+++ b/elliptic-curve/tests/pkcs8.rs
@@ -4,7 +4,7 @@
 
 use elliptic_curve::{
     dev::{PublicKey, SecretKey},
-    pkcs8::{DecodePrivateKey, DecodePublicKey, EncodePrivateKey, PrivateKeyDocument},
+    pkcs8::{DecodePrivateKey, DecodePublicKey, EncodePrivateKey},
     sec1::ToEncodedPoint,
 };
 use hex_literal::hex;
@@ -21,7 +21,7 @@ const EXAMPLE_SCALAR: [u8; 32] =
     hex!("AABBCCDDEEFF0000000000000000000000000000000000000000000000000001");
 
 /// Example PKCS#8 private key
-fn example_private_key() -> PrivateKeyDocument {
+fn example_private_key() -> der::SecretDocument {
     SecretKey::from_be_bytes(&EXAMPLE_SCALAR)
         .unwrap()
         .to_pkcs8_der()
@@ -30,7 +30,7 @@ fn example_private_key() -> PrivateKeyDocument {
 
 #[test]
 fn decode_pkcs8_private_key_from_der() {
-    let secret_key = SecretKey::from_pkcs8_der(example_private_key().as_ref()).unwrap();
+    let secret_key = SecretKey::from_pkcs8_der(example_private_key().as_bytes()).unwrap();
     assert_eq!(secret_key.to_be_bytes().as_slice(), &EXAMPLE_SCALAR);
 }
 


### PR DESCRIPTION
Also bumps `pkcs8` to v0.9.0-pre.2.

This should hopefully be the last prerelease before a final release.