### PR TITLE
Forward `std` feature to `sec1`

### DIFF
--- a/elliptic-curve/CHANGELOG.md
+++ b/elliptic-curve/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+- Forward `std` feature to `sec1` dependency ([#1131])
+
+[#1131]: https://github.com/RustCrypto/traits/pull/1131
+
 ## 0.12.3 (2022-08-01)
 ### Added
 - Aliases for SEC1 compressed/uncompressed points ([#1067])

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -54,7 +54,7 @@ hazmat = []
 jwk = ["alloc", "base64ct/alloc", "serde", "serde_json", "zeroize/alloc"]
 pem = ["alloc", "arithmetic", "der/pem", "pem-rfc7468/alloc", "pkcs8", "sec1/pem"]
 serde = ["alloc", "pkcs8", "sec1/serde", "serdect"]
-std = ["alloc", "rand_core/std"]
+std = ["alloc", "rand_core/std", "sec1/std"]
 voprf = ["digest"]
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
Without this, `sec1::Error` does not implement `std::error::Error`.