### PR TITLE
signature v1.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,7 +52,7 @@ name = "async-signature"
 version = "0.2.0-pre"
 dependencies = [
  "async-trait",
- "signature 1.6.0-pre",
+ "signature 1.6.0",
 ]
 
 [[package]]
@@ -241,7 +241,7 @@ dependencies = [
  "digest 0.10.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "elliptic-curve 0.12.3",
  "password-hash",
- "signature 1.6.0-pre",
+ "signature 1.6.0",
  "universal-hash 0.5.0",
 ]
 
@@ -981,7 +981,7 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "1.6.0-pre"
+version = "1.6.0"
 dependencies = [
  "digest 0.10.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex-literal",

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -23,7 +23,7 @@ cipher = { version = "0.4", optional = true }
 digest = { version = "0.10", optional = true, features = ["mac"] }
 elliptic-curve = { version = "0.12", optional = true, path = "../elliptic-curve" }
 password-hash = { version = "0.4", optional = true, path = "../password-hash" }
-signature = { version = "=1.6.0-pre", optional = true, default-features = false, path = "../signature" }
+signature = { version = "1.5", optional = true, default-features = false, path = "../signature" }
 universal-hash = { version = "0.5", optional = true, path = "../universal-hash" }
 
 [features]

--- a/signature/CHANGELOG.md
+++ b/signature/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.6.0 (2022-08-14)
+### Added
+- `Keypair` trait ([#1080])
+
+### Changed
+- Rust 2021 edition upgrade; MSRV 1.56 ([#1081])
+- Bump `signature_derive` dependency to v1.0.0-pre.5 ([#1082])
+- Bump `hex-literal` dependency to v0.3 ([#1083])
+
+[#1080]: https://github.com/RustCrypto/traits/pull/1080
+[#1081]: https://github.com/RustCrypto/traits/pull/1081
+[#1082]: https://github.com/RustCrypto/traits/pull/1082
+[#1083]: https://github.com/RustCrypto/traits/pull/1083
+
 ## 1.5.0 (2022-01-04)
 ### Changed
 - Bump `digest` dependency to v0.10 ([#850])

--- a/signature/Cargo.toml
+++ b/signature/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name          = "signature"
 description   = "Traits for cryptographic signature algorithms (e.g. ECDSA, Ed25519)"
-version       = "1.6.0-pre"
+version       = "1.6.0"
 authors       = ["RustCrypto Developers"]
 license       = "Apache-2.0 OR MIT"
 documentation = "https://docs.rs/signature"

--- a/signature/async/Cargo.toml
+++ b/signature/async/Cargo.toml
@@ -14,7 +14,7 @@ rust-version  = "1.56"
 
 [dependencies]
 async-trait = "0.1.9"
-signature = { version = "=1.6.0-pre", path = ".." }
+signature = { version = "1.6", path = ".." }
 
 [features]
 digest = ["signature/digest-preview"]


### PR DESCRIPTION
### Added
- `Keypair` trait ([#1080])

### Changed
- Rust 2021 edition upgrade; MSRV 1.56 ([#1081])
- Bump `signature_derive` dependency to v1.0.0-pre.5 ([#1082])
- Bump `hex-literal` dependency to v0.3 ([#1083])

[#1080]: https://github.com/RustCrypto/traits/pull/1080
[#1081]: https://github.com/RustCrypto/traits/pull/1081
[#1082]: https://github.com/RustCrypto/traits/pull/1082
[#1083]: https://github.com/RustCrypto/traits/pull/1083