### PR TITLE
aead v0.5.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "aead"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "blobby",
  "bytes",
@@ -235,7 +235,7 @@ dependencies = [
 name = "crypto"
 version = "0.4.0-pre"
 dependencies = [
- "aead 0.5.0",
+ "aead 0.5.1",
  "cipher 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "crypto-mac",
  "digest 0.10.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/aead/CHANGELOG.md
+++ b/aead/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.5.1 (2022-08-09)
+### Added
+- `AeadCore::generate_nonce` ([#1073])
+
+[#1073]: https://github.com/RustCrypto/traits/pull/1073
+
 ## 0.5.0 (2022-07-23)
 ### Added
 - Optional support for `BytesMut` as a `Buffer` ([#956])

--- a/aead/Cargo.toml
+++ b/aead/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aead"
-version = "0.5.0" # Also update html_root_url in lib.rs when bumping this
+version = "0.5.1" # Also update html_root_url in lib.rs when bumping this
 description = """
 Traits for Authenticated Encryption with Associated Data (AEAD) algorithms,
 such as AES-GCM as ChaCha20Poly1305, which provide a high-level API


### PR DESCRIPTION
### Added
- `AeadCore::generate_nonce` ([#1073])

[#1073]: https://github.com/RustCrypto/traits/pull/1073