### PR TITLE
Bump `elliptic-curve` to v0.13.0-pre

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -414,6 +414,26 @@ dependencies = [
 [[package]]
 name = "elliptic-curve"
 version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3"
+dependencies = [
+ "base16ct",
+ "crypto-bigint 0.4.9",
+ "der 0.6.1",
+ "digest 0.10.6",
+ "ff 0.12.1",
+ "generic-array",
+ "group 0.12.1",
+ "hkdf 0.12.3",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.0-pre"
 dependencies = [
  "base16ct",
  "base64ct",
@@ -433,26 +453,6 @@ dependencies = [
  "serdect",
  "sha2 0.10.6",
  "sha3",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "elliptic-curve"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3"
-dependencies = [
- "base16ct",
- "crypto-bigint 0.4.9",
- "der 0.6.1",
- "digest 0.10.6",
- "ff 0.12.1",
- "generic-array",
- "group 0.12.1",
- "hkdf 0.12.3",
- "rand_core 0.6.4",
- "sec1",
  "subtle",
  "zeroize",
 ]
@@ -719,7 +719,7 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51f44edd08f51e2ade572f141051021c5af22677e42b7dd28a88155151c33594"
 dependencies = [
- "elliptic-curve 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "elliptic-curve 0.12.3",
 ]
 
 [[package]]

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -21,7 +21,7 @@ crypto-common = { version = "0.1", default-features = false, path = "../crypto-c
 aead = { version = "0.5", optional = true, path = "../aead" }
 cipher = { version = "0.4", optional = true }
 digest = { version = "0.10", optional = true, features = ["mac"] }
-elliptic-curve = { version = "0.12", optional = true, path = "../elliptic-curve" }
+elliptic-curve = { version = "0.12", optional = true } # TODO(tarcieri): path = "../elliptic-curve"
 password-hash = { version = "0.4", optional = true, path = "../password-hash" }
 signature = { version = "=2.0.0-pre.2", optional = true, default-features = false, path = "../signature" }
 universal-hash = { version = "0.5", optional = true, path = "../universal-hash" }

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elliptic-curve"
-version = "0.12.3"
+version = "0.13.0-pre"
 description = """
 General purpose Elliptic Curve Cryptography (ECC) support, including types
 and traits for representing various elliptic curve forms, scalars, points,


### PR DESCRIPTION
Breaking changes were introduced in #1024, so this bumps the crate version to v0.13.0-pre to note that happened.

Note that there is no crate release associated with this version. When a crate release occurs, it will be bumped to `-pre.0`.