### PR TITLE
signature: expand hazmat to cover sign-with-rng case

### DIFF
--- a/signature/src/hazmat.rs
+++ b/signature/src/hazmat.rs
@@ -12,6 +12,9 @@
 
 use crate::{Error, Signature};
 
+#[cfg(feature = "rand-preview")]
+use crate::rand_core::{CryptoRng, RngCore};
+
 /// Sign the provided message prehash, returning a digital signature.
 pub trait PrehashSigner<S: Signature> {
     /// Attempt to sign the given message digest, returning a digital signature
@@ -27,6 +30,29 @@ pub trait PrehashSigner<S: Signature> {
     /// Allowed lengths are algorithm-dependent and up to a particular
     /// implementation to decide.
     fn sign_prehash(&self, prehash: &[u8]) -> Result<S, Error>;
+}
+
+/// Sign the provided message prehash using the provided external randomness source, returning a digital signature.
+#[cfg(feature = "rand-preview")]
+#[cfg_attr(docsrs, doc(cfg(feature = "rand-preview")))]
+pub trait RandomizedPrehashSigner<S: Signature> {
+    /// Attempt to sign the given message digest, returning a digital signature
+    /// on success, or an error if something went wrong.
+    ///
+    /// The `prehash` parameter should be the output of a secure cryptographic
+    /// hash function.
+    ///
+    /// This API takes a `prehash` byte slice as there can potentially be many
+    /// compatible lengths for the message digest for a given concrete signature
+    /// algorithm.
+    ///
+    /// Allowed lengths are algorithm-dependent and up to a particular
+    /// implementation to decide.
+    fn sign_prehash_with_rng(
+        &self,
+        rng: impl CryptoRng + RngCore,
+        prehash: &[u8],
+    ) -> Result<S, Error>;
 }
 
 /// Verify the provided message prehash using `Self` (e.g. a public key)


### PR DESCRIPTION
Expand hazmat with the RandomizedPrehashSigner trait, declaring fn sign_prehash_with_rng(). This is necessary for hazmat implementation for the RSA PSS keys.

Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@linaro.org>