### PR TITLE
signature: Rust 2021 edition upgrade; MSRV 1.56

### DIFF
--- a/.github/workflows/signature.yml
+++ b/.github/workflows/signature.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.41.0 # MSRV
+          - 1.56.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -36,8 +36,6 @@ jobs:
           target: ${{ matrix.target }}
           override: true
           profile: minimal
-      # Isolate this crate from workspace which is otherwise MSRV 1.56 due to 2021 edition crates
-      - run: rm ../Cargo.toml
       - run: cargo build --no-default-features --release --target ${{ matrix.target }}
 
   minimal-versions:
@@ -50,7 +48,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.41.0 # MSRV
+          - 1.56.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v2
@@ -60,8 +58,6 @@ jobs:
           toolchain: ${{ matrix.rust }}
           override: true
           profile: minimal
-      # Isolate this crate from workspace which is otherwise MSRV 1.56 due to 2021 edition crates
-      - run: rm ../Cargo.toml
       - run: cargo check --all-features
       - run: cargo test --no-default-features --release
       - run: cargo test --release

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,7 +52,7 @@ name = "async-signature"
 version = "0.2.0-pre"
 dependencies = [
  "async-trait",
- "signature 1.5.0",
+ "signature 1.6.0-pre",
 ]
 
 [[package]]
@@ -241,7 +241,7 @@ dependencies = [
  "digest 0.10.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "elliptic-curve 0.12.3",
  "password-hash",
- "signature 1.5.0",
+ "signature 1.6.0-pre",
  "universal-hash 0.5.0",
 ]
 
@@ -1006,7 +1006,7 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "1.5.0"
+version = "1.6.0-pre"
 dependencies = [
  "digest 0.10.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex-literal 0.2.2",

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -23,7 +23,7 @@ cipher = { version = "0.4", optional = true }
 digest = { version = "0.10", optional = true, features = ["mac"] }
 elliptic-curve = { version = "0.12", optional = true, path = "../elliptic-curve" }
 password-hash = { version = "0.4", optional = true, path = "../password-hash" }
-signature = { version = "1.5", optional = true, default-features = false, path = "../signature" }
+signature = { version = "=1.6.0-pre", optional = true, default-features = false, path = "../signature" }
 universal-hash = { version = "0.5", optional = true, path = "../universal-hash" }
 
 [features]

--- a/signature/Cargo.toml
+++ b/signature/Cargo.toml
@@ -1,13 +1,14 @@
 [package]
 name          = "signature"
 description   = "Traits for cryptographic signature algorithms (e.g. ECDSA, Ed25519)"
-version       = "1.5.0" # Also update html_root_url in lib.rs when bumping this
+version       = "1.6.0-pre"
 authors       = ["RustCrypto Developers"]
 license       = "Apache-2.0 OR MIT"
 documentation = "https://docs.rs/signature"
 repository    = "https://github.com/RustCrypto/traits/tree/master/signature"
 readme        = "README.md"
-edition       = "2018"
+edition       = "2021"
+rust-version  = "1.56"
 keywords      = ["crypto", "ecdsa", "ed25519", "signature", "signing"]
 categories    = ["cryptography", "no-std"]
 

--- a/signature/README.md
+++ b/signature/README.md
@@ -2,10 +2,10 @@
 
 [![crate][crate-image]][crate-link]
 [![Docs][docs-image]][docs-link]
+[![Build Status][build-image]][build-link]
 ![Apache2/MIT licensed][license-image]
 ![Rust Version][rustc-image]
 [![Project Chat][chat-image]][chat-link]
-[![Build Status][build-image]][build-link]
 
 This crate contains traits which provide generic, object-safe APIs for
 generating and verifying [digital signatures][1].
@@ -13,7 +13,7 @@ generating and verifying [digital signatures][1].
 Used by the [`ecdsa`][2] and [`ed25519`][3] crates, with forthcoming support
 in the [`rsa`][4] crate.
 
-See also the [Signatory][5] project for trait wrappers for using these traits
+See also the [Signatory][5] crate for trait wrappers for using these traits
 with many popular Rust cryptography crates, including `ed25519-dalek`, *ring*,
 `secp256k1-rs`, and `sodiumoxide`.
 
@@ -21,7 +21,7 @@ with many popular Rust cryptography crates, including `ed25519-dalek`, *ring*,
 
 ## Minimum Supported Rust Version
 
-Rust **1.41** or higher.
+Rust **1.56** or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be
 done with a minor version bump.
@@ -52,16 +52,16 @@ dual licensed as above, without any additional terms or conditions.
 
 [//]: # (badges)
 
-[crate-image]: https://img.shields.io/crates/v/signature.svg
+[crate-image]:  https://buildstats.info/crate/signature
 [crate-link]: https://crates.io/crates/signature
 [docs-image]: https://docs.rs/signature/badge.svg
 [docs-link]: https://docs.rs/signature/
+[build-image]: https://github.com/RustCrypto/traits/actions/workflows/signature.yml/badge.svg
+[build-link]: https://github.com/RustCrypto/traits/actions/workflows/signature.yml
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.41+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.56+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260048-signatures
-[build-image]: https://github.com/RustCrypto/traits/workflows/signature/badge.svg?branch=master&event=push
-[build-link]: https://github.com/RustCrypto/traits/actions?query=workflow%3Asignature
 
 [//]: # (general links)
 

--- a/signature/async/Cargo.toml
+++ b/signature/async/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name          = "async-signature"
 description   = "Traits for cryptographic signature algorithms (e.g. ECDSA, Ed25519)"
-version       = "0.2.0-pre" # Also update html_root_url in lib.rs when bumping this
+version       = "0.2.0-pre"
 authors       = ["RustCrypto Developers"]
 license       = "Apache-2.0 OR MIT"
 documentation = "https://docs.rs/async-signature"
@@ -14,7 +14,7 @@ rust-version  = "1.56"
 
 [dependencies]
 async-trait = "0.1.9"
-signature = { version = "1.5", path = ".." }
+signature = { version = "=1.6.0-pre", path = ".." }
 
 [features]
 digest = ["signature/digest-preview"]

--- a/signature/async/src/lib.rs
+++ b/signature/async/src/lib.rs
@@ -1,28 +1,9 @@
-//! RustCrypto: `async-signature` crate.
-//!
-//! This is an experimental crate containing `async` versions of select traits
-//! from the [`signature`] crate, namely [`AsyncSigner`] and when the `digest`
-//! feature is enabled, [`AsyncDigestSigner`].
-//!
-//! Traits are implemented using [`async-trait`], which rewrites the traits to
-//! use `Box`-ed futures.
-//!
-//! The longer-term goal is to move these traits into the [`signature`] crate
-//! itself, however before doing so we'd like to remove the [`async-trait`]
-//! dependency in order to enable use in `no_std` environments. This crate
-//! is a stopgap until that happens.
-//!
-//! For more information, see:
-//! <https://github.com/RustCrypto/traits/issues/304>
-//!
-//! [`async-trait`]: https://docs.rs/async-trait
-
-#![cfg_attr(docsrs, feature(doc_cfg))]
+#![doc = include_str!("../README.md")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
-    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
-    html_root_url = "https://docs.rs/async-signature/0.2.0-pre"
+    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg"
 )]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
 

--- a/signature/derive/Cargo.toml
+++ b/signature/derive/Cargo.toml
@@ -7,7 +7,8 @@ description   = "Custom derive support for the 'signature' crate"
 documentation = "https://docs.rs/signature"
 repository    = "https://github.com/RustCrypto/traits/tree/master/signature/derive"
 readme        = "README.md"
-edition       = "2018"
+edition       = "2021"
+rust-version  = "1.56"
 keywords      = ["crypto", "ecdsa", "ed25519", "signature", "signing"]
 categories    = ["cryptography", "no-std"]
 

--- a/signature/derive/src/lib.rs
+++ b/signature/derive/src/lib.rs
@@ -1,9 +1,5 @@
-//! Custom derive support for the `signature` crate.
-//!
-//! This crate can be used to derive `Signer` and `Verifier` impls for
-//! types that impl `DigestSigner` or `DigestVerifier` respectively.
-
 #![crate_type = "proc-macro"]
+#![doc = include_str!("../README.md")]
 #![deny(warnings, unused_import_braces, unused_qualifications)]
 #![forbid(unsafe_code)]
 

--- a/signature/src/lib.rs
+++ b/signature/src/lib.rs
@@ -1,25 +1,13 @@
-//! RustCrypto: `signature` crate.
-//!
-//! Traits which provide generic, object-safe APIs for generating and verifying
-//! digital signatures, i.e. message authentication using public-key cryptography.
-//!
-//! ## Minimum Supported Rust Version
-//!
-//! Rust **1.41** or higher.
-//!
-//! Minimum supported Rust version may be changed in the future, but such
-//! changes will be accompanied with a minor version bump.
-//!
-//! ## SemVer policy
-//!
-//! - MSRV is considered exempt from SemVer as noted above
-//! - All on-by-default features of this library are covered by SemVer
-//! - Off-by-default features ending in `*-preview` (e.g. `derive-preview`,
-//!   `digest-preview`) are unstable "preview" features which are also
-//!   considered exempt from SemVer (typically because they rely on pre-1.0
-//!   crates as dependencies). However, breaking changes to these features
-//!   will, like MSRV, also be accompanied by a minor version bump.
-//!
+#![no_std]
+#![doc = include_str!("../README.md")]
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
+    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg"
+)]
+#![cfg_attr(docsrs, feature(doc_cfg))]
+#![forbid(unsafe_code)]
+#![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
+
 //! # Design
 //!
 //! This crate provides a common set of traits for signing and verifying
@@ -154,16 +142,6 @@
 //! [`digest`]: https://docs.rs/digest/
 //! [`Digest`]: https://docs.rs/digest/latest/digest/trait.Digest.html
 //! [Fiat-Shamir heuristic]: https://en.wikipedia.org/wiki/Fiat%E2%80%93Shamir_heuristic
-
-#![no_std]
-#![cfg_attr(docsrs, feature(doc_cfg))]
-#![doc(
-    html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
-    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
-    html_root_url = "https://docs.rs/signature/1.5.0"
-)]
-#![forbid(unsafe_code)]
-#![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
 
 #[cfg(feature = "std")]
 extern crate std;


### PR DESCRIPTION
Since we have PRs that demand an MSRV bump (#1080), bumps the crate's edition to the latest, which requires MSRV 1.56.