### PR TITLE
signature: remove `Error` bound on `SignatureEncoding`

### DIFF
--- a/signature/src/encoding.rs
+++ b/signature/src/encoding.rs
@@ -1,13 +1,11 @@
 //! Encoding support.
 
-use crate::Error;
-
 #[cfg(feature = "alloc")]
 use alloc::vec::Vec;
 
 /// Support for decoding/encoding signatures as bytes.
 pub trait SignatureEncoding:
-    Clone + Sized + for<'a> TryFrom<&'a [u8], Error = Error> + TryInto<Self::Repr>
+    Clone + Sized + for<'a> TryFrom<&'a [u8]> + TryInto<Self::Repr>
 {
     /// Byte representation of a signature.
     type Repr: 'static + AsRef<[u8]> + Clone + Send + Sync;


### PR DESCRIPTION
Previously it mandated the use of `signature::Error` as the associated `Error` type for `TryFrom<&'a [u8]>`.

This isn't strictly necessary though. Downstream impls should be able to use their own error type.

It's also inconsistent with the `TryInto` bounds, which allow any error type.