### PR TITLE
universal-hash: add `UhfBackend::blocks_needed_to_align`

### DIFF
--- a/universal-hash/src/lib.rs
+++ b/universal-hash/src/lib.rs
@@ -53,6 +53,13 @@ pub trait UhfBackend: ParBlocksSizeUser {
             self.proc_block(block);
         }
     }
+
+    /// Returns the number of blocks that should be passed to `Self::proc_block` before
+    /// `Self::proc_par_blocks` can be used efficiently. This is always less than
+    /// `Self::ParBlocksSize`.
+    fn blocks_needed_to_align(&self) -> usize {
+        0
+    }
 }
 
 /// Trait for [`UhfBackend`] users.


### PR DESCRIPTION
Originally suggested by @str4d here:

https://github.com/RustCrypto/traits/pull/965#discussion_r857126434

The use case is ensuring unbuffered processing of the input AEAD message body when the AAD does not line up with the number of blocks it's processing in parallel.

This number of blocks can be input from the start of the message body to finish completely filling the buffer, ensuring all subsequent processing occurs at the start of the buffer.