### PR TITLE
crypto-common: add `getrandom` feature

### DIFF
--- a/crypto-common/Cargo.toml
+++ b/crypto-common/Cargo.toml
@@ -19,6 +19,7 @@ typenum = "1.14"
 
 [features]
 std = []
+getrandom = ["rand_core/getrandom"]
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
Transitively enables `rand_core/getrandom`, making it possible to access `crypto_common::rand_core::OsRng`.