### PR TITLE
elliptic-curve v0.12.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -239,7 +239,7 @@ dependencies = [
  "cipher 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "crypto-mac",
  "digest 0.10.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "elliptic-curve 0.12.2",
+ "elliptic-curve 0.12.3",
  "password-hash",
  "signature 1.5.0",
  "universal-hash 0.5.0",
@@ -406,7 +406,7 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.12.2"
+version = "0.12.3"
 dependencies = [
  "base16ct",
  "base64ct",

--- a/elliptic-curve/CHANGELOG.md
+++ b/elliptic-curve/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.12.3 (2022-08-01)
+### Added
+- Aliases for SEC1 compressed/uncompressed points ([#1067])
+
+### Fixed
+- `arithmetic` + `serde` feature combo ([#1066])
+
+[#1066]: https://github.com/RustCrypto/traits/pull/1066
+[#1067]: https://github.com/RustCrypto/traits/pull/1067
+
 ## 0.12.2 (2022-07-01)
 ### Changed
 - Bump `crypto-bigint` to v0.4.8 ([#1039])

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elliptic-curve"
-version = "0.12.2"
+version = "0.12.3"
 description = """
 General purpose Elliptic Curve Cryptography (ECC) support, including types
 and traits for representing various elliptic curve forms, scalars, points,


### PR DESCRIPTION
### Added
- Aliases for SEC1 compressed/uncompressed points ([#1067])

### Fixed
- `arithmetic` + `serde` feature combo ([#1066])

[#1066]: https://github.com/RustCrypto/traits/pull/1066
[#1067]: https://github.com/RustCrypto/traits/pull/1067