### PR TITLE
async-signature v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,7 +49,7 @@ dependencies = [
 
 [[package]]
 name = "async-signature"
-version = "0.2.0-pre"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "signature 1.6.0",

--- a/signature/async/CHANGELOG.md
+++ b/signature/async/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.0 (2022-08-14)
+### Added
+- `AsyncKeypair` trait ([#1085])
+
+### Changed
+- Bump minimum `signature` requirement to v1.6 ([#1084])
+
+[#1084]: https://github.com/RustCrypto/traits/pull/1084
+[#1085]: https://github.com/RustCrypto/traits/pull/1085
+
 ## 0.1.0 (2022-01-04)
 ### Changed
 - Bump `signature` crate dependency to v1.5 ([#850], [#867])

--- a/signature/async/Cargo.toml
+++ b/signature/async/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name          = "async-signature"
 description   = "Traits for cryptographic signature algorithms (e.g. ECDSA, Ed25519)"
-version       = "0.2.0-pre"
+version       = "0.2.0"
 authors       = ["RustCrypto Developers"]
 license       = "Apache-2.0 OR MIT"
 documentation = "https://docs.rs/async-signature"


### PR DESCRIPTION
### Added
- `AsyncKeypair` trait ([#1085])

### Changed
- Bump minimum `signature` requirement to v1.6 ([#1084])

[#1084]: https://github.com/RustCrypto/traits/pull/1084
[#1085]: https://github.com/RustCrypto/traits/pull/1085