### PR TITLE
elliptic-curve v0.12.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -239,7 +239,7 @@ dependencies = [
  "cipher 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "crypto-mac",
  "digest 0.10.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "elliptic-curve 0.12.0",
+ "elliptic-curve 0.12.1",
  "password-hash",
  "signature 1.5.0",
  "universal-hash 0.4.1",
@@ -406,7 +406,7 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "base16ct",
  "base64ct",

--- a/elliptic-curve/CHANGELOG.md
+++ b/elliptic-curve/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.12.1 (2022-06-12)
+### Added
+- `impl_field_element!` macro ([#1021])
+- Generic impl of complete prime order formulas ([#1022])
+
+### Changed
+- Bump `crypto-bigint` to v0.4.4 ([#1018], [#1020])
+
+[#1018]: https://github.com/RustCrypto/formats/pull/1018
+[#1020]: https://github.com/RustCrypto/formats/pull/1020
+[#1021]: https://github.com/RustCrypto/formats/pull/1021
+[#1022]: https://github.com/RustCrypto/formats/pull/1022
+
 ## 0.12.0 (2022-05-08)
 ### Added
 - `ecdh::SharedSecret::extract` HKDF helper ([#1007])

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elliptic-curve"
-version = "0.12.0"
+version = "0.12.1"
 description = """
 General purpose Elliptic Curve Cryptography (ECC) support, including types
 and traits for representing various elliptic curve forms, scalars, points,


### PR DESCRIPTION
### Added
- `impl_field_element!` macro ([#1021])
- Generic impl of complete prime order formulas ([#1022])

### Changed
- Bump `crypto-bigint` to v0.4.4 ([#1018], [#1020])

[#1018]: https://github.com/RustCrypto/formats/pull/1018
[#1020]: https://github.com/RustCrypto/formats/pull/1020
[#1021]: https://github.com/RustCrypto/formats/pull/1021
[#1022]: https://github.com/RustCrypto/formats/pull/1022