### PR TITLE
signature_derive v1.0.0-pre.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1169,7 +1169,7 @@ dependencies = [
 
 [[package]]
 name = "signature_derive"
-version = "1.0.0-pre.6"
+version = "1.0.0-pre.7"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/signature/Cargo.toml
+++ b/signature/Cargo.toml
@@ -15,7 +15,7 @@ categories    = ["cryptography", "no-std"]
 [dependencies]
 digest = { version = "0.10.3", optional = true, default-features = false }
 rand_core = { version = "0.6", optional = true, default-features = false }
-signature_derive = { version = "=1.0.0-pre.6", optional = true, path = "derive" }
+signature_derive = { version = "=1.0.0-pre.7", optional = true, path = "derive" }
 
 [dev-dependencies]
 hex-literal = "0.3"

--- a/signature/derive/CHANGELOG.md
+++ b/signature/derive/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.0.0-pre.7 (2022-09-16)
+### Fixed
+- Support for `where` bounds ([#1118])
+
+[#1118]: https://github.com/RustCrypto/traits/pull/1118
+
 ## 1.0.0-pre.6 (2022-09-12)
 ### Added
 - `DigestSigner`/`DigestVerifier` support ([#1103])

--- a/signature/derive/Cargo.toml
+++ b/signature/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "signature_derive"
-version       = "1.0.0-pre.6"
+version       = "1.0.0-pre.7"
 authors       = ["RustCrypto Developers"]
 license       = "Apache-2.0 OR MIT"
 description   = "Custom derive support for the 'signature' crate"


### PR DESCRIPTION
### Fixed
- Support for `where` bounds ([#1118])

[#1118]: https://github.com/RustCrypto/traits/pull/1118