### PR TITLE
signature: remove `AsMut` bound on `Repr`

### DIFF
--- a/signature/src/encoding.rs
+++ b/signature/src/encoding.rs
@@ -10,7 +10,7 @@ pub trait SignatureEncoding:
     Clone + Sized + for<'a> TryFrom<&'a [u8], Error = Error> + Into<Self::Repr>
 {
     /// Byte representation of a signature.
-    type Repr: 'static + AsRef<[u8]> + AsMut<[u8]> + Clone + Send + Sync;
+    type Repr: 'static + AsRef<[u8]> + Clone + Send + Sync;
 
     /// Decode signature from its byte representation.
     fn from_bytes(bytes: &Self::Repr) -> Result<Self> {


### PR DESCRIPTION
Without a `Default` bound (#1143) there's little purpose to having an `AsMut` bound on `Repr`, which would allow `Default` to construct an empty bytestring and `AsMut` used to write into it.

Given there isn't an obvious use case, fewer bounds are better.