### PR TITLE
elliptic-curve: allow bigger `c1` constant in `OsswuMapParams`

### DIFF
--- a/elliptic-curve/src/hash2curve/osswu.rs
+++ b/elliptic-curve/src/hash2curve/osswu.rs
@@ -11,7 +11,7 @@ where
     F: Field,
 {
     /// The first constant term
-    pub c1: [u64; 4],
+    pub c1: &'static [u64],
     /// The second constant term
     pub c2: F,
     /// The ISO A variable or Curve A variable


### PR DESCRIPTION
Apparently this was need for https://github.com/RustCrypto/elliptic-curves/pull/600. It will also be necessary for P-512. I assume this is a breaking change?