### PR TITLE
signature v1.6.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,7 +62,7 @@ name = "async-signature"
 version = "0.2.0"
 dependencies = [
  "async-trait",
- "signature 1.6.1",
+ "signature 1.6.2",
 ]
 
 [[package]]
@@ -311,7 +311,7 @@ dependencies = [
  "digest 0.10.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "elliptic-curve 0.12.3",
  "password-hash",
- "signature 1.6.1",
+ "signature 1.6.2",
  "universal-hash 0.5.0",
 ]
 
@@ -1168,7 +1168,7 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "1.6.1"
+version = "1.6.2"
 dependencies = [
  "digest 0.10.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex-literal",

--- a/signature/CHANGELOG.md
+++ b/signature/CHANGELOG.md
@@ -4,7 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 1.6.1 (2022-09-12)
+## 1.6.2 (2022-09-15)
+### Changed
+- Relax `Keypair` type bounds ([#1107])
+
+[#1107]: https://github.com/RustCrypto/traits/pull/1107
+
+## 1.6.1 (2022-09-12) [YANKED]
 ### Added
 - `hazmat-preview` feature with `PrehashSigner`/`PrehashVerifier` traits ([#1099])
 

--- a/signature/Cargo.toml
+++ b/signature/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name          = "signature"
 description   = "Traits for cryptographic signature algorithms (e.g. ECDSA, Ed25519)"
-version       = "1.6.1"
+version       = "1.6.2"
 authors       = ["RustCrypto Developers"]
 license       = "Apache-2.0 OR MIT"
 documentation = "https://docs.rs/signature"


### PR DESCRIPTION
### Changed
- Relax `Keypair` type bounds ([#1107])

[#1107]: https://github.com/RustCrypto/traits/pull/1107