### PR TITLE
aead v0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "aead"
-version = "0.5.0-pre.2"
+version = "0.5.0"
 dependencies = [
  "blobby",
  "bytes",
@@ -235,7 +235,7 @@ dependencies = [
 name = "crypto"
 version = "0.4.0-pre"
 dependencies = [
- "aead 0.5.0-pre.2",
+ "aead 0.5.0",
  "cipher 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "crypto-mac",
  "digest 0.10.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/aead/CHANGELOG.md
+++ b/aead/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.5.0 (2022-07-23)
+### Added
+- Optional support for `BytesMut` as a `Buffer` ([#956])
+- `getrandom` feature ([#1042])
+
+### Changed
+- Replace `NewAead` trait with `KeyInit` trait from `crypto-common` ([#1033])
+- Rust 2021 edition upgrade; MSRV 1.56+ ([#1044])
+
+[#956]: https://github.com/RustCrypto/traits/pull/956
+[#1033]: https://github.com/RustCrypto/traits/pull/1033
+[#1042]: https://github.com/RustCrypto/traits/pull/1042
+[#1044]: https://github.com/RustCrypto/traits/pull/1044
+
 ## 0.4.3 (2021-08-29)
 ### Added
 - `Result` type alias ([#725])

--- a/aead/Cargo.toml
+++ b/aead/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aead"
-version = "0.5.0-pre.2" # Also update html_root_url in lib.rs when bumping this
+version = "0.5.0" # Also update html_root_url in lib.rs when bumping this
 description = """
 Traits for Authenticated Encryption with Associated Data (AEAD) algorithms,
 such as AES-GCM as ChaCha20Poly1305, which provide a high-level API

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2021"
 rust-version = "1.57"
 
 [dependencies]
-aead = { version = "=0.5.0-pre.2", optional = true, path = "../aead" }
+aead = { version = "0.5", optional = true, path = "../aead" }
 cipher = { version = "0.4", optional = true }
 digest = { version = "0.10", optional = true }
 elliptic-curve = { version = "0.12", optional = true, path = "../elliptic-curve" }


### PR DESCRIPTION
### Added
- Optional support for `BytesMut` as a `Buffer` ([#956])
- `getrandom` feature ([#1042])

### Changed
- Replace `NewAead` trait with `KeyInit` trait from `crypto-common` ([#1033])
- Rust 2021 edition upgrade; MSRV 1.56+ ([#1044])

[#956]: https://github.com/RustCrypto/traits/pull/956
[#1033]: https://github.com/RustCrypto/traits/pull/1033
[#1042]: https://github.com/RustCrypto/traits/pull/1042
[#1044]: https://github.com/RustCrypto/traits/pull/1044