### PR TITLE
signature: remove `Default` bound on `SignatureEncoding::Repr`

### DIFF
--- a/signature/src/encoding.rs
+++ b/signature/src/encoding.rs
@@ -10,7 +10,7 @@ pub trait SignatureEncoding:
     Clone + Sized + for<'a> TryFrom<&'a [u8], Error = Error> + Into<Self::Repr>
 {
     /// Byte representation of a signature.
-    type Repr: 'static + AsRef<[u8]> + AsMut<[u8]> + Clone + Default + Send + Sync;
+    type Repr: 'static + AsRef<[u8]> + AsMut<[u8]> + Clone + Send + Sync;
 
     /// Decode signature from its byte representation.
     fn from_bytes(bytes: &Self::Repr) -> Result<Self> {


### PR DESCRIPTION
Unfortunately the `Default` impl on `core` array types is still problematic here:

```
error[E0277]: the trait bound `[u8; 64]: Default` is not satisfied
   --> ed25519/src/lib.rs:339:17
    |
339 |     type Repr = SignatureBytes;
    |                 ^^^^^^^^^^^^^^ the trait `Default` is not implemented for `[u8; 64]`
```