### PR TITLE
universal-hash: add back `finalize_reset`

### DIFF
--- a/universal-hash/src/lib.rs
+++ b/universal-hash/src/lib.rs
@@ -32,7 +32,7 @@ extern crate std;
 pub use crypto_common::{
     self, generic_array,
     typenum::{self, consts},
-    Block, Key, KeyInit, ParBlocks,
+    Block, Key, KeyInit, ParBlocks, Reset,
 };
 
 use core::slice;
@@ -124,6 +124,18 @@ pub trait UniversalHash: BlockSizeUser + Sized {
 
     /// Retrieve result and consume hasher instance.
     fn finalize(self) -> Block<Self>;
+
+    /// Obtain the [`Output`] of a [`UniversalHash`] computation and reset it back
+    /// to its initial state.
+    #[inline]
+    fn finalize_reset(&mut self) -> Block<Self>
+    where
+        Self: Clone + Reset,
+    {
+        let ret = self.clone().finalize();
+        self.reset();
+        ret
+    }
 
     /// Verify the [`UniversalHash`] of the processed input matches
     /// a given `expected` value.


### PR DESCRIPTION
This method was used by the `aes-gcm-siv` crate to handle a case where consuming `self` is problematic and borrowing `&mut self` is much more straightforward. It seems we've had several cases like this pop up with similar methods that were removed in other crates like `block-modes` and `digest`.

The method is provided but bounded on `Clone + Reset`, with the latter sourced from `crypto-common`.