### PR TITLE
aead: fix `new_test!` macro

### DIFF
--- a/aead/src/dev.rs
+++ b/aead/src/dev.rs
@@ -11,7 +11,7 @@ macro_rules! new_test {
             use aead::{
                 dev::blobby::Blob6Iterator,
                 generic_array::{typenum::Unsigned, GenericArray},
-                Aead, NewAead, Payload,
+                Aead, KeyInit, Payload,
             };
 
             fn run_test(


### PR DESCRIPTION
It was referencing the now-removed `NewAead` trait