### PR TITLE
elliptic-curve: use `serdect` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -326,8 +326,8 @@ dependencies = [
  "pem-rfc7468 0.5.1",
  "rand_core",
  "sec1",
- "serde",
  "serde_json",
+ "serdect",
  "sha2 0.10.2",
  "sha3",
  "subtle",
@@ -777,6 +777,16 @@ checksum = "8e8d9fa5c3b304765ce1fd9c4c8a3de2c8db365a5b91be52f186efc675681d95"
 dependencies = [
  "itoa",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serdect"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "038fce1bf4d74b9b30ea7dcd59df75ba8ec669a5dcb3cc64fbfcef7334ced32c"
+dependencies = [
+ "base16ct",
  "serde",
 ]
 

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -32,7 +32,7 @@ group = { version = "0.12", optional = true, default-features = false }
 hex-literal = { version = "0.3", optional = true }
 pem-rfc7468 = { version = "0.5", optional = true }
 sec1 = { version = "=0.3.0-pre.2", optional = true, features = ["subtle", "zeroize"] }
-serde = { version = "1", optional = true, default-features = false }
+serdect = { version = "0.1", optional = true, default-features = false, features = ["alloc"] }
 serde_json = { version = "1", optional = true, default-features = false, features = ["alloc"] }
 
 [dev-dependencies]
@@ -52,6 +52,7 @@ hazmat = []
 jwk = ["alloc", "base64ct/alloc", "serde", "serde_json", "zeroize/alloc"]
 pem = ["alloc", "arithmetic", "pem-rfc7468/alloc", "pkcs8", "sec1/pem"]
 pkcs8 = ["sec1/pkcs8"]
+serde = ["alloc", "serdect"]
 std = ["alloc", "rand_core/std"]
 voprf = ["digest"]
 

--- a/elliptic-curve/src/jwk.rs
+++ b/elliptic-curve/src/jwk.rs
@@ -19,7 +19,7 @@ use core::{
     marker::PhantomData,
     str::{self, FromStr},
 };
-use serde::{de, ser, Deserialize, Serialize};
+use serdect::serde::{de, ser, Deserialize, Serialize};
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
 #[cfg(feature = "arithmetic")]

--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -133,9 +133,6 @@ pub use crate::jwk::{JwkEcKey, JwkParameters};
 #[cfg(feature = "pkcs8")]
 pub use ::sec1::pkcs8;
 
-#[cfg(feature = "serde")]
-pub use serde;
-
 use core::fmt::Debug;
 use generic_array::GenericArray;
 

--- a/elliptic-curve/src/public_key.rs
+++ b/elliptic-curve/src/public_key.rs
@@ -31,8 +31,8 @@ use {
 #[cfg(any(feature = "jwk", feature = "pem"))]
 use alloc::string::{String, ToString};
 
-#[cfg(all(feature = "alloc", feature = "serde"))]
-use serde::{de, ser, Deserialize, Serialize};
+#[cfg(feature = "serde")]
+use serdect::serde::{de, ser, Deserialize, Serialize};
 
 /// Elliptic curve public keys.
 ///
@@ -352,8 +352,8 @@ where
     }
 }
 
-#[cfg(all(feature = "alloc", feature = "serde"))]
-#[cfg_attr(docsrs, doc(cfg(all(feature = "alloc", feature = "serde"))))]
+#[cfg(feature = "serde")]
+#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 impl<C> Serialize for PublicKey<C>
 where
     C: Curve + AlgorithmParameters + ProjectiveArithmetic,
@@ -365,17 +365,12 @@ where
         S: ser::Serializer,
     {
         let der = self.to_public_key_der().map_err(ser::Error::custom)?;
-
-        if serializer.is_human_readable() {
-            base16ct::upper::encode_string(der.as_ref()).serialize(serializer)
-        } else {
-            der.as_ref().serialize(serializer)
-        }
+        serdect::slice::serialize_hex_upper_or_bin(&der, serializer)
     }
 }
 
-#[cfg(all(feature = "alloc", feature = "serde"))]
-#[cfg_attr(docsrs, doc(cfg(all(feature = "alloc", feature = "serde"))))]
+#[cfg(feature = "serde")]
+#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 impl<'de, C> Deserialize<'de> for PublicKey<C>
 where
     C: Curve + AlgorithmParameters + ProjectiveArithmetic,
@@ -386,17 +381,8 @@ where
     where
         D: de::Deserializer<'de>,
     {
-        use de::Error;
-
-        if deserializer.is_human_readable() {
-            let der_bytes = base16ct::mixed::decode_vec(<&str>::deserialize(deserializer)?)
-                .map_err(D::Error::custom)?;
-            Self::from_public_key_der(&der_bytes)
-        } else {
-            let der_bytes = <&[u8]>::deserialize(deserializer)?;
-            Self::from_public_key_der(der_bytes)
-        }
-        .map_err(D::Error::custom)
+        let der_bytes = serdect::slice::deserialize_hex_or_bin_vec(deserializer)?;
+        Self::from_public_key_der(&der_bytes).map_err(de::Error::custom)
     }
 }
 


### PR DESCRIPTION
Uses the `serdect` crate, which provides constant time-ish serde serializers/deserializers, for impl'ing the `serde::{Deserialize, Serialize}` traits.