### PR TITLE
signature: relax `Keypair` type bounds

### DIFF
--- a/signature/async/src/lib.rs
+++ b/signature/async/src/lib.rs
@@ -13,7 +13,6 @@ pub use signature::{self, Error, Signature};
 pub use signature::digest::{self, Digest};
 
 use async_trait::async_trait;
-use signature::Verifier;
 
 /// Asynchronously sign the provided message bytestring using `Self`
 /// (e.g. client for a Cloud KMS or HSM), returning a digital signature.
@@ -77,12 +76,12 @@ where
 /// Keypair with async signer component and an associated verifying key.
 ///
 /// This represents a type which holds both an async signing key and a verifying key.
-pub trait AsyncKeypair<S>: AsRef<Self::VerifyingKey> + AsyncSigner<S>
+pub trait AsyncKeypair<S>: AsRef<Self::VerifyingKey>
 where
     S: Signature + Send + 'static,
 {
     /// Verifying key type for this keypair.
-    type VerifyingKey: Verifier<S>;
+    type VerifyingKey;
 
     /// Get the verifying key which can verify signatures produced by the
     /// signing key portion of this keypair.

--- a/signature/src/keypair.rs
+++ b/signature/src/keypair.rs
@@ -1,13 +1,13 @@
 //! Signing keypairs.
 
-use crate::{Signature, Signer, Verifier};
+use crate::Signature;
 
 /// Signing keypair with an associated verifying key.
 ///
 /// This represents a type which holds both a signing key and a verifying key.
-pub trait Keypair<S: Signature>: AsRef<Self::VerifyingKey> + Signer<S> {
+pub trait Keypair<S: Signature>: AsRef<Self::VerifyingKey> {
     /// Verifying key type for this keypair.
-    type VerifyingKey: Verifier<S>;
+    type VerifyingKey;
 
     /// Get the verifying key which can verify signatures produced by the
     /// signing key portion of this keypair.


### PR DESCRIPTION
The Keypair trait might be useful for representing relationship between
DigestSigner and DigestVerifier, RandomizedSigner and
RandomizedVerifier, etc. in addition to just Signer/Verfifier pair.

Relax type boundaries for the Keypair and AsyncKeypair traits.

Fixes #1106
