### PR TITLE
crypto-common v0.1.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,7 +17,7 @@ version = "0.5.0-pre.2"
 dependencies = [
  "blobby",
  "bytes",
- "crypto-common 0.1.4",
+ "crypto-common 0.1.5",
  "generic-array",
  "heapless",
 ]
@@ -194,7 +194,7 @@ name = "cipher"
 version = "0.4.3"
 dependencies = [
  "blobby",
- "crypto-common 0.1.4",
+ "crypto-common 0.1.5",
  "inout",
  "zeroize",
 ]
@@ -281,7 +281,7 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "generic-array",
  "rand_core 0.6.3",
@@ -355,7 +355,7 @@ version = "0.10.3"
 dependencies = [
  "blobby",
  "block-buffer 0.10.2",
- "crypto-common 0.1.4",
+ "crypto-common 0.1.5",
  "subtle",
 ]
 

--- a/crypto-common/CHANGELOG.md
+++ b/crypto-common/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.5 (2022-07-09)
+### Fixed
+- Support on-label MSRV ([#1049])
+
+[#1049]: https://github.com/RustCrypto/traits/pull/1049
+
 ## 0.1.4 (2022-07-02)
 ### Added
 - `getrandom` feature ([#1034])

--- a/crypto-common/Cargo.toml
+++ b/crypto-common/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "crypto-common"
 description = "Common cryptographic traits"
-version = "0.1.4"
+version = "0.1.5"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
### Fixed
- Support on-label MSRV ([#1049])

[#1049]: https://github.com/RustCrypto/traits/pull/1049