### PR TITLE
elliptic-curve: fix outdated doc

### DIFF
--- a/elliptic-curve/src/secret_key.rs
+++ b/elliptic-curve/src/secret_key.rs
@@ -2,7 +2,8 @@
 //!
 //! The [`SecretKey`] type is a wrapper around a secret scalar value which is
 //! designed to prevent unintentional exposure (e.g. via `Debug` or other
-//! logging).
+//! logging). It also handles zeroing the secret value out of memory securely
+//! on drop.
 
 #[cfg(all(feature = "pkcs8", feature = "sec1"))]
 mod pkcs8;

--- a/elliptic-curve/src/secret_key.rs
+++ b/elliptic-curve/src/secret_key.rs
@@ -3,9 +3,6 @@
 //! The [`SecretKey`] type is a wrapper around a secret scalar value which is
 //! designed to prevent unintentional exposure (e.g. via `Debug` or other
 //! logging).
-//!
-//! When the `zeroize` feature of this crate is enabled, it also handles
-//! zeroing it out of memory securely on drop.
 
 #[cfg(all(feature = "pkcs8", feature = "sec1"))]
 mod pkcs8;


### PR DESCRIPTION
The `zeroize` feature flag has been removed, zeroization on drop is now done by default.