### PR TITLE
Use the API as intended by the subtle crate authors

### DIFF
--- a/universal-hash/src/lib.rs
+++ b/universal-hash/src/lib.rs
@@ -151,7 +151,7 @@ pub trait UniversalHash: BlockSizeUser + Sized {
     /// from universal hash functions.
     #[inline]
     fn verify(self, expected: &Block<Self>) -> Result<(), Error> {
-        if self.finalize().ct_eq(expected).unwrap_u8() == 1 {
+        if self.finalize().ct_eq(expected).into::<bool>() {
             Ok(())
         } else {
             Err(Error)


### PR DESCRIPTION
This is admittedly a very nit-picky change, but according to the Subtle documentation (https://docs.rs/subtle/latest/subtle/struct.Choice.html#note), a `Choice` should be converted to a `bool` using the `From` implementation. Specifically they added the following note to the `unwrap_u8` documentation:

> This function only exists as an escape hatch for the rare case where it’s not possible to use one of the subtle-provided trait impls.
> **To convert a Choice to a bool, use the From implementation instead.**