### PR TITLE
aead: use `crypto-common`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,21 +5,21 @@ version = 3
 [[package]]
 name = "aead"
 version = "0.4.3"
-dependencies = [
- "blobby",
- "bytes",
- "generic-array",
- "heapless",
- "rand_core 0.6.3",
-]
-
-[[package]]
-name = "aead"
-version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b613b8e1e3cf911a086f53f03bf286f52fd7a7258e4fa606f0ef220d39d8877"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "aead"
+version = "0.5.0-pre"
+dependencies = [
+ "blobby",
+ "bytes",
+ "crypto-common 0.1.3",
+ "generic-array",
+ "heapless",
 ]
 
 [[package]]
@@ -39,7 +39,7 @@ version = "0.10.0-pre"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8004e8b23ff2c65e28ff77bab0eccd36f4a6c2c8e0b55c46acba481425cc3a4f"
 dependencies = [
- "aead 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aead 0.4.3",
  "aes",
  "cipher 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "ctr",
@@ -182,7 +182,7 @@ version = "0.10.0-pre"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "746c430f71e66469abcf493c11484b1a86b957c84fc2d0ba664cd12ac23679ea"
 dependencies = [
- "aead 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aead 0.4.3",
  "chacha20",
  "cipher 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "poly1305",
@@ -235,7 +235,7 @@ dependencies = [
 name = "crypto"
 version = "0.4.0-pre"
 dependencies = [
- "aead 0.4.3",
+ "aead 0.5.0-pre",
  "cipher 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "crypto-mac",
  "digest 0.10.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -604,7 +604,7 @@ name = "hpke"
 version = "0.9.0"
 source = "git+https://github.com/rozbb/rust-hpke?rev=9230db267819f5795a47510139f4f1a60688ce82#9230db267819f5795a47510139f4f1a60688ce82"
 dependencies = [
- "aead 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aead 0.4.3",
  "aes-gcm",
  "byteorder",
  "chacha20poly1305",

--- a/aead/Cargo.toml
+++ b/aead/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aead"
-version = "0.4.3" # Also update html_root_url in lib.rs when bumping this
+version = "0.5.0-pre" # Also update html_root_url in lib.rs when bumping this
 description = """
 Traits for Authenticated Encryption with Associated Data (AEAD) algorithms,
 such as AES-GCM as ChaCha20Poly1305, which provide a high-level API
@@ -15,18 +15,20 @@ keywords = ["crypto", "encryption"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
+crypto-common = { version = "0.1", path = "../crypto-common" }
 generic-array = { version = "0.14", default-features = false }
 
 # optional dependencies
 blobby = { version = "0.3", optional = true }
 bytes = { version = "1", optional = true, default-features = false }
 heapless = { version = "0.7", optional = true, default-features = false }
-rand_core = { version = "0.6", optional = true }
 
 [features]
+default = ["rand_core"]
 alloc = []
-std = ["alloc", "rand_core/std"]
+std = ["alloc", "crypto-common/std"]
 dev = ["blobby"]
+rand_core = ["crypto-common/rand_core"]
 stream = []
 
 [package.metadata.docs.rs]

--- a/aead/src/stream.rs
+++ b/aead/src/stream.rs
@@ -32,7 +32,7 @@
 
 #![allow(clippy::upper_case_acronyms)]
 
-use crate::{AeadCore, AeadInPlace, Buffer, Error, Key, NewAead, Result};
+use crate::{AeadCore, AeadInPlace, Buffer, Error, Key, KeyInit, Result};
 use core::ops::{AddAssign, Sub};
 use generic_array::{
     typenum::{Unsigned, U4, U5},
@@ -76,7 +76,7 @@ where
     /// Create a new STREAM with the given key and nonce.
     fn new(key: &Key<A>, nonce: &Nonce<A, Self>) -> Self
     where
-        A: NewAead,
+        A: KeyInit,
         Self: Sized,
     {
         Self::from_aead(A::new(key), nonce)
@@ -227,7 +227,7 @@ macro_rules! impl_stream_object {
             #[doc = "object from the given AEAD key and nonce."]
             pub fn new(key: &Key<A>, nonce: &Nonce<A, S>) -> Self
             where
-                A: NewAead,
+                A: KeyInit,
                 S: NewStream<A>,
             {
                 Self::from_stream_primitive(S::new(key, nonce))
@@ -238,7 +238,7 @@ macro_rules! impl_stream_object {
             #[doc = "object from the given AEAD primitive."]
             pub fn from_aead(aead: A, nonce: &Nonce<A, S>) -> Self
             where
-                A: NewAead,
+                A: KeyInit,
                 S: NewStream<A>,
             {
                 Self::from_stream_primitive(S::from_aead(aead, nonce))

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2021"
 rust-version = "1.57"
 
 [dependencies]
-aead = { version = "0.4", optional = true, path = "../aead" }
+aead = { version = "=0.5.0-pre", optional = true, path = "../aead" }
 cipher = { version = "0.4", optional = true }
 digest = { version = "0.10", optional = true }
 elliptic-curve = { version = "0.12", optional = true, path = "../elliptic-curve" }


### PR DESCRIPTION
Replaces the `NewAead` trait with the same-shaped `KeyInit` trait.