### PR TITLE
signature_derive v1.0.0-pre.5

### DIFF
--- a/signature/derive/CHANGELOG.md
+++ b/signature/derive/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.0.0-pre.5 (2022-08-14)
+### Changed
+- Rust 2021 edition upgrade; MSRV 1.56 ([#1081])
+
+[#1081]: https://github.com/RustCrypto/traits/pull/1081
+
 ## 1.0.0-pre.4 (2022-01-04)
 ### Changed
 - Support for new `digest` v0.10 API ([#850])


### PR DESCRIPTION
### Changed
- Rust 2021 edition upgrade; MSRV 1.56 ([#1081])

[#1081]: https://github.com/RustCrypto/traits/pull/1081