### PR TITLE
elliptic-curve: bump `crypto-bigint` to v0.4.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -259,9 +259,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-bigint"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac961631d66e80ac7ac2ac01320628ce214ad2b5ef0a88ceb86eae459069e2b4"
+checksum = "9f2b443d17d49dad5ef0ede301c3179cc923b8822f3393b4d2c28c269dd4a122"
 dependencies = [
  "generic-array",
  "rand_core 0.6.3",
@@ -410,7 +410,7 @@ version = "0.12.1"
 dependencies = [
  "base16ct",
  "base64ct",
- "crypto-bigint 0.4.7",
+ "crypto-bigint 0.4.8",
  "der 0.6.0",
  "digest 0.10.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "ff 0.12.0",

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -17,7 +17,7 @@ rust-version = "1.57"
 
 [dependencies]
 base16ct = "0.1.1"
-crypto-bigint = { version = "0.4.7", default-features = false, features = ["rand_core", "generic-array", "zeroize"] }
+crypto-bigint = { version = "0.4.8", default-features = false, features = ["rand_core", "generic-array", "zeroize"] }
 der = { version = "0.6", default-features = false, features = ["oid"] }
 generic-array = { version = "0.14", default-features = false }
 rand_core = { version = "0.6", default-features = false }

--- a/elliptic-curve/src/dev.rs
+++ b/elliptic-curve/src/dev.rs
@@ -186,11 +186,11 @@ impl PrimeFieldBits for Scalar {
     type ReprBits = [u64; 4];
 
     fn to_le_bits(&self) -> ScalarBits {
-        self.0.as_uint().to_uint_array().into()
+        self.0.as_uint().to_words().into()
     }
 
     fn char_le_bits() -> ScalarBits {
-        MockCurve::ORDER.to_uint_array().into()
+        MockCurve::ORDER.to_words().into()
     }
 }
 

--- a/elliptic-curve/src/macros.rs
+++ b/elliptic-curve/src/macros.rs
@@ -153,7 +153,7 @@ macro_rules! impl_field_element {
             ///
             /// Used incorrectly this can lead to invalid results!
             pub(crate) const fn from_uint_unchecked(w: $uint) -> Self {
-                Self(<$uint>::from_uint_array($to_mont(w.as_uint_array())))
+                Self(<$uint>::from_words($to_mont(w.as_words())))
             }
 
             /// Returns the big-endian encoding of this [`
@@ -179,7 +179,7 @@ macro_rules! impl_field_element {
             /// `] in canonical form.
             #[inline]
             pub const fn to_canonical(self) -> $uint {
-                <$uint>::from_uint_array($from_mont(self.0.as_uint_array()))
+                <$uint>::from_words($from_mont(self.0.as_words()))
             }
 
             /// Determine if this [`
@@ -218,9 +218,9 @@ macro_rules! impl_field_element {
 
             /// Add elements.
             pub const fn add(&self, rhs: &Self) -> Self {
-                Self(<$uint>::from_uint_array($add(
-                    self.0.as_uint_array(),
-                    rhs.0.as_uint_array(),
+                Self(<$uint>::from_words($add(
+                    self.0.as_words(),
+                    rhs.0.as_words(),
                 )))
             }
 
@@ -232,29 +232,29 @@ macro_rules! impl_field_element {
 
             /// Subtract elements.
             pub const fn sub(&self, rhs: &Self) -> Self {
-                Self(<$uint>::from_uint_array($sub(
-                    self.0.as_uint_array(),
-                    rhs.0.as_uint_array(),
+                Self(<$uint>::from_words($sub(
+                    self.0.as_words(),
+                    rhs.0.as_words(),
                 )))
             }
 
             /// Multiply elements.
             pub const fn mul(&self, rhs: &Self) -> Self {
-                Self(<$uint>::from_uint_array($mul(
-                    self.0.as_uint_array(),
-                    rhs.0.as_uint_array(),
+                Self(<$uint>::from_words($mul(
+                    self.0.as_words(),
+                    rhs.0.as_words(),
                 )))
             }
 
             /// Negate element.
             pub const fn neg(&self) -> Self {
-                Self(<$uint>::from_uint_array($neg(self.0.as_uint_array())))
+                Self(<$uint>::from_words($neg(self.0.as_words())))
             }
 
             /// Compute modular square.
             #[must_use]
             pub const fn square(&self) -> Self {
-                Self(<$uint>::from_uint_array($square(self.0.as_uint_array())))
+                Self(<$uint>::from_words($square(self.0.as_words())))
             }
         }
 


### PR DESCRIPTION
Fixes deprecation warnings