### PR TITLE
crypto: remove `crypto-mac` crate dependency

### DIFF
--- a/.github/workflows/crypto.yml
+++ b/.github/workflows/crypto.yml
@@ -38,7 +38,7 @@ jobs:
           profile: minimal
       - run: cargo build --no-default-features --release --target ${{ matrix.target }}
       - run: cargo build --no-default-features --release --target ${{ matrix.target }}
-               --features aead,cipher,mac,digest,elliptic-curve,signature,universal-hash
+               --features aead,cipher,digest,elliptic-curve,signature,universal-hash
 
   # TODO: use the reusable workflow after this crate will be part of the
   # toot workspace

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -237,7 +237,6 @@ version = "0.4.0-pre"
 dependencies = [
  "aead 0.5.1",
  "cipher 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "crypto-mac",
  "digest 0.10.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "elliptic-curve 0.12.3",
  "password-hash",

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -17,9 +17,8 @@ rust-version = "1.57"
 [dependencies]
 aead = { version = "0.5", optional = true, path = "../aead" }
 cipher = { version = "0.4", optional = true }
-digest = { version = "0.10", optional = true }
+digest = { version = "0.10", optional = true, features = ["mac"] }
 elliptic-curve = { version = "0.12", optional = true, path = "../elliptic-curve" }
-mac = { version = "0.11", package = "crypto-mac", optional = true }
 password-hash = { version = "0.4", optional = true, path = "../password-hash" }
 signature = { version = "1.5", optional = true, default-features = false, path = "../signature" }
 universal-hash = { version = "0.5", optional = true, path = "../universal-hash" }
@@ -30,7 +29,6 @@ std = [
     "cipher/std",
     "digest/std",
     "elliptic-curve/std",
-    "mac/std",
     "password-hash/std",
     "signature/std",
     "universal-hash/std"

--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -36,7 +36,6 @@
 //! | [`cipher`](https://docs.rs/cipher) | `cipher` | Block and stream ciphers (i.e. low-level symmetric encryption) |
 //! | [`digest`](https://docs.rs/digest) | `digest` | Cryptographic hash functions |
 //! | [`elliptic_curve`](https://docs.rs/elliptic-curve) | `elliptic-curve` | Elliptic curve cryptography |
-//! | [`mac`](https://docs.rs/crypto-mac) | `mac` | Message Authentication Codes (i.e. symmetric message authentication) |
 //! | [`password_hash`](https://docs.rs/password-hash) | `password-hash` | Password hashing functions |
 //! | [`signature`](https://docs.rs/signature) | `signature` | Digital signatures (i.e. public key-based message authentication) |
 //! | [`universal_hash`](https://docs.rs/universal-hash) | `universal‑hash` | Universal Hash Functions (used to build MACs) |
@@ -55,9 +54,6 @@ pub use digest;
 
 #[cfg(feature = "elliptic-curve")]
 pub use elliptic_curve;
-
-#[cfg(feature = "mac")]
-pub use mac;
 
 #[cfg(feature = "password-hash")]
 pub use password_hash;


### PR DESCRIPTION
It's been merged into `digest`