### PR TITLE
signature: fallible encoding support

### DIFF
--- a/signature/src/encoding.rs
+++ b/signature/src/encoding.rs
@@ -7,14 +7,17 @@ use alloc::vec::Vec;
 
 /// Support for decoding/encoding signatures as bytes.
 pub trait SignatureEncoding:
-    Clone + Sized + for<'a> TryFrom<&'a [u8], Error = Error> + Into<Self::Repr>
+    Clone + Sized + for<'a> TryFrom<&'a [u8], Error = Error> + TryInto<Self::Repr>
 {
     /// Byte representation of a signature.
     type Repr: 'static + AsRef<[u8]> + Clone + Send + Sync;
 
     /// Encode signature as its byte representation.
     fn to_bytes(&self) -> Self::Repr {
-        self.clone().into()
+        self.clone()
+            .try_into()
+            .ok()
+            .expect("signature encoding error")
     }
 
     /// Encode signature as a byte vector.


### PR DESCRIPTION
This is helpful for "no panic" profiles.

The `Error` type is deliberately left opaque, which means that `From`/`Into` still work via blanket `TryFrom`/`TryInto` impls with `Error = Infallible`.

The `SignatureEncoding::to_bytes` method still provides infallible serialization.