### PR TITLE
universal-hash v0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -242,7 +242,7 @@ dependencies = [
  "elliptic-curve 0.12.2",
  "password-hash",
  "signature 1.5.0",
- "universal-hash 0.5.0-pre.2",
+ "universal-hash 0.5.0",
 ]
 
 [[package]]
@@ -1118,7 +1118,7 @@ dependencies = [
 
 [[package]]
 name = "universal-hash"
-version = "0.5.0-pre.2"
+version = "0.5.0"
 dependencies = [
  "crypto-common 0.1.6",
  "subtle",

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -22,7 +22,7 @@ elliptic-curve = { version = "0.12", optional = true, path = "../elliptic-curve"
 mac = { version = "0.11", package = "crypto-mac", optional = true }
 password-hash = { version = "0.4", optional = true, path = "../password-hash" }
 signature = { version = "1.5", optional = true, default-features = false, path = "../signature" }
-universal-hash = { version = "=0.5.0-pre.2", optional = true, path = "../universal-hash" }
+universal-hash = { version = "0.5", optional = true, path = "../universal-hash" }
 
 [features]
 std = [

--- a/universal-hash/CHANGELOG.md
+++ b/universal-hash/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.5.0 (2021-07-30)
+### Added
+- `UhfBackend` trait ([#1051], [#1059])
+- `UhfClosure` trait ([#1051])
+- `UniversalHash::update_with_backend` method ([#1051])
+
+### Changed
+- Replace `NewUniversalHash` trait with `KeyInit` from `crypto-common` ([#1051])
+- Source `Block` and `Key` types from `crypto-common` ([#1051])
+- `UniversalHash::update` is now provided takes a slice of blocks ([#1051])
+- `UniversalHash::finalize` now returns a `Block` ([#1051])
+- Rust 2021 edition; MSRV 1.56 ([#1051])
+
+### Removed
+- `Ouput` replaced by `Block` ([#1051])
+- `UniversalHash::reset` replaced with `Reset` trait from `crypto-common` ([#1051])
+
+[#1051]: https://github.com/RustCrypto/traits/pull/1051
+[#1059]: https://github.com/RustCrypto/traits/pull/1059
+
 ## 0.4.1 (2021-07-20)
 ### Changed
 - Pin `subtle` dependency to v2.4 ([#689])

--- a/universal-hash/Cargo.toml
+++ b/universal-hash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "universal-hash"
-version = "0.5.0-pre.2"
+version = "0.5.0"
 description = "Traits which describe the functionality of universal hash functions (UHFs)"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
### Added
- `UhfBackend` trait ([#1051], [#1059])
- `UhfClosure` trait ([#1051])
- `UniversalHash::update_with_backend` method ([#1051])

### Changed
- Replace `NewUniversalHash` trait with `KeyInit` from `crypto-common` ([#1051])
- Source `Block` and `Key` types from `crypto-common` ([#1051])
- `UniversalHash::update` is now provided takes a slice of blocks ([#1051])
- `UniversalHash::finalize` now returns a `Block` ([#1051])
- Rust 2021 edition; MSRV 1.56 ([#1051])

### Removed
- `Ouput` replaced by `Block` ([#1051])
- `UniversalHash::reset` replaced with `Reset` trait from `crypto-common` ([#1051])

[#1051]: https://github.com/RustCrypto/traits/pull/1051
[#1059]: https://github.com/RustCrypto/traits/pull/1059