### PR TITLE
crypto v0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -233,7 +233,7 @@ dependencies = [
 
 [[package]]
 name = "crypto"
-version = "0.4.0-pre"
+version = "0.4.0"
 dependencies = [
  "aead 0.5.1",
  "cipher 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/crypto/CHANGELOG.md
+++ b/crypto/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.0 (2022-08-09)
+### Added
+- Re-export `crypto-common` as `common` ([#1076])
+
+### Changed
+- Bump `aead` to v0.5 ([#1058])
+- Bump `cipher` to 0.4 ([#951])
+- Bump `digest` dependency to v0.10 ([#850])
+- Bump `elliptic-curve` to v0.12 ([#1009])
+- Bump `password-hash` to v0.4 ([#961])
+- Bump `signature` to v1.5 ([#867])
+- Bump `universal-hash` to v0.5 ([#1061])
+
+### Removed
+- `mac` feature: merged into `digest` ([#1075])
+
+[#850]: https://github.com/RustCrypto/traits/pull/850
+[#867]: https://github.com/RustCrypto/traits/pull/867
+[#951]: https://github.com/RustCrypto/traits/pull/951
+[#961]: https://github.com/RustCrypto/traits/pull/961
+[#1009]: https://github.com/RustCrypto/traits/pull/1009
+[#1058]: https://github.com/RustCrypto/traits/pull/1058
+[#1061]: https://github.com/RustCrypto/traits/pull/1061
+[#1075]: https://github.com/RustCrypto/traits/pull/1075
+[#1076]: https://github.com/RustCrypto/traits/pull/1076
+
 ## 0.3.0 (2021-06-08)
 ### Changed
 - Bump `elliptic-curve` crate dependency to v0.10 ([#663])

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crypto"
-version = "0.4.0-pre" # Also update html_root_url in lib.rs when bumping this
+version = "0.4.0" # Also update html_root_url in lib.rs when bumping this
 description = """
 Resources for building cryptosystems in Rust using the RustCrypto project's ecosystem.
 """


### PR DESCRIPTION
### Added
- Re-export `crypto-common` as `common` ([#1076])

### Changed
- Bump `aead` to v0.5 ([#1058])
- Bump `cipher` to 0.4 ([#951])
- Bump `digest` dependency to v0.10 ([#850])
- Bump `elliptic-curve` to v0.12 ([#1009])
- Bump `password-hash` to v0.4 ([#961])
- Bump `signature` to v1.5 ([#867])
- Bump `universal-hash` to v0.5 ([#1061])

### Removed
- `mac` feature: merged into `digest` ([#1075])

[#850]: https://github.com/RustCrypto/traits/pull/850
[#867]: https://github.com/RustCrypto/traits/pull/867
[#951]: https://github.com/RustCrypto/traits/pull/951
[#961]: https://github.com/RustCrypto/traits/pull/961
[#1009]: https://github.com/RustCrypto/traits/pull/1009
[#1058]: https://github.com/RustCrypto/traits/pull/1058
[#1061]: https://github.com/RustCrypto/traits/pull/1061
[#1075]: https://github.com/RustCrypto/traits/pull/1075
[#1076]: https://github.com/RustCrypto/traits/pull/1076