### PR TITLE
elliptic-curve: `ecdh::SharedSecret::extract` HKDF helper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -286,6 +286,7 @@ checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
 dependencies = [
  "block-buffer 0.10.2",
  "crypto-common 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "subtle",
 ]
 
 [[package]]
@@ -302,7 +303,7 @@ checksum = "43ee23aa5b4f68c7a092b5c3beb25f50c406adc75e2363634f242f28ab255372"
 dependencies = [
  "der 0.4.5",
  "elliptic-curve 0.10.4",
- "hmac",
+ "hmac 0.11.0",
  "signature 1.3.2",
 ]
 
@@ -335,6 +336,7 @@ dependencies = [
  "generic-array",
  "group 0.12.0",
  "hex-literal 0.3.4",
+ "hkdf 0.12.3",
  "pem-rfc7468 0.5.1",
  "pkcs8 0.9.0",
  "rand_core",
@@ -475,7 +477,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01706d578d5c281058480e673ae4086a9f4710d8df1ad80a5b03e39ece5f886b"
 dependencies = [
  "digest 0.9.0",
- "hmac",
+ "hmac 0.11.0",
+]
+
+[[package]]
+name = "hkdf"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "791a029f6b9fc27657f6f188ec6e5e43f6911f6f878e0dc5501396e09809d437"
+dependencies = [
+ "hmac 0.12.1",
 ]
 
 [[package]]
@@ -486,6 +497,15 @@ checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
 dependencies = [
  "crypto-mac",
  "digest 0.9.0",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest 0.10.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -992,7 +1012,7 @@ dependencies = [
  "bincode",
  "const-oid 0.6.2",
  "getrandom",
- "hkdf",
+ "hkdf 0.11.0",
  "p256",
  "rand_core",
  "serde",

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -29,6 +29,7 @@ base64ct = { version = "1", optional = true, default-features = false }
 digest = { version = "0.10", optional = true }
 ff = { version = "0.12", optional = true, default-features = false }
 group = { version = "0.12", optional = true, default-features = false }
+hkdf = { version = "0.12", optional = true, default-features = false }
 hex-literal = { version = "0.3", optional = true }
 pem-rfc7468 = { version = "0.5", optional = true }
 pkcs8 = { version = "0.9", optional = true, default-features = false }
@@ -48,7 +49,7 @@ arithmetic = ["ff", "group"]
 bits = ["arithmetic", "ff/bits"]
 dev = ["arithmetic", "hex-literal", "pem", "pkcs8"]
 hash2curve = ["arithmetic", "digest"]
-ecdh = ["arithmetic"]
+ecdh = ["arithmetic", "digest", "hkdf"]
 hazmat = []
 jwk = ["alloc", "base64ct/alloc", "serde", "serde_json", "zeroize/alloc"]
 pem = ["alloc", "arithmetic", "pem-rfc7468/alloc", "pkcs8", "sec1/pem"]

--- a/elliptic-curve/src/secret_key.rs
+++ b/elliptic-curve/src/secret_key.rs
@@ -78,9 +78,7 @@ pub(crate) const SEC1_PEM_TYPE_LABEL: &str = "EC PRIVATE KEY";
 ///
 /// To decode an elliptic curve private key from PKCS#8, enable the `pkcs8`
 /// feature of this crate (or the `pkcs8` feature of a specific RustCrypto
-/// elliptic curve crate) and use the
-/// [`DecodePrivateKey`][`elliptic_curve::pkcs8::DecodePrivateKey`]
-/// trait to parse it.
+/// elliptic curve crate) and use the [`DecodePrivateKey`]  trait to parse it.
 ///
 /// When the `pem` feature of this crate (or a specific RustCrypto elliptic
 /// curve crate) is enabled, a [`FromStr`] impl is also available.


### PR DESCRIPTION
Adds support for using HKDF to generate key material from an ECDH shared secret using the `hkdf` crate.

Renames the previous `as_bytes` method to `raw_secret_bytes` with a warning that the `extract` method should be preferred instead.