### PR TITLE
aead: `getrandom` eature

### DIFF
--- a/aead/Cargo.toml
+++ b/aead/Cargo.toml
@@ -15,7 +15,7 @@ keywords = ["crypto", "encryption"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-crypto-common = { version = "0.1", path = "../crypto-common" }
+crypto-common = { version = "0.1.4", path = "../crypto-common" }
 generic-array = { version = "0.14", default-features = false }
 
 # optional dependencies
@@ -28,6 +28,7 @@ default = ["rand_core"]
 alloc = []
 std = ["alloc", "crypto-common/std"]
 dev = ["blobby"]
+getrandom = ["crypto-common/getrandom", "rand_core"]
 rand_core = ["crypto-common/rand_core"]
 stream = []
 

--- a/aead/src/lib.rs
+++ b/aead/src/lib.rs
@@ -43,6 +43,10 @@ pub use generic_array::{self, typenum::consts};
 #[cfg_attr(docsrs, doc(cfg(feature = "bytes")))]
 pub use bytes;
 
+#[cfg(feature = "getrandom")]
+#[cfg_attr(docsrs, doc(cfg(feature = "getrandom")))]
+pub use crypto_common::rand_core::OsRng;
+
 #[cfg(feature = "heapless")]
 #[cfg_attr(docsrs, doc(cfg(feature = "heapless")))]
 pub use heapless;
@@ -414,8 +418,10 @@ impl<Alg: AeadInPlace> AeadMutInPlace for Alg {
     }
 }
 
-/// AEAD payloads are a combination of a message (plaintext or ciphertext)
-/// and "additional associated data" (AAD) to be authenticated (in cleartext)
+/// AEAD payloads (message + AAD).
+///
+/// Combination of a message (plaintext or ciphertext) and
+/// "additional associated data" (AAD) to be authenticated (in cleartext)
 /// along with the message.
 ///
 /// If you don't care about AAD, you can pass a `&[u8]` as the payload to


### PR DESCRIPTION
Adds a `getrandom` feature which activates `crypto-common/getrandom` and makes it simple to access `OsRng` without importing an additional dependency.