### PR TITLE
async-keypair v0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,7 +59,7 @@ dependencies = [
 
 [[package]]
 name = "async-signature"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "async-trait",
  "signature 1.6.2",

--- a/signature/async/CHANGELOG.md
+++ b/signature/async/CHANGELOG.md
@@ -4,7 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.2.0 (2022-08-14)
+## 0.2.1 (2022-09-15)
+### Changed
+- Relax `AsyncKeypair` bounds ([#1107])
+- Deprecate `AsyncKeypair` ([#1112])
+
+[#1107]: https://github.com/RustCrypto/traits/pull/1107
+[#1112]: https://github.com/RustCrypto/traits/pull/1112
+
+## 0.2.0 (2022-08-14) [YANKED]
 ### Added
 - `AsyncKeypair` trait ([#1085])
 

--- a/signature/async/Cargo.toml
+++ b/signature/async/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name          = "async-signature"
 description   = "Traits for cryptographic signature algorithms (e.g. ECDSA, Ed25519)"
-version       = "0.2.0"
+version       = "0.2.1"
 authors       = ["RustCrypto Developers"]
 license       = "Apache-2.0 OR MIT"
 documentation = "https://docs.rs/async-signature"


### PR DESCRIPTION
### Changed
- Relax `AsyncKeypair` bounds ([#1107])
- Deprecate `AsyncKeypair` ([#1112])

[#1107]: https://github.com/RustCrypto/traits/pull/1107
[#1112]: https://github.com/RustCrypto/traits/pull/1112