### PR TITLE
KEM: Updated HPKE deps for testing

### DIFF
--- a/.github/workflows/kem.yml
+++ b/.github/workflows/kem.yml
@@ -59,7 +59,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.56.0 # MSRV
+          - 1.57.0 # Next MSRV candidate
           - stable
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/kem.yml
+++ b/.github/workflows/kem.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.56.0 # MSRV
+          - 1.57.0 # Next MSRV candidate
           - stable
         target:
           - thumbv7em-none-eabi

--- a/kem/Cargo.toml
+++ b/kem/Cargo.toml
@@ -18,21 +18,12 @@ generic-array = "0.14"
 zeroize = { version = "1.5", default-features = false }
 
 [dev-dependencies]
-rand = { version = "0.8", features = [ "getrandom" ] }
-x3dh-ke = "0.1"
+hpke = "0.10"
 p256 = { version = "0.9", features = [ "ecdsa" ] }
 pqcrypto = { version = "0.15", default-features = false, features = [ "pqcrypto-saber" ] }
 pqcrypto-traits = "0.3"
-
-# We use an hpke commit that pulls in x25519-dalek v2.0.0-pre.1. This is necessary because all the
-# modern crates (including this one) use zeroize >1.3, which is incompatible with the previous
-# x25519-dalek version. Once the next x25519-dalek version is cut, the next hpke version will be
-# cut, and this commit-based dependency can go away.
-[dev-dependencies.hpke]
-git = "https://github.com/rozbb/rust-hpke"
-rev = "18eda000f27a871f360c283b30407a95169d7d58"
-default-features = false
-features = [ "x25519" ]
+rand = { version = "0.8", features = [ "getrandom" ] }
+x3dh-ke = "0.1"
 
 [features]
 default = []


### PR DESCRIPTION
Finally release an HPKE v0.10, and fixed broken. This removes the hacky dep that we previously used for KEM testing. Also I alphabetized the deps.