### PR TITLE
signature v1.6.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,7 +62,7 @@ name = "async-signature"
 version = "0.2.1"
 dependencies = [
  "async-trait",
- "signature 1.6.2",
+ "signature 1.6.3",
 ]
 
 [[package]]
@@ -311,7 +311,7 @@ dependencies = [
  "digest 0.10.4",
  "elliptic-curve 0.12.3",
  "password-hash",
- "signature 1.6.2",
+ "signature 1.6.3",
  "universal-hash 0.5.0",
 ]
 
@@ -1158,7 +1158,7 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "1.6.2"
+version = "1.6.3"
 dependencies = [
  "digest 0.10.4",
  "hex-literal",

--- a/signature/CHANGELOG.md
+++ b/signature/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.6.2 (2022-09-16)
+### Changed
+- Bump `signature_derive` to v1.0.0-pre.7 ([#1119])
+
+[#1119]: https://github.com/RustCrypto/traits/pull/1119
+
 ## 1.6.2 (2022-09-15)
 ### Changed
 - Relax `Keypair` type bounds ([#1107])

--- a/signature/Cargo.toml
+++ b/signature/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name          = "signature"
 description   = "Traits for cryptographic signature algorithms (e.g. ECDSA, Ed25519)"
-version       = "1.6.2"
+version       = "1.6.3"
 authors       = ["RustCrypto Developers"]
 license       = "Apache-2.0 OR MIT"
 documentation = "https://docs.rs/signature"


### PR DESCRIPTION
### Changed
- Bump `signature_derive` to v1.0.0-pre.7 ([#1119])

[#1119]: https://github.com/RustCrypto/traits/pull/1119