### PR TITLE
signature_derive: fix `Digest*` trait derivation

### DIFF
--- a/.github/workflows/signature.yml
+++ b/.github/workflows/signature.yml
@@ -66,3 +66,21 @@ jobs:
       - run: cargo test --no-default-features --release
       - run: cargo test --release
       - run: cargo test --all-features --release
+
+  derive:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - 1.56.0 # MSRV
+          - stable
+    steps:
+      - uses: actions/checkout@v2
+      - uses: RustCrypto/actions/cargo-cache@master
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
+          override: true
+          profile: minimal
+      - run: cargo test --release
+        working-directory: signature/derive

--- a/signature/derive/src/lib.rs
+++ b/signature/derive/src/lib.rs
@@ -260,6 +260,7 @@ mod tests {
             quote! {
                 impl<D, S, C: EllipticCurve> ::signature::DigestSigner<D, S> for MySigner<C>
                 where
+                    D: ::signature::digest::Digest,
                     S: ::signature::Signature,
                     Self: ::signature::hazmat::PrehashSigner<S>
                 {
@@ -288,11 +289,12 @@ mod tests {
             quote! {
                 impl<D, S, C: EllipticCurve> ::signature::DigestVerifier<D, S> for MyVerifier<C>
                 where
+                    D: ::signature::digest::Digest,
                     S: ::signature::Signature,
                     Self: ::signature::hazmat::PrehashVerifier<S>
                 {
-                    fn verify_digest(&self, digest: D) -> ::signature::Result<S> {
-                        self.verify_prehash(&digest.finalize())
+                    fn verify_digest(&self, digest: D, signature: &S) -> ::signature::Result<()> {
+                        self.verify_prehash(&digest.finalize(), signature)
                     }
                 }
             }


### PR DESCRIPTION
The derived code in the test fixtures is incorrect.

Likewise, it seems there wasn't a proper CI job for this crate. This commit also includes fixes which ensure `signature_derive`'s tests are run in CI.