### PR TITLE
elliptic-curve: add aliases for SEC1 compressed/uncompressed points

### DIFF
--- a/elliptic-curve/src/sec1.rs
+++ b/elliptic-curve/src/sec1.rs
@@ -5,13 +5,26 @@
 pub use sec1::point::{Coordinates, ModulusSize, Tag};
 
 use crate::{Curve, FieldSize, Result, SecretKey};
+use generic_array::GenericArray;
 use subtle::CtOption;
 
 #[cfg(feature = "arithmetic")]
 use crate::{AffinePoint, Error, ProjectiveArithmetic};
 
+/// Encoded elliptic curve point with point compression.
+pub type CompressedPoint<C> = GenericArray<u8, CompressedPointSize<C>>;
+
+/// Size of a compressed elliptic curve point.
+pub type CompressedPointSize<C> = <FieldSize<C> as ModulusSize>::CompressedPointSize;
+
 /// Encoded elliptic curve point sized appropriately for a given curve.
 pub type EncodedPoint<C> = sec1::point::EncodedPoint<FieldSize<C>>;
+
+/// Encoded elliptic curve point *without* point compression.
+pub type UncompressedPoint<C> = GenericArray<u8, UncompressedPointSize<C>>;
+
+/// Size of an uncompressed elliptic curve point.
+pub type UncompressedPointSize<C> = <FieldSize<C> as ModulusSize>::UncompressedPointSize;
 
 /// Trait for deserializing a value from a SEC1 encoded curve point.
 ///


### PR DESCRIPTION
Adds `GenericArray` type aliases for representing compressed/uncompressed SEC1 points, along with type aliases for calculating their sizes.