### PR TITLE
elliptic-curve v0.12.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -180,7 +180,7 @@ dependencies = [
  "cipher 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "crypto-mac",
  "digest 0.10.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "elliptic-curve 0.12.0-pre.4",
+ "elliptic-curve 0.12.0",
  "password-hash",
  "signature 1.5.0",
  "universal-hash",
@@ -325,7 +325,7 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.12.0-pre.4"
+version = "0.12.0"
 dependencies = [
  "base16ct",
  "base64ct",
@@ -337,7 +337,7 @@ dependencies = [
  "group 0.12.0",
  "hex-literal 0.3.4",
  "hkdf 0.12.3",
- "pem-rfc7468 0.5.1",
+ "pem-rfc7468 0.6.0",
  "pkcs8 0.9.0",
  "rand_core",
  "sec1",
@@ -599,15 +599,6 @@ name = "pem-rfc7468"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f22eb0e3c593294a99e9ff4b24cf6b752d43f193aa4415fe5077c159996d497"
-dependencies = [
- "base64ct",
-]
-
-[[package]]
-name = "pem-rfc7468"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "973e070439aaacda48e5effad187f36d670b7635f7dcb75fa3c6f482d1b5b932"
 dependencies = [
  "base64ct",
 ]

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -18,7 +18,7 @@ rust-version = "1.57"
 aead = { version = "0.4", optional = true, path = "../aead" }
 cipher = { version = "0.4", optional = true }
 digest = { version = "0.10", optional = true }
-elliptic-curve = { version = "0.12.0-pre", optional = true, path = "../elliptic-curve" }
+elliptic-curve = { version = "0.12", optional = true, path = "../elliptic-curve" }
 mac = { version = "0.11", package = "crypto-mac", optional = true }
 password-hash = { version = "0.4", optional = true, path = "../password-hash" }
 signature = { version = "1.5", optional = true, default-features = false, path = "../signature" }

--- a/elliptic-curve/CHANGELOG.md
+++ b/elliptic-curve/CHANGELOG.md
@@ -4,6 +4,41 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.12.0 (2022-05-08)
+### Added
+- `ecdh::SharedSecret::extract` HKDF helper ([#1007])
+
+### Changed
+- Bump `digest` dependency to v0.10 ([#883], [#904])
+- Make `NonZeroScalar::invert` infallible ([#894])
+- `ToCompactEncodedPoint` now returns `CtOption` ([#895])
+- Move `hash2field` into `hash2curve` module ([#903])
+- Bump `ff` and `group` dependencies to v0.12 ([#994])
+- Use `serdect` crate ([#996])
+- Replace `AlgorithmParamters` with `AssociatedOid` ([#1001])
+- Bump `crypto-bigint` dependency to v0.4 ([#1005])
+- Bump `der` dependency to v0.6 ([#1006])
+- Bump `pkcs8` dependency to v0.9 ([#1006])
+- Bump `sec1` dependency to v0.3 ([#1006])
+- Bump `pem-rfc7468` dependency to v0.6 ([#1009])
+
+### Removed
+- `Zeroize` impl from `ecdh::SharedSecret` ([#978])
+
+[#883]: https://github.com/RustCrypto/formats/pull/883
+[#894]: https://github.com/RustCrypto/formats/pull/894
+[#895]: https://github.com/RustCrypto/formats/pull/895
+[#903]: https://github.com/RustCrypto/formats/pull/903
+[#904]: https://github.com/RustCrypto/formats/pull/904
+[#978]: https://github.com/RustCrypto/formats/pull/978
+[#994]: https://github.com/RustCrypto/formats/pull/994
+[#996]: https://github.com/RustCrypto/formats/pull/996
+[#1001]: https://github.com/RustCrypto/formats/pull/1001
+[#1005]: https://github.com/RustCrypto/formats/pull/1005
+[#1006]: https://github.com/RustCrypto/formats/pull/1006
+[#1007]: https://github.com/RustCrypto/formats/pull/1007
+[#1009]: https://github.com/RustCrypto/formats/pull/1009
+
 ## 0.11.12 (2022-01-30)
 ### Changed
 - Disable `bits` feature on docs.rs due to nightly breakage ([#927])

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elliptic-curve"
-version = "0.12.0-pre.4" # Also update html_root_url in lib.rs when bumping this
+version = "0.12.0"
 description = """
 General purpose Elliptic Curve Cryptography (ECC) support, including types
 and traits for representing various elliptic curve forms, scalars, points,
@@ -31,7 +31,7 @@ ff = { version = "0.12", optional = true, default-features = false }
 group = { version = "0.12", optional = true, default-features = false }
 hkdf = { version = "0.12", optional = true, default-features = false }
 hex-literal = { version = "0.3", optional = true }
-pem-rfc7468 = { version = "0.5", optional = true }
+pem-rfc7468 = { version = "0.6", optional = true }
 pkcs8 = { version = "0.9", optional = true, default-features = false }
 sec1 = { version = "0.3", optional = true, features = ["subtle", "zeroize"] }
 serdect = { version = "0.1", optional = true, default-features = false, features = ["alloc"] }
@@ -52,7 +52,7 @@ hash2curve = ["arithmetic", "digest"]
 ecdh = ["arithmetic", "digest", "hkdf"]
 hazmat = []
 jwk = ["alloc", "base64ct/alloc", "serde", "serde_json", "zeroize/alloc"]
-pem = ["alloc", "arithmetic", "pem-rfc7468/alloc", "pkcs8", "sec1/pem"]
+pem = ["alloc", "arithmetic", "der/pem", "pem-rfc7468/alloc", "pkcs8", "sec1/pem"]
 serde = ["alloc", "sec1/serde", "serdect"]
 std = ["alloc", "rand_core/std"]
 voprf = ["digest"]

--- a/elliptic-curve/README.md
+++ b/elliptic-curve/README.md
@@ -2,10 +2,10 @@
 
 [![crate][crate-image]][crate-link]
 [![Docs][docs-image]][docs-link]
+[![Build Status][build-image]][build-link]
 ![Apache2/MIT licensed][license-image]
 ![Rust Version][rustc-image]
 [![Project Chat][chat-image]][chat-link]
-[![Build Status][build-image]][build-link]
 
 General purpose Elliptic Curve Cryptography (ECC) support, including types
 and traits for representing various elliptic curve forms, scalars, points,
@@ -42,13 +42,13 @@ dual licensed as above, without any additional terms or conditions.
 
 [//]: # (badges)
 
-[crate-image]: https://img.shields.io/crates/v/elliptic-curve.svg
+[crate-image]: https://buildstats.info/crate/elliptic-curve
 [crate-link]: https://crates.io/crates/elliptic-curve
 [docs-image]: https://docs.rs/elliptic-curve/badge.svg
 [docs-link]: https://docs.rs/elliptic-curve/
+[build-image]: https://github.com/RustCrypto/traits/actions/workflows/elliptic-curve.yml/badge.svg
+[build-link]: https://github.com/RustCrypto/traits/actions/workflows/elliptic-curve.yml
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
 [rustc-image]: https://img.shields.io/badge/rustc-1.57+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260040-elliptic-curves
-[build-image]: https://github.com/RustCrypto/elliptic-curves/workflows/elliptic-curve%20crate/badge.svg?branch=master&event=push
-[build-link]: https://github.com/RustCrypto/elliptic-curves/actions?query=workflow%3A%22elliptic-curve+crate%22

--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -3,8 +3,7 @@
 #![doc = include_str!("../README.md")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
-    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
-    html_root_url = "https://docs.rs/elliptic-curve/0.12.0-pre.1"
+    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg"
 )]
 #![forbid(unsafe_code, clippy::unwrap_used)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]


### PR DESCRIPTION
### Added
- `ecdh::SharedSecret::extract` HKDF helper ([#1007])

### Changed
- Bump `digest` dependency to v0.10 ([#883], [#904])
- Make `NonZeroScalar::invert` infallible ([#894])
- `ToCompactEncodedPoint` now returns `CtOption` ([#895])
- Move `hash2field` into `hash2curve` module ([#903])
- Bump `ff` and `group` dependencies to v0.12 ([#994])
- Use `serdect` crate ([#996])
- Replace `AlgorithmParamters` with `AssociatedOid` ([#1001])
- Bump `crypto-bigint` dependency to v0.4 ([#1005])
- Bump `der` dependency to v0.6 ([#1006])
- Bump `pkcs8` dependency to v0.9 ([#1006])
- Bump `sec1` dependency to v0.3 ([#1006])

### Removed
- `Zeroize` impl from `ecdh::SharedSecret` ([#978])

[#883]: https://github.com/RustCrypto/formats/pull/883
[#894]: https://github.com/RustCrypto/formats/pull/894
[#895]: https://github.com/RustCrypto/formats/pull/895
[#903]: https://github.com/RustCrypto/formats/pull/903
[#904]: https://github.com/RustCrypto/formats/pull/904
[#978]: https://github.com/RustCrypto/formats/pull/978
[#994]: https://github.com/RustCrypto/formats/pull/994
[#996]: https://github.com/RustCrypto/formats/pull/996
[#1001]: https://github.com/RustCrypto/formats/pull/1001
[#1005]: https://github.com/RustCrypto/formats/pull/1005
[#1006]: https://github.com/RustCrypto/formats/pull/1006
[#1007]: https://github.com/RustCrypto/formats/pull/1007