### PR TITLE
crypto-common: move `ParBlocks*` from `cipher` crate

### DIFF
--- a/cipher/src/lib.rs
+++ b/cipher/src/lib.rs
@@ -51,21 +51,11 @@ pub use crypto_common::{
     generic_array,
     typenum::{self, consts},
     AlgorithmName, Block, InnerIvInit, InvalidLength, Iv, IvSizeUser, Key, KeyInit, KeyIvInit,
-    KeySizeUser,
+    KeySizeUser, ParBlocks, ParBlocksSizeUser,
 };
-use generic_array::{ArrayLength, GenericArray};
 
 /// Trait for loading current IV state.
 pub trait IvState: IvSizeUser {
     /// Returns current IV state.
     fn iv_state(&self) -> Iv<Self>;
 }
-
-/// Types which process blocks in parallel.
-pub trait ParBlocksSizeUser: BlockSizeUser {
-    /// Number of blocks which can be processed in parallel.
-    type ParBlocksSize: ArrayLength<Block<Self>>;
-}
-
-/// Parallel blocks on which [`ParBlocksSizeUser`] implementors operate.
-pub type ParBlocks<T> = GenericArray<Block<T>, <T as ParBlocksSizeUser>::ParBlocksSize>;

--- a/crypto-common/src/lib.rs
+++ b/crypto-common/src/lib.rs
@@ -25,10 +25,16 @@ use rand_core::{CryptoRng, RngCore};
 
 /// Block on which [`BlockSizeUser`] implementors operate.
 pub type Block<B> = GenericArray<u8, <B as BlockSizeUser>::BlockSize>;
+
+/// Parallel blocks on which [`ParBlocksSizeUser`] implementors operate.
+pub type ParBlocks<T> = GenericArray<Block<T>, <T as ParBlocksSizeUser>::ParBlocksSize>;
+
 /// Output array of [`OutputSizeUser`] implementors.
 pub type Output<T> = GenericArray<u8, <T as OutputSizeUser>::OutputSize>;
+
 /// Key used by [`KeySizeUser`] implementors.
 pub type Key<B> = GenericArray<u8, <B as KeySizeUser>::KeySize>;
+
 /// Initialization vector (nonce) used by [`IvSizeUser`] implementors.
 pub type Iv<B> = GenericArray<u8, <B as IvSizeUser>::IvSize>;
 
@@ -49,6 +55,12 @@ impl<T: BlockSizeUser> BlockSizeUser for &T {
 
 impl<T: BlockSizeUser> BlockSizeUser for &mut T {
     type BlockSize = T::BlockSize;
+}
+
+/// Types which can process blocks in parallel.
+pub trait ParBlocksSizeUser: BlockSizeUser {
+    /// Number of blocks which can be processed in parallel.
+    type ParBlocksSize: ArrayLength<Block<Self>>;
 }
 
 /// Types which return data with the given size.


### PR DESCRIPTION
Moves `ParBlocks`/`ParBlocksSizeUser` from the `cipher` crate so it can be reused in the `universal-hash` crate (see #965, #1051).

The `cipher` crate re-exports them in an API-compatible way, so this is not a breaking change.