### PR TITLE
password-hash: use `Salt` type with `PasswordHasher`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -265,7 +265,7 @@ dependencies = [
  "cipher 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "crypto-common 0.1.6",
  "digest 0.10.6",
- "elliptic-curve 0.12.3",
+ "elliptic-curve 0.13.0-pre",
  "password-hash",
  "signature 2.0.0-rc.1",
  "universal-hash 0.5.0",
@@ -777,7 +777,7 @@ dependencies = [
 
 [[package]]
 name = "password-hash"
-version = "0.4.2"
+version = "0.5.0-pre"
 dependencies = [
  "base64ct",
  "rand_core 0.6.4",

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -21,8 +21,8 @@ crypto-common = { version = "0.1", default-features = false }
 aead = { version = "0.5", optional = true, path = "../aead" }
 cipher = { version = "0.4", optional = true }
 digest = { version = "0.10", optional = true, features = ["mac"] }
-elliptic-curve = { version = "0.12", optional = true } # TODO(tarcieri): path = "../elliptic-curve"
-password-hash = { version = "0.4", optional = true, path = "../password-hash" }
+elliptic-curve = { version = "=0.13.0-pre", optional = true, path = "../elliptic-curve" }
+password-hash = { version = "=0.5.0-pre", optional = true, path = "../password-hash" }
 signature = { version = "=2.0.0-rc.1", optional = true, default-features = false, path = "../signature" }
 universal-hash = { version = "0.5", optional = true, path = "../universal-hash" }
 

--- a/password-hash/Cargo.toml
+++ b/password-hash/Cargo.toml
@@ -5,7 +5,7 @@ Traits which describe the functionality of password hashing algorithms,
 as well as a `no_std`-friendly implementation of the PHC string format
 (a well-defined subset of the Modular Crypt Format a.k.a. MCF)
 """
-version = "0.4.2"
+version = "0.5.0-pre"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/password-hash/src/lib.rs
+++ b/password-hash/src/lib.rs
@@ -203,7 +203,7 @@ impl<'a> PasswordHash<'a> {
     pub fn generate(
         phf: impl PasswordHasher,
         password: impl AsRef<[u8]>,
-        salt: &'a str,
+        salt: impl Into<Salt<'a>>,
     ) -> Result<Self> {
         phf.hash_password(password.as_ref(), salt)
     }

--- a/password-hash/src/traits.rs
+++ b/password-hash/src/traits.rs
@@ -30,17 +30,12 @@ pub trait PasswordHasher {
     /// salt value.
     ///
     /// Uses the default recommended parameters for a given algorithm.
-    fn hash_password<'a, S>(&self, password: &[u8], salt: &'a S) -> Result<PasswordHash<'a>>
-    where
-        S: AsRef<str> + ?Sized,
-    {
-        self.hash_password_customized(
-            password,
-            None,
-            None,
-            Self::Params::default(),
-            Salt::try_from(salt.as_ref())?,
-        )
+    fn hash_password<'a>(
+        &self,
+        password: &[u8],
+        salt: impl Into<Salt<'a>>,
+    ) -> Result<PasswordHash<'a>> {
+        self.hash_password_customized(password, None, None, Self::Params::default(), salt)
     }
 }
 

--- a/password-hash/tests/hashing.rs
+++ b/password-hash/tests/hashing.rs
@@ -68,12 +68,12 @@ impl<'a> TryFrom<StubParams> for ParamsString {
 #[test]
 fn verify_password_hash() {
     let valid_password = "test password";
-    let salt = "test-salt";
+    let salt = Salt::new("test-salt").unwrap();
     let hash = PasswordHash::generate(StubPasswordHasher, valid_password, salt).unwrap();
 
     // Sanity tests for StubFunction impl above
     assert_eq!(hash.algorithm, ALG);
-    assert_eq!(hash.salt.unwrap().as_str(), salt);
+    assert_eq!(hash.salt.unwrap(), salt);
 
     // Tests for generic password verification logic
     assert_eq!(


### PR DESCRIPTION
Previously `PasswordHash::hash_password` and `PasswordHash::generate` took `&str` for `Salt`, however this is a bit of a confusing API because the first thing it does is attempt to convert to a `Salt` which upholds several invariants including "B64" encoding.

This change makes the `Salt` parameter explicit so it's clear what type is responsible for checking those invariants.

Closes #1029.