### PR TITLE
signature v1.6.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,7 +62,7 @@ name = "async-signature"
 version = "0.2.0"
 dependencies = [
  "async-trait",
- "signature 1.6.0",
+ "signature 1.6.1",
 ]
 
 [[package]]
@@ -311,7 +311,7 @@ dependencies = [
  "digest 0.10.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "elliptic-curve 0.12.3",
  "password-hash",
- "signature 1.6.0",
+ "signature 1.6.1",
  "universal-hash 0.5.0",
 ]
 
@@ -1168,7 +1168,7 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "digest 0.10.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex-literal",

--- a/signature/CHANGELOG.md
+++ b/signature/CHANGELOG.md
@@ -4,7 +4,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 1.6.0 (2022-08-14)
+## 1.6.1 (2022-09-12)
+### Added
+- `hazmat-preview` feature with `PrehashSigner`/`PrehashVerifier` traits ([#1099])
+
+### Changed
+- Bump `signature_derive` to v1.0.0-pre.6 ([#1104])
+
+[#1099]: https://github.com/RustCrypto/traits/pull/1099
+[#1104]: https://github.com/RustCrypto/traits/pull/1104
+
+## 1.6.0 (2022-08-14) [YANKED]
 ### Added
 - `Keypair` trait ([#1080])
 

--- a/signature/Cargo.toml
+++ b/signature/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name          = "signature"
 description   = "Traits for cryptographic signature algorithms (e.g. ECDSA, Ed25519)"
-version       = "1.6.0"
+version       = "1.6.1"
 authors       = ["RustCrypto Developers"]
 license       = "Apache-2.0 OR MIT"
 documentation = "https://docs.rs/signature"


### PR DESCRIPTION
### Added
- `hazmat-preview` feature with `PrehashSigner`/`PrehashVerifier` traits ([#1099])

### Changed
- Bump `signature_derive` to v1.0.0-pre.6 ([#1104])

[#1099]: https://github.com/RustCrypto/traits/pull/1099
[#1104]: https://github.com/RustCrypto/traits/pull/1104