### PR TITLE
digest: update examples in readme

### DIFF
--- a/digest/README.md
+++ b/digest/README.md
@@ -35,22 +35,22 @@ First add `blake2` crate to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-blake2 = "0.8"
+sha2 = "0.10"
 ```
 
-`blake2` and other crates re-export `digest` crate and `Digest` trait for
+`sha2` and other crates re-export `digest` crate and `Digest` trait for
 convenience, so you don't have to add `digest` crate as an explicit dependency.
 
 Now you can write the following code:
 
 ```rust
-use blake2::{Blake2b, Digest};
+use sha2::{Sha256, Digest};
 
-let mut hasher = Blake2b::new();
+let mut hasher = Sha256::new();
 let data = b"Hello world!";
-hasher.input(data);
+hasher.update(data);
 // `input` can be called repeatedly and is generic over `AsRef<[u8]>`
-hasher.input("String data");
+hasher.update("String data");
 // Note that calling `finalize()` consumes hasher
 let hash = hasher.finalize();
 println!("Result: {:x}", hash);
@@ -63,9 +63,9 @@ Alternatively you can use chained approach, which is equivalent to the previous
 example:
 
 ```rust
-let hash = Blake2b::new()
-    .chain(b"Hello world!")
-    .chain("String data")
+let hash = Sha256::new()
+    .chain_update(b"Hello world!")
+    .chain_update("String data")
     .finalize();
 
 println!("Result: {:x}", hash);
@@ -74,7 +74,7 @@ println!("Result: {:x}", hash);
 If the whole message is available you also can use convinience `digest` method:
 
 ```rust
-let hash = Blake2b::digest(b"my message");
+let hash = Sha256::digest(b"my message");
 println!("Result: {:x}", hash);
 ```
 
@@ -84,11 +84,11 @@ If you want to hash data from [`Read`][3] trait (e.g. from file) you can rely on
 implementation of [`Write`][4] trait (requires enabled-by-default `std` feature):
 
 ```rust
-use blake2::{Blake2b, Digest};
+use sha2::{Sha256, Digest};
 use std::{fs, io};
 
 let mut file = fs::File::open(&path)?;
-let mut hasher = Blake2b::new();
+let mut hasher = Sha256::new();
 let n = io::copy(&mut file, &mut hasher)?;
 let hash = hasher.finalize();
 
@@ -109,17 +109,17 @@ use digest::Digest;
 // Instead use crates from: https://github.com/RustCrypto/password-hashing
 fn hash_password<D: Digest>(password: &str, salt: &str, output: &mut [u8]) {
     let mut hasher = D::new();
-    hasher.input(password.as_bytes());
-    hasher.input(b"$");
-    hasher.input(salt.as_bytes());
+    hasher.update(password.as_bytes());
+    hasher.update(b"$");
+    hasher.update(salt.as_bytes());
     output.copy_from_slice(hasher.finalize().as_slice())
 }
 
-use blake2::Blake2b;
-use sha2::Sha256;
+let mut buf1 = [0u8; 32];
+let mut buf2 = [0u8; 64];
 
-hash_password::<Blake2b>("my_password", "abcd", &mut buf);
-hash_password::<Sha256>("my_password", "abcd", &mut buf);
+hash_password::<sha2::Sha256>("my_password", "abcd", &mut buf1);
+hash_password::<sha2::Sha512>("my_password", "abcd", &mut buf2);
 ```
 
 If you want to use hash functions with trait objects, use `digest::DynDigest`


### PR DESCRIPTION
Closes #1072 

Since the `blake2` crate is currently not in the best state, the updated examples use `sha2` instead of it.