### PR TITLE
signature_derive v1.0.0-pre.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1179,7 +1179,7 @@ dependencies = [
 
 [[package]]
 name = "signature_derive"
-version = "1.0.0-pre.5"
+version = "1.0.0-pre.6"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/signature/Cargo.toml
+++ b/signature/Cargo.toml
@@ -15,7 +15,7 @@ categories    = ["cryptography", "no-std"]
 [dependencies]
 digest = { version = "0.10.3", optional = true, default-features = false }
 rand_core = { version = "0.6", optional = true, default-features = false }
-signature_derive = { version = "=1.0.0-pre.5", optional = true, path = "derive" }
+signature_derive = { version = "=1.0.0-pre.6", optional = true, path = "derive" }
 
 [dev-dependencies]
 hex-literal = "0.3"

--- a/signature/derive/CHANGELOG.md
+++ b/signature/derive/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.0.0-pre.6 (2022-09-12)
+### Added
+- `DigestSigner`/`DigestVerifier` support ([#1103])
+
+### Removed
+- `synstructure` dependency ([#1100])
+
+[#1100]: https://github.com/RustCrypto/traits/pull/1100
+[#1103]: https://github.com/RustCrypto/traits/pull/1103
+
 ## 1.0.0-pre.5 (2022-08-14)
 ### Changed
 - Rust 2021 edition upgrade; MSRV 1.56 ([#1081])

--- a/signature/derive/Cargo.toml
+++ b/signature/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "signature_derive"
-version       = "1.0.0-pre.5"
+version       = "1.0.0-pre.6"
 authors       = ["RustCrypto Developers"]
 license       = "Apache-2.0 OR MIT"
 description   = "Custom derive support for the 'signature' crate"


### PR DESCRIPTION
### Added
- `DigestSigner`/`DigestVerifier` support ([#1103])

### Removed
- `synstructure` dependency ([#1100])

[#1100]: https://github.com/RustCrypto/traits/pull/1100
[#1103]: https://github.com/RustCrypto/traits/pull/1103