### PR TITLE
crypto-common v0.1.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,7 +17,7 @@ version = "0.5.0-pre.2"
 dependencies = [
  "blobby",
  "bytes",
- "crypto-common 0.1.5",
+ "crypto-common 0.1.6",
  "generic-array",
  "heapless",
 ]
@@ -194,7 +194,7 @@ name = "cipher"
 version = "0.4.3"
 dependencies = [
  "blobby",
- "crypto-common 0.1.5",
+ "crypto-common 0.1.6",
  "inout",
  "zeroize",
 ]
@@ -281,7 +281,7 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "generic-array",
  "rand_core 0.6.3",
@@ -355,7 +355,7 @@ version = "0.10.3"
 dependencies = [
  "blobby",
  "block-buffer 0.10.2",
- "crypto-common 0.1.5",
+ "crypto-common 0.1.6",
  "subtle",
 ]
 

--- a/cipher/CHANGELOG.md
+++ b/cipher/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.4 [UNRELEASED]
+### Changed
+- Move `ParBlocks`/`ParBlocksSizeUser` to the `crypto-common` crate ([#1052])
+
+[#1052]: https://github.com/RustCrypto/traits/pull/1052
+
 ## 0.4.3 (2022-02-22)
 ### Fixed
 - Do not enable the `alloc` feature by default ([#953])

--- a/cipher/Cargo.toml
+++ b/cipher/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["crypto", "block-cipher", "stream-cipher", "trait"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-crypto-common = { version = "0.1.3", path = "../crypto-common" }
+crypto-common = { version = "0.1.6", path = "../crypto-common" }
 inout = "0.1"
 
 # optional dependencies

--- a/crypto-common/CHANGELOG.md
+++ b/crypto-common/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.6 (2022-07-16)
+### Added
+- Move `ParBlocks`/`ParBlocksSizeUser` from `cipher` crate ([#1052])
+
+[#1052]: https://github.com/RustCrypto/traits/pull/1052
+
 ## 0.1.5 (2022-07-09)
 ### Fixed
 - Support on-label MSRV ([#1049])

--- a/crypto-common/Cargo.toml
+++ b/crypto-common/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "crypto-common"
 description = "Common cryptographic traits"
-version = "0.1.5"
+version = "0.1.6"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
### Added
- Move `ParBlocks`/`ParBlocksSizeUser` from `cipher` crate ([#1052])

[#1052]: https://github.com/RustCrypto/traits/pull/1052