### PR TITLE
signature: add `Keypair` trait

### DIFF
--- a/signature/src/keypair.rs
+++ b/signature/src/keypair.rs
@@ -1,0 +1,17 @@
+//! Signing keypairs.
+
+use crate::{Signature, Signer, Verifier};
+
+/// Signing keypair with an associated verifying key.
+///
+/// This represents a type which holds both a signing key and a verifying key.
+pub trait Keypair<S: Signature>: AsRef<Self::VerifyingKey> + Signer<S> {
+    /// Verifying key type for this keypair.
+    type VerifyingKey: Verifier<S>;
+
+    /// Get the verifying key which can verify signatures produced by the
+    /// signing key portion of this keypair.
+    fn verifying_key(&self) -> &Self::VerifyingKey {
+        self.as_ref()
+    }
+}

--- a/signature/src/lib.rs
+++ b/signature/src/lib.rs
@@ -176,8 +176,9 @@ pub use digest;
 pub use rand_core;
 
 mod error;
+mod keypair;
 mod signature;
 mod signer;
 mod verifier;
 
-pub use crate::{error::*, signature::*, signer::*, verifier::*};
+pub use crate::{error::*, keypair::*, signature::*, signer::*, verifier::*};


### PR DESCRIPTION
Adds a trait for types which represent a combination of both a signing key and verifying key as is common in many digital signature systems.

The `Keypair` name follows Rust standard capitalization rules for the closed compound word "keypair" as commonly used in cryptography.