### PR TITLE
elliptic-curve: move `NonIdentity` under `point`

### DIFF
--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -80,10 +80,6 @@ pub mod ecdh;
 #[cfg_attr(docsrs, doc(cfg(feature = "hash2curve")))]
 pub mod hash2curve;
 
-#[cfg(feature = "arithmetic")]
-#[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
-pub mod non_identity;
-
 #[cfg(feature = "sec1")]
 #[cfg_attr(docsrs, doc(cfg(feature = "sec1")))]
 pub mod sec1;
@@ -125,7 +121,6 @@ pub use {
         arithmetic::{
             AffineArithmetic, PrimeCurveArithmetic, ProjectiveArithmetic, ScalarArithmetic,
         },
-        non_identity::NonIdentity,
         public_key::PublicKey,
         scalar::{nonzero::NonZeroScalar, Scalar},
     },

--- a/elliptic-curve/src/point.rs
+++ b/elliptic-curve/src/point.rs
@@ -1,5 +1,12 @@
 //! Traits for elliptic curve points.
 
+#[cfg(feature = "arithmetic")]
+#[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
+mod non_identity;
+
+#[cfg(feature = "arithmetic")]
+pub use self::non_identity::NonIdentity;
+
 use crate::{Curve, FieldBytes};
 use subtle::{Choice, CtOption};
 

--- a/elliptic-curve/src/point/non_identity.rs
+++ b/elliptic-curve/src/point/non_identity.rs
@@ -38,7 +38,7 @@ where
 
 impl<P: Copy> NonIdentity<P> {
     /// Return wrapped point.
-    pub fn to_point(&self) -> P {
+    pub fn to_point(self) -> P {
         self.point
     }
 }
@@ -57,7 +57,7 @@ where
     }
 
     /// Converts this element into its affine representation.
-    pub fn to_affine(&self) -> NonIdentity<P::AffineRepr> {
+    pub fn to_affine(self) -> NonIdentity<P::AffineRepr> {
         NonIdentity {
             point: self.point.to_affine(),
         }
@@ -69,7 +69,7 @@ where
     P: PrimeCurveAffine,
 {
     /// Converts this element to its curve representation.
-    pub fn to_curve(&self) -> NonIdentity<P::Curve> {
+    pub fn to_curve(self) -> NonIdentity<P::Curve> {
         NonIdentity {
             point: self.point.to_curve(),
         }

--- a/elliptic-curve/src/point/non_identity.rs
+++ b/elliptic-curve/src/point/non_identity.rs
@@ -161,10 +161,8 @@ where
 
 #[cfg(all(test, feature = "dev"))]
 mod tests {
-    use crate::{
-        dev::{AffinePoint, ProjectivePoint},
-        NonIdentity,
-    };
+    use super::NonIdentity;
+    use crate::dev::{AffinePoint, ProjectivePoint};
     use group::GroupEncoding;
     use hex_literal::hex;
 

--- a/elliptic-curve/src/public_key.rs
+++ b/elliptic-curve/src/public_key.rs
@@ -1,8 +1,8 @@
 //! Elliptic curve public keys.
 
 use crate::{
-    AffinePoint, Curve, Error, NonIdentity, NonZeroScalar, ProjectiveArithmetic, ProjectivePoint,
-    Result,
+    point::NonIdentity, AffinePoint, Curve, Error, NonZeroScalar, ProjectiveArithmetic,
+    ProjectivePoint, Result,
 };
 use core::fmt::Debug;
 use group::{Curve as _, Group};


### PR DESCRIPTION
Reflects that the type represents a non-identity curve point.

cc @daxpedda 