### PR TITLE
signature: use `&mut impl CryptoRngCore` RNG arguments

### DIFF
--- a/signature/Cargo.toml
+++ b/signature/Cargo.toml
@@ -14,7 +14,7 @@ categories    = ["cryptography", "no-std"]
 
 [dependencies]
 digest = { version = "0.10.3", optional = true, default-features = false }
-rand_core = { version = "0.6", optional = true, default-features = false }
+rand_core = { version = "0.6.4", optional = true, default-features = false }
 derive = { package = "signature_derive", version = "=2.0.0-pre.0", optional = true, path = "derive" }
 
 [dev-dependencies]


### PR DESCRIPTION
`rand_core` v0.6.4 added an auto-impl'd `CryptoRngCore` marker trait for types which impl `CryptoRng + RngCore` which is slightly more convenient and less verbose.

This commit changes to using `&mut impl CryptoRngCore` as proposed in #1087. This hopefully strikes a balance between least surprise and minimal required syntax, namely &mut references are reusable and don't
require knowledge of the blanket impl of `RngCore` for `&mut R: RngCore`