### PR TITLE
Update VOPRF identifier type

### DIFF
--- a/elliptic-curve/src/voprf.rs
+++ b/elliptic-curve/src/voprf.rs
@@ -7,14 +7,14 @@ use crate::PrimeCurve;
 /// Elliptic curve parameters used by VOPRF.
 pub trait VoprfParameters: PrimeCurve {
     /// The `ID` parameter which identifies a particular elliptic curve
-    /// as defined in [section 4 of `draft-irtf-cfrg-voprf-08`][voprf].
+    /// as defined in [section 4 of `draft-irtf-cfrg-voprf-19`][voprf].
     ///
-    /// [voprf]: https://www.ietf.org/archive/id/draft-irtf-cfrg-voprf-08.html#section-4
-    const ID: u16;
+    /// [voprf]: https://www.ietf.org/archive/id/draft-irtf-cfrg-voprf-19.html#name-ciphersuites-2
+    const ID: &'static str;
 
     /// The `Hash` parameter which assigns a particular hash function to this
-    /// ciphersuite as defined in [section 4 of `draft-irtf-cfrg-voprf-08`][voprf].
+    /// ciphersuite as defined in [section 4 of `draft-irtf-cfrg-voprf-19`][voprf].
     ///
-    /// [voprf]: https://www.ietf.org/archive/id/draft-irtf-cfrg-voprf-08.html#section-4
+    /// [voprf]: https://www.ietf.org/archive/id/draft-irtf-cfrg-voprf-19.html#name-ciphersuites-2
     type Hash: digest::Digest;
 }


### PR DESCRIPTION
See https://github.com/cfrg/draft-irtf-cfrg-voprf/pull/371.
We should probably at least wait until this is merged upstream.

Cc @kevinlewi.