### PR TITLE
signature_derive: fix support for `where` bounds

### DIFF
--- a/signature/derive/src/lib.rs
+++ b/signature/derive/src/lib.rs
@@ -10,9 +10,12 @@
 )]
 
 use proc_macro::TokenStream;
-use proc_macro2::TokenStream as TokenStream2;
+use proc_macro2::{Span, TokenStream as TokenStream2};
 use quote::quote;
-use syn::{parse_macro_input, DeriveInput, Ident, TypeParam};
+use syn::{
+    parse_macro_input, parse_quote, punctuated::Punctuated, DeriveInput, Ident, PredicateType,
+    Token, TraitBound, Type, TypeParam, TypeParamBound, WhereClause, WherePredicate,
+};
 
 /// Derive the [`Signer`] trait for a type which impls [`DigestSigner`].
 ///
@@ -37,19 +40,26 @@ pub fn derive_signer(input: TokenStream) -> TokenStream {
 }
 
 fn emit_signer_impl(input: DeriveInput) -> TokenStream2 {
-    let params = DeriveParams::new(input);
-    let ident = &params.ident;
-    let type_params = &params.type_params;
-    let type_idents = params.type_idents();
+    let s_ident = Ident::new("__S", Span::call_site());
+
+    let mut params = DeriveParams::new(input);
+    params.add_bound(&s_ident, parse_quote!(::signature::PrehashSignature));
+    params.add_bound(
+        &Ident::new("Self", Span::call_site()),
+        parse_quote!(::signature::DigestSigner<#s_ident::Digest, #s_ident>),
+    );
+
+    let name = params.name;
+    let impl_generics = params.impl_generics;
+    let ty_generics = params.ty_generics;
+    let where_clause = params.where_clause;
 
     quote! {
-        impl<S, #(#type_params),*> ::signature::Signer<S> for #ident<#(#type_idents),*>
-        where
-            S: ::signature::PrehashSignature,
-            Self: ::signature::DigestSigner<S::Digest, S>
+        impl<#(#impl_generics),*> ::signature::Signer<#s_ident> for #name<#(#ty_generics),*>
+        #where_clause
         {
-            fn try_sign(&self, msg: &[u8]) -> ::signature::Result<S> {
-                self.try_sign_digest(S::Digest::new_with_prefix(msg))
+            fn try_sign(&self, msg: &[u8]) -> ::signature::Result<#s_ident> {
+                self.try_sign_digest(#s_ident::Digest::new_with_prefix(msg))
             }
         }
     }
@@ -78,19 +88,26 @@ pub fn derive_verifier(input: TokenStream) -> TokenStream {
 }
 
 fn emit_verifier_impl(input: DeriveInput) -> TokenStream2 {
-    let params = DeriveParams::new(input);
-    let ident = &params.ident;
-    let type_params = &params.type_params;
-    let type_idents = params.type_idents();
+    let s_ident = Ident::new("__S", Span::call_site());
+
+    let mut params = DeriveParams::new(input);
+    params.add_bound(&s_ident, parse_quote!(::signature::PrehashSignature));
+    params.add_bound(
+        &Ident::new("Self", Span::call_site()),
+        parse_quote!(::signature::DigestVerifier<#s_ident::Digest, #s_ident>),
+    );
+
+    let name = params.name;
+    let impl_generics = params.impl_generics;
+    let ty_generics = params.ty_generics;
+    let where_clause = params.where_clause;
 
     quote! {
-        impl<S, #(#type_params),*> ::signature::Verifier<S> for #ident<#(#type_idents),*>
-        where
-            S: ::signature::PrehashSignature,
-            Self: ::signature::DigestVerifier<S::Digest, S>
+        impl<#(#impl_generics),*> ::signature::Verifier<#s_ident> for #name<#(#ty_generics),*>
+        #where_clause
         {
-            fn verify(&self, msg: &[u8], signature: &S) -> ::signature::Result<()> {
-                self.verify_digest(S::Digest::new_with_prefix(msg), signature)
+            fn verify(&self, msg: &[u8], signature: &#s_ident) -> ::signature::Result<()> {
+                self.verify_digest(#s_ident::Digest::new_with_prefix(msg), signature)
             }
         }
     }
@@ -107,19 +124,27 @@ pub fn derive_digest_signer(input: TokenStream) -> TokenStream {
 }
 
 fn emit_digest_signer_impl(input: DeriveInput) -> TokenStream2 {
-    let params = DeriveParams::new(input);
-    let ident = &params.ident;
-    let type_params = &params.type_params;
-    let type_idents = params.type_idents();
+    let d_ident = Ident::new("__D", Span::call_site());
+    let s_ident = Ident::new("__S", Span::call_site());
+
+    let mut params = DeriveParams::new(input);
+    params.add_bound(&d_ident, parse_quote!(::signature::digest::Digest));
+    params.add_bound(&s_ident, parse_quote!(::signature::Signature));
+    params.add_bound(
+        &Ident::new("Self", Span::call_site()),
+        parse_quote!(::signature::hazmat::PrehashSigner<#s_ident>),
+    );
+
+    let name = params.name;
+    let impl_generics = params.impl_generics;
+    let ty_generics = params.ty_generics;
+    let where_clause = params.where_clause;
 
     quote! {
-        impl<D, S, #(#type_params),*> ::signature::DigestSigner<D, S> for #ident<#(#type_idents),*>
-        where
-            D: ::signature::digest::Digest,
-            S: ::signature::Signature,
-            Self: ::signature::hazmat::PrehashSigner<S>
+        impl<#(#impl_generics),*> ::signature::DigestSigner<#d_ident, #s_ident> for #name<#(#ty_generics),*>
+        #where_clause
         {
-            fn try_sign_digest(&self, digest: D) -> ::signature::Result<S> {
+            fn try_sign_digest(&self, digest: #d_ident) -> ::signature::Result<#s_ident> {
                 self.sign_prehash(&digest.finalize())
             }
         }
@@ -137,19 +162,27 @@ pub fn derive_digest_verifier(input: TokenStream) -> TokenStream {
 }
 
 fn emit_digest_verifier_impl(input: DeriveInput) -> TokenStream2 {
-    let params = DeriveParams::new(input);
-    let ident = &params.ident;
-    let type_params = &params.type_params;
-    let type_idents = params.type_idents();
+    let d_ident = Ident::new("__D", Span::call_site());
+    let s_ident = Ident::new("__S", Span::call_site());
+
+    let mut params = DeriveParams::new(input);
+    params.add_bound(&d_ident, parse_quote!(::signature::digest::Digest));
+    params.add_bound(&s_ident, parse_quote!(::signature::Signature));
+    params.add_bound(
+        &Ident::new("Self", Span::call_site()),
+        parse_quote!(::signature::hazmat::PrehashVerifier<#s_ident>),
+    );
+
+    let name = params.name;
+    let impl_generics = params.impl_generics;
+    let ty_generics = params.ty_generics;
+    let where_clause = params.where_clause;
 
     quote! {
-        impl<D, S, #(#type_params),*> ::signature::DigestVerifier<D, S> for #ident<#(#type_idents),*>
-        where
-            D: ::signature::digest::Digest,
-            S: ::signature::Signature,
-            Self: ::signature::hazmat::PrehashVerifier<S>
+        impl<#(#impl_generics),*> ::signature::DigestVerifier<#d_ident, #s_ident> for #name<#(#ty_generics),*>
+        #where_clause
         {
-            fn verify_digest(&self, digest: D, signature: &S) -> ::signature::Result<()> {
+            fn verify_digest(&self, digest: #d_ident, signature: &#s_ident) -> ::signature::Result<()> {
                 self.verify_prehash(&digest.finalize(), signature)
             }
         }
@@ -158,28 +191,75 @@ fn emit_digest_verifier_impl(input: DeriveInput) -> TokenStream2 {
 
 /// Derivation parameters parsed from `DeriveInput`.
 struct DeriveParams {
-    /// `Ident` for the struct the trait impls are being added to.
-    ident: Ident,
+    /// Name of the struct the trait impls are being added to.
+    name: Ident,
 
-    /// Generic type parameters.
-    type_params: Vec<TypeParam>,
+    /// Generic parameters of `impl`.
+    impl_generics: Vec<TypeParam>,
+
+    /// Generic parameters of the type.
+    ty_generics: Vec<Ident>,
+
+    /// Where clause in-progress.
+    where_clause: WhereClause,
 }
 
 impl DeriveParams {
     /// Parse parameters from `DeriveInput`.
     fn new(input: DeriveInput) -> Self {
+        let impl_generics = input.generics.type_params().cloned().collect();
+
+        let ty_generics = input
+            .generics
+            .type_params()
+            .map(|bound| bound.ident.clone())
+            .collect();
+
+        let where_clause = input
+            .generics
+            .where_clause
+            .clone()
+            .unwrap_or_else(|| WhereClause {
+                where_token: <Token![where]>::default(),
+                predicates: Punctuated::new(),
+            });
+
         Self {
-            ident: input.ident,
-            type_params: input.generics.type_params().cloned().collect(),
+            name: input.ident,
+            impl_generics,
+            ty_generics,
+            where_clause,
         }
     }
 
-    /// Get the `Ident`s which correspond to each of the `type_params`.
-    fn type_idents(&self) -> Vec<Ident> {
-        self.type_params
-            .iter()
-            .map(|bound| bound.ident.clone())
-            .collect()
+    /// Add a generic parameter with the given bound.
+    fn add_bound(&mut self, name: &Ident, bound: TraitBound) {
+        if name != "Self" {
+            self.impl_generics.push(TypeParam {
+                attrs: vec![],
+                ident: name.clone(),
+                colon_token: None,
+                bounds: Default::default(),
+                eq_token: None,
+                default: None,
+            });
+        }
+
+        let type_path = parse_quote!(#name);
+
+        let mut bounds = Punctuated::new();
+        bounds.push(TypeParamBound::Trait(bound));
+
+        let predicate_type = PredicateType {
+            lifetimes: None,
+            bounded_ty: Type::Path(type_path),
+            colon_token: <Token![:]>::default(),
+            bounds,
+        };
+
+        self.where_clause
+            .predicates
+            .push(WherePredicate::Type(predicate_type))
     }
 }
 
@@ -192,7 +272,10 @@ mod tests {
     fn signer() {
         let input = parse_quote! {
             #[derive(Signer)]
-            struct MySigner<C: EllipticCurve> {
+            struct MySigner<C>
+            where
+                C: EllipticCurve
+            {
                 scalar: Scalar<C::ScalarSize>
             }
         };
@@ -202,13 +285,14 @@ mod tests {
         assert_eq!(
             output.to_string(),
             quote! {
-                impl<S, C: EllipticCurve> ::signature::Signer<S> for MySigner<C>
+                impl<C, __S> ::signature::Signer<__S> for MySigner<C>
                 where
-                    S: ::signature::PrehashSignature,
-                    Self: ::signature::DigestSigner<S::Digest, S>
+                    C: EllipticCurve,
+                    __S: ::signature::PrehashSignature,
+                    Self: ::signature::DigestSigner<__S::Digest, __S>
                 {
-                    fn try_sign(&self, msg: &[u8]) -> ::signature::Result<S> {
-                        self.try_sign_digest(S::Digest::new_with_prefix(msg))
+                    fn try_sign(&self, msg: &[u8]) -> ::signature::Result<__S> {
+                        self.try_sign_digest(__S::Digest::new_with_prefix(msg))
                     }
                 }
             }
@@ -230,13 +314,13 @@ mod tests {
         assert_eq!(
             output.to_string(),
             quote! {
-                impl<S, C: EllipticCurve> ::signature::Verifier<S> for MyVerifier<C>
+                impl<C: EllipticCurve, __S> ::signature::Verifier<__S> for MyVerifier<C>
                 where
-                    S: ::signature::PrehashSignature,
-                    Self: ::signature::DigestVerifier<S::Digest, S>
+                    __S: ::signature::PrehashSignature,
+                    Self: ::signature::DigestVerifier<__S::Digest, __S>
                 {
-                    fn verify(&self, msg: &[u8], signature: &S) -> ::signature::Result<()> {
-                        self.verify_digest(S::Digest::new_with_prefix(msg), signature)
+                    fn verify(&self, msg: &[u8], signature: &__S) -> ::signature::Result<()> {
+                        self.verify_digest(__S::Digest::new_with_prefix(msg), signature)
                     }
                 }
             }
@@ -258,13 +342,13 @@ mod tests {
         assert_eq!(
             output.to_string(),
             quote! {
-                impl<D, S, C: EllipticCurve> ::signature::DigestSigner<D, S> for MySigner<C>
+                impl<C: EllipticCurve, __D, __S> ::signature::DigestSigner<__D, __S> for MySigner<C>
                 where
-                    D: ::signature::digest::Digest,
-                    S: ::signature::Signature,
-                    Self: ::signature::hazmat::PrehashSigner<S>
+                    __D: ::signature::digest::Digest,
+                    __S: ::signature::Signature,
+                    Self: ::signature::hazmat::PrehashSigner<__S>
                 {
-                    fn try_sign_digest(&self, digest: D) -> ::signature::Result<S> {
+                    fn try_sign_digest(&self, digest: __D) -> ::signature::Result<__S> {
                         self.sign_prehash(&digest.finalize())
                     }
                 }
@@ -287,13 +371,13 @@ mod tests {
         assert_eq!(
             output.to_string(),
             quote! {
-                impl<D, S, C: EllipticCurve> ::signature::DigestVerifier<D, S> for MyVerifier<C>
+                impl<C: EllipticCurve, __D, __S> ::signature::DigestVerifier<__D, __S> for MyVerifier<C>
                 where
-                    D: ::signature::digest::Digest,
-                    S: ::signature::Signature,
-                    Self: ::signature::hazmat::PrehashVerifier<S>
+                    __D: ::signature::digest::Digest,
+                    __S: ::signature::Signature,
+                    Self: ::signature::hazmat::PrehashVerifier<__S>
                 {
-                    fn verify_digest(&self, digest: D, signature: &S) -> ::signature::Result<()> {
+                    fn verify_digest(&self, digest: __D, signature: &__S) -> ::signature::Result<()> {
                         self.verify_prehash(&digest.finalize(), signature)
                     }
                 }


### PR DESCRIPTION
Retains the original where bounds provided in a type declaration.

Additionally this adds `__` to the names of the type parameters used by the `impl` to avoid clashes with ones that might be specified for a given type.