### PR TITLE
Make Cargo.toml comments on optional dependencies consistent

### DIFF
--- a/crypto-common/Cargo.toml
+++ b/crypto-common/Cargo.toml
@@ -13,9 +13,10 @@ categories = ["cryptography", "no-std"]
 
 [dependencies]
 generic-array = { version = "0.14.4", features = ["more_lengths"] }
+typenum = "1.14" # earlier versions of typenum don't satisfy the 'static bound on U* types
+
+# optional dependencies
 rand_core = { version = "0.6", optional = true }
-# earlier versions of typenum don't satisfy the 'static bound on U* types
-typenum = "1.14"
 
 [features]
 std = []

--- a/digest/Cargo.toml
+++ b/digest/Cargo.toml
@@ -14,6 +14,7 @@ categories = ["cryptography", "no-std"]
 [dependencies]
 crypto-common = { version = "0.1.3", path = "../crypto-common" }
 
+# optional dependencies
 block-buffer = { version = "0.10", optional = true }
 subtle = { version = "=2.4", default-features = false, optional = true }
 blobby = { version = "0.3", optional = true }

--- a/password-hash/Cargo.toml
+++ b/password-hash/Cargo.toml
@@ -20,7 +20,7 @@ rust-version = "1.57"
 base64ct = "1"
 subtle = { version = "2", default-features = false }
 
-# optional features
+# optional dependencies
 rand_core = { version = "0.6", optional = true, default-features = false }
 
 [features]


### PR DESCRIPTION
This style is consistent with other crates in this repo (and elsewhere in the project), for example `cipher`.