### PR TITLE
Implement `NonIdentity`

### DIFF
--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -80,6 +80,10 @@ pub mod ecdh;
 #[cfg_attr(docsrs, doc(cfg(feature = "hash2curve")))]
 pub mod hash2curve;
 
+#[cfg(feature = "arithmetic")]
+#[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
+pub mod non_identity;
+
 #[cfg(feature = "sec1")]
 #[cfg_attr(docsrs, doc(cfg(feature = "sec1")))]
 pub mod sec1;
@@ -121,6 +125,7 @@ pub use {
         arithmetic::{
             AffineArithmetic, PrimeCurveArithmetic, ProjectiveArithmetic, ScalarArithmetic,
         },
+        non_identity::NonIdentity,
         public_key::PublicKey,
         scalar::{nonzero::NonZeroScalar, Scalar},
     },

--- a/elliptic-curve/src/non_identity.rs
+++ b/elliptic-curve/src/non_identity.rs
@@ -1,0 +1,205 @@
+//! Non-identity point type.
+
+use core::ops::Deref;
+
+use group::{prime::PrimeCurveAffine, Curve, GroupEncoding};
+use rand_core::{CryptoRng, RngCore};
+use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
+
+#[cfg(feature = "serde")]
+use serdect::serde::{de, ser, Deserialize, Serialize};
+
+/// Non-identity point type.
+///
+/// This type ensures that its value is not the identity point, ala `core::num::NonZero*`.
+///
+/// In the context of ECC, it's useful for ensuring that certain arithmetic
+/// cannot result in the identity point.
+#[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
+#[derive(Clone, Copy)]
+pub struct NonIdentity<P> {
+    point: P,
+}
+
+impl<P> NonIdentity<P>
+where
+    P: ConditionallySelectable + ConstantTimeEq + Default + GroupEncoding,
+{
+    /// Create a [`NonIdentity`] from a point.
+    pub fn new(point: P) -> CtOption<Self> {
+        CtOption::new(Self { point }, !point.ct_eq(&P::default()))
+    }
+
+    /// Decode a [`NonIdentity`] from its encoding.
+    pub fn from_repr(repr: &P::Repr) -> CtOption<Self> {
+        Self::from_bytes(repr)
+    }
+}
+
+impl<P: Copy> NonIdentity<P> {
+    /// Return wrapped point.
+    pub fn to_point(&self) -> P {
+        self.point
+    }
+}
+
+impl<P> NonIdentity<P>
+where
+    P: ConditionallySelectable + ConstantTimeEq + Curve + Default + GroupEncoding,
+{
+    /// Generate a random `NonIdentity<ProjectivePoint>`.
+    pub fn random(mut rng: impl CryptoRng + RngCore) -> Self {
+        loop {
+            if let Some(point) = Self::new(P::random(&mut rng)).into() {
+                break point;
+            }
+        }
+    }
+
+    /// Converts this element into its affine representation.
+    pub fn to_affine(&self) -> NonIdentity<P::AffineRepr> {
+        NonIdentity {
+            point: self.point.to_affine(),
+        }
+    }
+}
+
+impl<P> NonIdentity<P>
+where
+    P: PrimeCurveAffine,
+{
+    /// Converts this element to its curve representation.
+    pub fn to_curve(&self) -> NonIdentity<P::Curve> {
+        NonIdentity {
+            point: self.point.to_curve(),
+        }
+    }
+}
+
+impl<P> AsRef<P> for NonIdentity<P> {
+    fn as_ref(&self) -> &P {
+        &self.point
+    }
+}
+
+impl<P> ConditionallySelectable for NonIdentity<P>
+where
+    P: ConditionallySelectable,
+{
+    fn conditional_select(a: &Self, b: &Self, choice: Choice) -> Self {
+        Self {
+            point: P::conditional_select(&a.point, &b.point, choice),
+        }
+    }
+}
+
+impl<P> ConstantTimeEq for NonIdentity<P>
+where
+    P: ConstantTimeEq,
+{
+    fn ct_eq(&self, other: &Self) -> Choice {
+        self.point.ct_eq(&other.point)
+    }
+}
+
+impl<P> Deref for NonIdentity<P> {
+    type Target = P;
+
+    fn deref(&self) -> &Self::Target {
+        &self.point
+    }
+}
+
+impl<P> GroupEncoding for NonIdentity<P>
+where
+    P: ConditionallySelectable + ConstantTimeEq + Default + GroupEncoding,
+{
+    type Repr = P::Repr;
+
+    fn from_bytes(bytes: &Self::Repr) -> CtOption<Self> {
+        let point = P::from_bytes(bytes);
+        point.and_then(|point| CtOption::new(Self { point }, !point.ct_eq(&P::default())))
+    }
+
+    fn from_bytes_unchecked(bytes: &Self::Repr) -> CtOption<Self> {
+        P::from_bytes_unchecked(bytes).map(|point| Self { point })
+    }
+
+    fn to_bytes(&self) -> Self::Repr {
+        self.point.to_bytes()
+    }
+}
+
+#[cfg(feature = "serde")]
+#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
+impl<P> Serialize for NonIdentity<P>
+where
+    P: Serialize,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: ser::Serializer,
+    {
+        self.point.serialize(serializer)
+    }
+}
+
+#[cfg(feature = "serde")]
+#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
+impl<'de, P> Deserialize<'de> for NonIdentity<P>
+where
+    P: ConditionallySelectable + ConstantTimeEq + Default + Deserialize<'de> + GroupEncoding,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        Option::from(Self::new(P::deserialize(deserializer)?))
+            .ok_or_else(|| de::Error::custom("expected non-identity point"))
+    }
+}
+
+#[cfg(all(test, feature = "dev"))]
+mod tests {
+    use crate::{
+        dev::{AffinePoint, ProjectivePoint},
+        NonIdentity,
+    };
+    use group::GroupEncoding;
+    use hex_literal::hex;
+
+    #[test]
+    fn new_success() {
+        let point = ProjectivePoint::from_bytes(
+            &hex!("02c9afa9d845ba75166b5c215767b1d6934e50c3db36e89b127b8a622b120f6721").into(),
+        )
+        .unwrap();
+
+        assert!(bool::from(NonIdentity::new(point).is_some()));
+
+        assert!(bool::from(
+            NonIdentity::new(AffinePoint::from(point)).is_some()
+        ));
+    }
+
+    #[test]
+    fn new_fail() {
+        assert!(bool::from(
+            NonIdentity::new(ProjectivePoint::default()).is_none()
+        ));
+        assert!(bool::from(
+            NonIdentity::new(AffinePoint::default()).is_none()
+        ));
+    }
+
+    #[test]
+    fn round_trip() {
+        let bytes = hex!("02c9afa9d845ba75166b5c215767b1d6934e50c3db36e89b127b8a622b120f6721");
+        let point = NonIdentity::<ProjectivePoint>::from_repr(&bytes.into()).unwrap();
+        assert_eq!(&bytes, point.to_bytes().as_slice());
+
+        let bytes = hex!("02c9afa9d845ba75166b5c215767b1d6934e50c3db36e89b127b8a622b120f6721");
+        let point = NonIdentity::<AffinePoint>::from_repr(&bytes.into()).unwrap();
+        assert_eq!(&bytes, point.to_bytes().as_slice());
+    }
+}

--- a/elliptic-curve/src/public_key.rs
+++ b/elliptic-curve/src/public_key.rs
@@ -1,7 +1,8 @@
 //! Elliptic curve public keys.
 
 use crate::{
-    AffinePoint, Curve, Error, NonZeroScalar, ProjectiveArithmetic, ProjectivePoint, Result,
+    AffinePoint, Curve, Error, NonIdentity, NonZeroScalar, ProjectiveArithmetic, ProjectivePoint,
+    Result,
 };
 use core::fmt::Debug;
 use group::{Curve as _, Group};
@@ -268,6 +269,28 @@ where
 {
     fn from(public_key: &PublicKey<C>) -> EncodedPoint<C> {
         public_key.to_encoded_point(C::COMPRESS_POINTS)
+    }
+}
+
+impl<C, P> From<NonIdentity<P>> for PublicKey<C>
+where
+    C: Curve + ProjectiveArithmetic,
+    P: Copy + Into<AffinePoint<C>>,
+{
+    fn from(value: NonIdentity<P>) -> Self {
+        PublicKey::from(&value)
+    }
+}
+
+impl<C, P> From<&NonIdentity<P>> for PublicKey<C>
+where
+    C: Curve + ProjectiveArithmetic,
+    P: Copy + Into<AffinePoint<C>>,
+{
+    fn from(value: &NonIdentity<P>) -> Self {
+        Self {
+            point: value.to_point().into(),
+        }
     }
 }
 


### PR DESCRIPTION
It would be nice to implement math that is generic over both projective and affine points with a common prime marker trait, see https://github.com/zkcrypto/group/issues/43.
I believe in the meantime we could use `Into<ProjectivePoint<C>> where C: PrimeCurve`.

In the future I would like to implement the following math (which I believe are correct):
- Multiplication between `NonIdentity` points.
- Multiplication with `NonZeroScalar`.
- Introduce `fn add_identity(&self) -> NonIdentity`.

Additionally the `PublicKey` type has to be adjusted to return `NonIdentity` when appopriate, which is a breaking change.

On a last point I would like to suggest renaming this to `NonIdentityPoint`, which would be more in line with `NonZeroScalar`.

Fixes #1170.