### PR TITLE
signature: update remaining use of `CryptoRng + RngCore`

### DIFF
--- a/signature/src/hazmat.rs
+++ b/signature/src/hazmat.rs
@@ -13,7 +13,7 @@
 use crate::Error;
 
 #[cfg(feature = "rand-preview")]
-use crate::rand_core::{CryptoRng, RngCore};
+use crate::rand_core::CryptoRngCore;
 
 /// Sign the provided message prehash, returning a digital signature.
 pub trait PrehashSigner<S> {
@@ -50,7 +50,7 @@ pub trait RandomizedPrehashSigner<S> {
     /// implementation to decide.
     fn sign_prehash_with_rng(
         &self,
-        rng: impl CryptoRng + RngCore,
+        rng: &mut impl CryptoRngCore,
         prehash: &[u8],
     ) -> Result<S, Error>;
 }


### PR DESCRIPTION
In #1147, other usages of a CSRNG were changed to use `&mut impl CryptoRngCore`. However, `RandomizedPrehashSigner` was not updated accordingly.

This commit updates it as well.