### PR TITLE
cipher: add unaligned bytes en/decryption without padding

### DIFF
--- a/cipher/src/lib.rs
+++ b/cipher/src/lib.rs
@@ -75,5 +75,6 @@ pub trait ParBlocksSizeUser: BlockSizeUser {
 /// Parallel blocks on which [`ParBlocksSizeUser`] implementors operate.
 pub type ParBlocks<T> = GenericArray<Block<T>, <T as ParBlocksSizeUser>::ParBlocksSize>;
 
+/// If unaligned tail procesing failed, this struct should be returned.
 #[derive(Debug)]
 pub struct TailError;

--- a/cipher/src/lib.rs
+++ b/cipher/src/lib.rs
@@ -45,8 +45,8 @@ mod errors;
 mod stream;
 mod stream_core;
 mod stream_wrapper;
-mod unaligned_bytes_mut;
 mod unaligned_bytes;
+mod unaligned_bytes_mut;
 
 pub use crate::{block::*, errors::*, stream::*, stream_core::*, stream_wrapper::*};
 pub use crypto_common::{

--- a/cipher/src/lib.rs
+++ b/cipher/src/lib.rs
@@ -45,6 +45,8 @@ mod errors;
 mod stream;
 mod stream_core;
 mod stream_wrapper;
+mod unaligned_bytes_mut;
+mod unaligned_bytes;
 
 pub use crate::{block::*, errors::*, stream::*, stream_core::*, stream_wrapper::*};
 pub use crypto_common::{

--- a/cipher/src/lib.rs
+++ b/cipher/src/lib.rs
@@ -74,3 +74,6 @@ pub trait ParBlocksSizeUser: BlockSizeUser {
 
 /// Parallel blocks on which [`ParBlocksSizeUser`] implementors operate.
 pub type ParBlocks<T> = GenericArray<Block<T>, <T as ParBlocksSizeUser>::ParBlocksSize>;
+
+#[derive(Debug)]
+pub struct TailError;

--- a/cipher/src/lib.rs
+++ b/cipher/src/lib.rs
@@ -48,7 +48,10 @@ mod stream_wrapper;
 mod unaligned_bytes;
 mod unaligned_bytes_mut;
 
-pub use crate::{block::*, errors::*, stream::*, stream_core::*, stream_wrapper::*};
+pub use crate::{
+    block::*, errors::*, stream::*, stream_core::*, stream_wrapper::*, unaligned_bytes::*,
+    unaligned_bytes_mut::*,
+};
 pub use crypto_common::{
     generic_array,
     typenum::{self, consts},

--- a/cipher/src/unaligned_bytes.rs
+++ b/cipher/src/unaligned_bytes.rs
@@ -1,6 +1,9 @@
 use crate::{Block, BlockDecrypt, BlockEncrypt, BlockSizeUser, TailError};
 use inout::InOutBuf;
 
+/// In many cases, plaintext and ciphertext input is not divisible by the block size, and padding is often used.
+/// In practical use, however, this is not always done, and user-specified processing to an unaligned part like, for example, XOR, is often applied.
+/// This trait enables to apply additional processing to an unaligned [`tail`].
 pub trait UnalignedBytesDecrypt: BlockDecrypt + BlockSizeUser {
     /// In many cases, plaintext and ciphertext input is not divisible by the block size, and padding is often used.
     /// In practical use, however, this is not always done, and the termination may be handled by, for example, XOR.
@@ -12,6 +15,7 @@ pub trait UnalignedBytesDecrypt: BlockDecrypt + BlockSizeUser {
         tail: &InOutBuf<'_, '_, u8>,
     ) -> Result<(), TailError>;
 
+    /// Decrypt `inout` bytes slice.
     #[inline]
     fn decrypt_bytes_inout<'inp, 'out>(
         &self,
@@ -54,6 +58,9 @@ pub trait UnalignedBytesDecrypt: BlockDecrypt + BlockSizeUser {
     }
 }
 
+/// In many cases, plaintext and ciphertext input is not divisible by the block size, and padding is often used.
+/// In practical use, however, this is not always done, and user-specified processing to an unaligned part like, for example, XOR, is often applied.
+/// This trait enables to apply additional processing to an unaligned [`tail`].
 pub trait UnalignedBytesEncrypt: BlockEncrypt + BlockSizeUser {
     /// In many cases, plaintext and ciphertext input is not divisible by the block size, and padding is often used.
     /// In practical use, however, this is not always done, and the termination may be handled by, for example, XOR.
@@ -65,6 +72,7 @@ pub trait UnalignedBytesEncrypt: BlockEncrypt + BlockSizeUser {
         tail: &InOutBuf<'_, '_, u8>,
     ) -> Result<(), TailError>;
 
+    /// Encrypt `inout` bytes slice.
     #[inline]
     fn encrypt_bytes_inout<'inp, 'out>(
         &self,

--- a/cipher/src/unaligned_bytes.rs
+++ b/cipher/src/unaligned_bytes.rs
@@ -1,0 +1,52 @@
+use inout::InOutBuf;
+use crate::{BlockDecrypt, BlockSizeUser, Block};
+
+pub trait UnalignedBytesDecrypt : BlockDecrypt + BlockSizeUser {
+    fn proc_tail(&self, blocks: &InOutBuf<'_, '_, Block<Self>>, tail: &InOutBuf<'_, '_, u8>) -> Result<(), TailError>;
+
+    #[inline]
+    fn decrypt_bytes_inout<'inp, 'out>(
+        &self,
+        data: InOutBuf<'inp, 'out, u8>,
+    ) -> Result<&'out [u8], TailError>
+    {
+        let n = data.len();
+
+        let (mut blocks, tail) = data.into_chunks();
+        self.decrypt_blocks_inout(blocks.reborrow());
+        if !tail.is_empty() {
+            self.proc_tail(&blocks, &tail)?
+        }
+        let out = unsafe {
+            let ptr = blocks.into_raw().1 as *const u8;
+            core::slice::from_raw_parts(ptr, n)
+        };
+        Ok(out)
+    }
+
+    /// Unaligned bytes input and decrypt in-place. Returns resulting plaintext slice.
+    ///
+    /// Returns [`TailError`] if length of output buffer is not sufficient.
+    #[inline]
+    fn decrypt_bytes<'a>(
+        &self,
+        buf: &'a mut [u8],
+    ) -> Result<&'a [u8], TailError> {
+        self.decrypt_bytes_inout(buf.into())
+    }
+
+    /// Unaligned bytes input and decrypt buffer-to-buffer. Returns resulting plaintext slice.
+    ///
+    /// Returns [`TailError`] if length of output buffer is not sufficient.
+    #[inline]
+    fn decrypt_bytes_b2b<'a>(
+        &self,
+        msg: &[u8],
+        out_buf: &'a mut [u8],
+    ) -> Result<&'a [u8], TailError> {
+        self.decrypt_bytes_inout(InOutBuf::new(msg, out_buf).unwrap())
+    }
+}
+
+#[derive(Debug)]
+pub struct TailError;

--- a/cipher/src/unaligned_bytes.rs
+++ b/cipher/src/unaligned_bytes.rs
@@ -1,4 +1,4 @@
-use crate::{Block, BlockDecrypt, BlockEncrypt, BlockSizeUser};
+use crate::{Block, BlockDecrypt, BlockEncrypt, BlockSizeUser, TailError};
 use inout::InOutBuf;
 
 pub trait UnalignedBytesDecrypt: BlockDecrypt + BlockSizeUser {
@@ -106,6 +106,3 @@ pub trait UnalignedBytesEncrypt: BlockEncrypt + BlockSizeUser {
         //self.encrypt_bytes_inout(InOutBuf::new(msg, out_buf)?)
     }
 }
-
-#[derive(Debug)]
-pub struct TailError;

--- a/cipher/src/unaligned_bytes.rs
+++ b/cipher/src/unaligned_bytes.rs
@@ -1,15 +1,22 @@
+use crate::{Block, BlockDecrypt, BlockEncrypt, BlockSizeUser};
 use inout::InOutBuf;
-use crate::{BlockDecrypt, BlockSizeUser, Block, BlockEncrypt};
 
-pub trait UnalignedBytesDecrypt : BlockDecrypt + BlockSizeUser {
-    fn proc_tail(&self, blocks: &InOutBuf<'_, '_, Block<Self>>, tail: &InOutBuf<'_, '_, u8>) -> Result<(), TailError>;
+pub trait UnalignedBytesDecrypt: BlockDecrypt + BlockSizeUser {
+    /// In many cases, plaintext and ciphertext input is not divisible by the block size, and padding is often used.
+    /// In practical use, however, this is not always done, and the termination may be handled by, for example, XOR.
+    /// This trait and fn [`proc_tail`] divides the input into aligned blocks and an unaligned part([`tail`]),
+    /// and then applies appropriate user-specified processing to the [`tail`].
+    fn proc_tail(
+        &self,
+        blocks: &InOutBuf<'_, '_, Block<Self>>,
+        tail: &InOutBuf<'_, '_, u8>,
+    ) -> Result<(), TailError>;
 
     #[inline]
     fn decrypt_bytes_inout<'inp, 'out>(
         &self,
         data: InOutBuf<'inp, 'out, u8>,
-    ) -> Result<&'out [u8], TailError>
-    {
+    ) -> Result<&'out [u8], TailError> {
         let n = data.len();
 
         let (mut blocks, tail) = data.into_chunks();
@@ -28,10 +35,7 @@ pub trait UnalignedBytesDecrypt : BlockDecrypt + BlockSizeUser {
     ///
     /// Returns [`TailError`] if length of output buffer is not sufficient.
     #[inline]
-    fn decrypt_bytes<'a>(
-        &self,
-        buf: &'a mut [u8],
-    ) -> Result<&'a [u8], TailError> {
+    fn decrypt_bytes<'a>(&self, buf: &'a mut [u8]) -> Result<&'a [u8], TailError> {
         self.decrypt_bytes_inout(buf.into())
     }
 
@@ -50,15 +54,22 @@ pub trait UnalignedBytesDecrypt : BlockDecrypt + BlockSizeUser {
     }
 }
 
-pub trait UnalignedBytesEncrypt : BlockEncrypt + BlockSizeUser {
-    fn proc_tail(&self, blocks: &InOutBuf<'_, '_, Block<Self>>, tail: &InOutBuf<'_, '_, u8>) -> Result<(), TailError>;
+pub trait UnalignedBytesEncrypt: BlockEncrypt + BlockSizeUser {
+    /// In many cases, plaintext and ciphertext input is not divisible by the block size, and padding is often used.
+    /// In practical use, however, this is not always done, and the termination may be handled by, for example, XOR.
+    /// This trait and fn [`proc_tail`] divides the input into aligned blocks and an unaligned part([`tail`]),
+    /// and then applies appropriate user-specified processing to the [`tail`].
+    fn proc_tail(
+        &self,
+        blocks: &InOutBuf<'_, '_, Block<Self>>,
+        tail: &InOutBuf<'_, '_, u8>,
+    ) -> Result<(), TailError>;
 
     #[inline]
     fn encrypt_bytes_inout<'inp, 'out>(
         &self,
         data: InOutBuf<'inp, 'out, u8>,
-    ) -> Result<&'out [u8], TailError>
-    {
+    ) -> Result<&'out [u8], TailError> {
         let n = data.len();
 
         let (mut blocks, tail) = data.into_chunks();
@@ -77,10 +88,7 @@ pub trait UnalignedBytesEncrypt : BlockEncrypt + BlockSizeUser {
     ///
     /// Returns [`TailError`] if length of output buffer is not sufficient.
     #[inline]
-    fn encrypt_bytes<'a>(
-        &self,
-        buf: &'a mut [u8],
-    ) -> Result<&'a [u8], TailError> {
+    fn encrypt_bytes<'a>(&self, buf: &'a mut [u8]) -> Result<&'a [u8], TailError> {
         self.encrypt_bytes_inout(buf.into())
     }
 

--- a/cipher/src/unaligned_bytes_mut.rs
+++ b/cipher/src/unaligned_bytes_mut.rs
@@ -1,15 +1,22 @@
+use crate::{Block, BlockDecryptMut, BlockEncryptMut, BlockSizeUser};
 use inout::InOutBuf;
-use crate::{BlockDecryptMut, BlockSizeUser, Block, BlockEncryptMut};
 
-pub trait UnalignedBytesDecryptMut : BlockDecryptMut + BlockSizeUser {
-    fn proc_tail(&self, blocks: &mut InOutBuf<'_, '_, Block<Self>>, tail: &mut InOutBuf<'_, '_, u8>) -> Result<(), TailError>;
+pub trait UnalignedBytesDecryptMut: BlockDecryptMut + BlockSizeUser {
+    /// In many cases, plaintext and ciphertext input is not divisible by the block size, and padding is often used.
+    /// In practical use, however, this is not always done, and the termination may be handled by, for example, XOR.
+    /// This trait and fn [`proc_tail`] divides the input into aligned blocks and an unaligned part([`tail`]),
+    /// and then applies appropriate user-specified processing to the [`tail`].
+    fn proc_tail(
+        &self,
+        blocks: &mut InOutBuf<'_, '_, Block<Self>>,
+        tail: &mut InOutBuf<'_, '_, u8>,
+    ) -> Result<(), TailError>;
 
     #[inline]
     fn decrypt_bytes_inout_mut<'inp, 'out>(
         &mut self,
         data: InOutBuf<'inp, 'out, u8>,
-    ) -> Result<&'out [u8], TailError>
-    {
+    ) -> Result<&'out [u8], TailError> {
         let n = data.len();
         let (mut blocks, mut tail) = data.into_chunks();
         self.decrypt_blocks_inout_mut(blocks.reborrow());
@@ -27,10 +34,7 @@ pub trait UnalignedBytesDecryptMut : BlockDecryptMut + BlockSizeUser {
     ///
     /// Returns [`TailError`] if length of output buffer is not sufficient.
     #[inline]
-    fn decrypt_bytes_mut<'a>(
-        &mut self,
-        buf: &'a mut [u8],
-    ) -> Result<&'a [u8], TailError> {
+    fn decrypt_bytes_mut<'a>(&mut self, buf: &'a mut [u8]) -> Result<&'a [u8], TailError> {
         self.decrypt_bytes_inout_mut(buf.into())
     }
 
@@ -49,15 +53,22 @@ pub trait UnalignedBytesDecryptMut : BlockDecryptMut + BlockSizeUser {
     }
 }
 
-pub trait UnalignedBytesEncryptMut : BlockEncryptMut + BlockSizeUser {
-    fn proc_tail(&self, blocks: &mut InOutBuf<'_, '_, Block<Self>>, tail: &mut InOutBuf<'_, '_, u8>) -> Result<(), TailError>;
+pub trait UnalignedBytesEncryptMut: BlockEncryptMut + BlockSizeUser {
+    /// In many cases, plaintext and ciphertext input is not divisible by the block size, and padding is often used.
+    /// In practical use, however, this is not always done, and the termination may be handled by, for example, XOR.
+    /// This trait and fn [`proc_tail`] divides the input into aligned blocks and an unaligned part([`tail`]),
+    /// and then applies appropriate user-specified processing to the [`tail`].
+    fn proc_tail(
+        &self,
+        blocks: &mut InOutBuf<'_, '_, Block<Self>>,
+        tail: &mut InOutBuf<'_, '_, u8>,
+    ) -> Result<(), TailError>;
 
     #[inline]
     fn encrypt_bytes_inout_mut<'inp, 'out>(
         &mut self,
         data: InOutBuf<'inp, 'out, u8>,
-    ) -> Result<&'out [u8], TailError>
-    {
+    ) -> Result<&'out [u8], TailError> {
         let n = data.len();
         let (mut blocks, mut tail) = data.into_chunks();
         self.encrypt_blocks_inout_mut(blocks.reborrow());
@@ -75,10 +86,7 @@ pub trait UnalignedBytesEncryptMut : BlockEncryptMut + BlockSizeUser {
     ///
     /// Returns [`TailError`] if length of output buffer is not sufficient.
     #[inline]
-    fn encrypt_bytes_mut<'a>(
-        &mut self,
-        buf: &'a mut [u8],
-    ) -> Result<&'a [u8], TailError> {
+    fn encrypt_bytes_mut<'a>(&mut self, buf: &'a mut [u8]) -> Result<&'a [u8], TailError> {
         self.encrypt_bytes_inout_mut(buf.into())
     }
 

--- a/cipher/src/unaligned_bytes_mut.rs
+++ b/cipher/src/unaligned_bytes_mut.rs
@@ -1,0 +1,53 @@
+use inout::InOutBuf;
+use crate::{BlockDecryptMut, BlockSizeUser, Block};
+
+pub trait UnalignedBytesDecryptMut : BlockDecryptMut + BlockSizeUser {
+    fn proc_tail(&self, blocks: &mut InOutBuf<'_, '_, Block<Self>>, tail: &mut InOutBuf<'_, '_, u8>) -> Result<(), TailError>;
+
+    #[inline]
+    fn decrypt_bytes_inout_mut<'inp, 'out>(
+        &mut self,
+        data: InOutBuf<'inp, 'out, u8>,
+    ) -> Result<&'out [u8], TailError>
+    {
+        let n = data.len();
+        let (mut blocks, mut tail) = data.into_chunks();
+        self.decrypt_blocks_inout_mut(blocks.reborrow());
+        if !tail.is_empty() {
+            self.proc_tail(&mut blocks, &mut tail)?
+        }
+        let out = unsafe {
+            let ptr = blocks.into_raw().1 as *const u8;
+            core::slice::from_raw_parts(ptr, n)
+        };
+        Ok(out)
+    }
+
+    /// Unaligned bytes input and decrypt in-place. Returns resulting plaintext slice.
+    ///
+    /// Returns [`TailError`] if length of output buffer is not sufficient.
+    #[inline]
+    fn decrypt_bytes_mut<'a>(
+        &mut self,
+        buf: &'a mut [u8],
+    ) -> Result<&'a [u8], TailError> {
+        self.decrypt_bytes_inout_mut(buf.into())
+    }
+
+    /// Unaligned bytes input and decrypt buffer-to-buffer. Returns resulting plaintext slice.
+    ///
+    /// Returns [`TailError`] if length of output buffer is not sufficient.
+    #[inline]
+    fn decrypt_bytes_b2b_mut<'a>(
+        &mut self,
+        msg: &[u8],
+        out_buf: &'a mut [u8],
+    ) -> Result<&'a [u8], TailError> {
+        self.decrypt_bytes_inout_mut(InOutBuf::new(msg, out_buf).unwrap())
+        // FIXME:  pass NotEqualError with TailError
+        //self.decrypt_bytes_inout_mut(InOutBuf::new(msg, out_buf)?)
+    }
+}
+
+#[derive(Debug)]
+pub struct TailError;

--- a/cipher/src/unaligned_bytes_mut.rs
+++ b/cipher/src/unaligned_bytes_mut.rs
@@ -1,6 +1,9 @@
 use crate::{Block, BlockDecryptMut, BlockEncryptMut, BlockSizeUser, TailError};
 use inout::InOutBuf;
 
+/// In many cases, plaintext and ciphertext input is not divisible by the block size, and padding is often used.
+/// In practical use, however, this is not always done, and user-specified processing to an unaligned part like, for example, XOR, is often applied.
+/// This trait enables to apply additional processing to an unaligned [`tail`].
 pub trait UnalignedBytesDecryptMut: BlockDecryptMut + BlockSizeUser {
     /// In many cases, plaintext and ciphertext input is not divisible by the block size, and padding is often used.
     /// In practical use, however, this is not always done, and the termination may be handled by, for example, XOR.
@@ -12,6 +15,7 @@ pub trait UnalignedBytesDecryptMut: BlockDecryptMut + BlockSizeUser {
         tail: &mut InOutBuf<'_, '_, u8>,
     ) -> Result<(), TailError>;
 
+    /// Decrypt `inout` bytes slice.
     #[inline]
     fn decrypt_bytes_inout_mut<'inp, 'out>(
         &mut self,
@@ -54,6 +58,9 @@ pub trait UnalignedBytesDecryptMut: BlockDecryptMut + BlockSizeUser {
     }
 }
 
+/// In many cases, plaintext and ciphertext input is not divisible by the block size, and padding is often used.
+/// In practical use, however, this is not always done, and user-specified processing to an unaligned part like, for example, XOR, is often applied.
+/// This trait enables to apply additional processing to an unaligned [`tail`].
 pub trait UnalignedBytesEncryptMut: BlockEncryptMut + BlockSizeUser {
     /// In many cases, plaintext and ciphertext input is not divisible by the block size, and padding is often used.
     /// In practical use, however, this is not always done, and the termination may be handled by, for example, XOR.
@@ -65,6 +72,7 @@ pub trait UnalignedBytesEncryptMut: BlockEncryptMut + BlockSizeUser {
         tail: &mut InOutBuf<'_, '_, u8>,
     ) -> Result<(), TailError>;
 
+    /// Encrypt `inout` bytes slice.
     #[inline]
     fn encrypt_bytes_inout_mut<'inp, 'out>(
         &mut self,

--- a/cipher/src/unaligned_bytes_mut.rs
+++ b/cipher/src/unaligned_bytes_mut.rs
@@ -1,5 +1,5 @@
 use inout::InOutBuf;
-use crate::{BlockDecryptMut, BlockSizeUser, Block};
+use crate::{BlockDecryptMut, BlockSizeUser, Block, BlockEncryptMut};
 
 pub trait UnalignedBytesDecryptMut : BlockDecryptMut + BlockSizeUser {
     fn proc_tail(&self, blocks: &mut InOutBuf<'_, '_, Block<Self>>, tail: &mut InOutBuf<'_, '_, u8>) -> Result<(), TailError>;
@@ -46,6 +46,54 @@ pub trait UnalignedBytesDecryptMut : BlockDecryptMut + BlockSizeUser {
         self.decrypt_bytes_inout_mut(InOutBuf::new(msg, out_buf).unwrap())
         // FIXME:  pass NotEqualError with TailError
         //self.decrypt_bytes_inout_mut(InOutBuf::new(msg, out_buf)?)
+    }
+}
+
+pub trait UnalignedBytesEncryptMut : BlockEncryptMut + BlockSizeUser {
+    fn proc_tail(&self, blocks: &mut InOutBuf<'_, '_, Block<Self>>, tail: &mut InOutBuf<'_, '_, u8>) -> Result<(), TailError>;
+
+    #[inline]
+    fn encrypt_bytes_inout_mut<'inp, 'out>(
+        &mut self,
+        data: InOutBuf<'inp, 'out, u8>,
+    ) -> Result<&'out [u8], TailError>
+    {
+        let n = data.len();
+        let (mut blocks, mut tail) = data.into_chunks();
+        self.encrypt_blocks_inout_mut(blocks.reborrow());
+        if !tail.is_empty() {
+            self.proc_tail(&mut blocks, &mut tail)?
+        }
+        let out = unsafe {
+            let ptr = blocks.into_raw().1 as *const u8;
+            core::slice::from_raw_parts(ptr, n)
+        };
+        Ok(out)
+    }
+
+    /// Unaligned bytes input and encrypt in-place. Returns resulting plaintext slice.
+    ///
+    /// Returns [`TailError`] if length of output buffer is not sufficient.
+    #[inline]
+    fn encrypt_bytes_mut<'a>(
+        &mut self,
+        buf: &'a mut [u8],
+    ) -> Result<&'a [u8], TailError> {
+        self.encrypt_bytes_inout_mut(buf.into())
+    }
+
+    /// Unaligned bytes input and encrypt buffer-to-buffer. Returns resulting plaintext slice.
+    ///
+    /// Returns [`TailError`] if length of output buffer is not sufficient.
+    #[inline]
+    fn encrypt_bytes_b2b_mut<'a>(
+        &mut self,
+        msg: &[u8],
+        out_buf: &'a mut [u8],
+    ) -> Result<&'a [u8], TailError> {
+        self.encrypt_bytes_inout_mut(InOutBuf::new(msg, out_buf).unwrap())
+        // FIXME:  pass NotEqualError with TailError
+        //self.encrypt_bytes_inout_mut(InOutBuf::new(msg, out_buf)?)
     }
 }
 

--- a/cipher/src/unaligned_bytes_mut.rs
+++ b/cipher/src/unaligned_bytes_mut.rs
@@ -1,4 +1,4 @@
-use crate::{Block, BlockDecryptMut, BlockEncryptMut, BlockSizeUser};
+use crate::{Block, BlockDecryptMut, BlockEncryptMut, BlockSizeUser, TailError};
 use inout::InOutBuf;
 
 pub trait UnalignedBytesDecryptMut: BlockDecryptMut + BlockSizeUser {
@@ -18,6 +18,7 @@ pub trait UnalignedBytesDecryptMut: BlockDecryptMut + BlockSizeUser {
         data: InOutBuf<'inp, 'out, u8>,
     ) -> Result<&'out [u8], TailError> {
         let n = data.len();
+
         let (mut blocks, mut tail) = data.into_chunks();
         self.decrypt_blocks_inout_mut(blocks.reborrow());
         if !tail.is_empty() {
@@ -70,6 +71,7 @@ pub trait UnalignedBytesEncryptMut: BlockEncryptMut + BlockSizeUser {
         data: InOutBuf<'inp, 'out, u8>,
     ) -> Result<&'out [u8], TailError> {
         let n = data.len();
+
         let (mut blocks, mut tail) = data.into_chunks();
         self.encrypt_blocks_inout_mut(blocks.reborrow());
         if !tail.is_empty() {
@@ -104,6 +106,3 @@ pub trait UnalignedBytesEncryptMut: BlockEncryptMut + BlockSizeUser {
         //self.encrypt_bytes_inout_mut(InOutBuf::new(msg, out_buf)?)
     }
 }
-
-#[derive(Debug)]
-pub struct TailError;


### PR DESCRIPTION
In many cases, plaintext and ciphertext input is not divisible by the block size, and padding is often used. In practical use, however, this is not always done, and the termination may be handled by, for example, XOR.
This trait and fn `proc_tail` divides the input into aligned blocks and an unaligned part(`tail`), and then applies appropriate user-specified processing to the `tail`


TODO: Show the example usage here, 
and add the same things on the documentation comments for fn proc_tail