### PR TITLE
elliptic-curve: rename `Curve::UInt` => `Curve::Uint`

### DIFF
--- a/elliptic-curve/src/arithmetic.rs
+++ b/elliptic-curve/src/arithmetic.rs
@@ -80,7 +80,7 @@ pub trait ScalarArithmetic: Curve {
     type Scalar: DefaultIsZeroes
         + From<ScalarCore<Self>>
         + Into<FieldBytes<Self>>
-        + Into<Self::UInt>
+        + Into<Self::Uint>
         + IsHigh
         + ff::Field
         + ff::PrimeField<Repr = FieldBytes<Self>>;

--- a/elliptic-curve/src/dev.rs
+++ b/elliptic-curve/src/dev.rs
@@ -65,7 +65,7 @@ pub type ScalarBits = crate::ScalarBits<MockCurve>;
 pub struct MockCurve;
 
 impl Curve for MockCurve {
-    type UInt = U256;
+    type Uint = U256;
 
     const ORDER: U256 =
         U256::from_be_hex("ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551");

--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -159,30 +159,30 @@ pub const ALGORITHM_OID: pkcs8::ObjectIdentifier =
 /// curves (e.g. [`SecretKey`]).
 pub trait Curve: 'static + Copy + Clone + Debug + Default + Eq + Ord + Send + Sync {
     /// Integer type used to represent field elements of this elliptic curve.
-    // TODO(tarcieri): replace this with an e.g. `const Curve::MODULUS: UInt`.
+    // TODO(tarcieri): replace this with an e.g. `const Curve::MODULUS: Uint`.
     // Requires rust-lang/rust#60551, i.e. `const_evaluatable_checked`
-    type UInt: bigint::AddMod<Output = Self::UInt>
+    type Uint: bigint::AddMod<Output = Self::Uint>
         + bigint::ArrayEncoding
         + bigint::Encoding
         + bigint::Integer
-        + bigint::NegMod<Output = Self::UInt>
+        + bigint::NegMod<Output = Self::Uint>
         + bigint::Random
         + bigint::RandomMod
-        + bigint::SubMod<Output = Self::UInt>
+        + bigint::SubMod<Output = Self::Uint>
         + zeroize::Zeroize;
 
     /// Order constant.
     ///
     /// Subdivided into either 32-bit or 64-bit "limbs" (depending on the
     /// target CPU's word size), specified from least to most significant.
-    const ORDER: Self::UInt;
+    const ORDER: Self::Uint;
 }
 
 /// Marker trait for elliptic curves with prime order.
 pub trait PrimeCurve: Curve {}
 
 /// Size of field elements of this elliptic curve.
-pub type FieldSize<C> = <<C as Curve>::UInt as bigint::ArrayEncoding>::ByteSize;
+pub type FieldSize<C> = <<C as Curve>::Uint as bigint::ArrayEncoding>::ByteSize;
 
 /// Byte representation of a base/scalar field element of a given curve.
 pub type FieldBytes<C> = GenericArray<u8, FieldSize<C>>;

--- a/elliptic-curve/src/ops.rs
+++ b/elliptic-curve/src/ops.rs
@@ -44,20 +44,20 @@ pub trait LinearCombination: Group {
 }
 
 /// Modular reduction.
-pub trait Reduce<UInt: Integer + ArrayEncoding>: Sized {
+pub trait Reduce<Uint: Integer + ArrayEncoding>: Sized {
     /// Perform a modular reduction, returning a field element.
-    fn from_uint_reduced(n: UInt) -> Self;
+    fn from_uint_reduced(n: Uint) -> Self;
 
     /// Interpret the given byte array as a big endian integer and perform
     /// a modular reduction.
-    fn from_be_bytes_reduced(bytes: ByteArray<UInt>) -> Self {
-        Self::from_uint_reduced(UInt::from_be_byte_array(bytes))
+    fn from_be_bytes_reduced(bytes: ByteArray<Uint>) -> Self {
+        Self::from_uint_reduced(Uint::from_be_byte_array(bytes))
     }
 
     /// Interpret the given byte array as a little endian integer and perform a
     /// modular reduction.
-    fn from_le_bytes_reduced(bytes: ByteArray<UInt>) -> Self {
-        Self::from_uint_reduced(UInt::from_le_byte_array(bytes))
+    fn from_le_bytes_reduced(bytes: ByteArray<Uint>) -> Self {
+        Self::from_uint_reduced(Uint::from_le_byte_array(bytes))
     }
 
     /// Interpret a digest as a big endian integer and perform a modular
@@ -66,7 +66,7 @@ pub trait Reduce<UInt: Integer + ArrayEncoding>: Sized {
     #[cfg_attr(docsrs, doc(cfg(feature = "digest")))]
     fn from_be_digest_reduced<D>(digest: D) -> Self
     where
-        D: FixedOutput<OutputSize = UInt::ByteSize>,
+        D: FixedOutput<OutputSize = Uint::ByteSize>,
     {
         Self::from_be_bytes_reduced(digest.finalize_fixed())
     }
@@ -77,7 +77,7 @@ pub trait Reduce<UInt: Integer + ArrayEncoding>: Sized {
     #[cfg_attr(docsrs, doc(cfg(feature = "digest")))]
     fn from_le_digest_reduced<D>(digest: D) -> Self
     where
-        D: FixedOutput<OutputSize = UInt::ByteSize>,
+        D: FixedOutput<OutputSize = Uint::ByteSize>,
     {
         Self::from_le_bytes_reduced(digest.finalize_fixed())
     }
@@ -90,7 +90,7 @@ pub trait Reduce<UInt: Integer + ArrayEncoding>: Sized {
 ///
 /// End users should use the [`Reduce`] impl on
 /// [`NonZeroScalar`][`crate::NonZeroScalar`] instead.
-pub trait ReduceNonZero<UInt: Integer + ArrayEncoding>: Sized {
+pub trait ReduceNonZero<Uint: Integer + ArrayEncoding>: Sized {
     /// Perform a modular reduction, returning a field element.
-    fn from_uint_reduced_nonzero(n: UInt) -> Self;
+    fn from_uint_reduced_nonzero(n: Uint) -> Self;
 }

--- a/elliptic-curve/src/scalar/core.rs
+++ b/elliptic-curve/src/scalar/core.rs
@@ -46,7 +46,7 @@ use serdect::serde::{de, ser, Deserialize, Serialize};
 #[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
 pub struct ScalarCore<C: Curve> {
     /// Inner unsigned integer type.
-    inner: C::UInt,
+    inner: C::Uint,
 }
 
 impl<C> ScalarCore<C>
@@ -55,37 +55,37 @@ where
 {
     /// Zero scalar.
     pub const ZERO: Self = Self {
-        inner: C::UInt::ZERO,
+        inner: C::Uint::ZERO,
     };
 
     /// Multiplicative identity.
     pub const ONE: Self = Self {
-        inner: C::UInt::ONE,
+        inner: C::Uint::ONE,
     };
 
     /// Scalar modulus.
-    pub const MODULUS: C::UInt = C::ORDER;
+    pub const MODULUS: C::Uint = C::ORDER;
 
     /// Generate a random [`ScalarCore`].
     pub fn random(rng: impl CryptoRng + RngCore) -> Self {
         Self {
-            inner: C::UInt::random_mod(rng, &NonZero::new(Self::MODULUS).unwrap()),
+            inner: C::Uint::random_mod(rng, &NonZero::new(Self::MODULUS).unwrap()),
         }
     }
 
-    /// Create a new scalar from [`Curve::UInt`].
-    pub fn new(uint: C::UInt) -> CtOption<Self> {
+    /// Create a new scalar from [`Curve::Uint`].
+    pub fn new(uint: C::Uint) -> CtOption<Self> {
         CtOption::new(Self { inner: uint }, uint.ct_lt(&Self::MODULUS))
     }
 
     /// Decode [`ScalarCore`] from big endian bytes.
     pub fn from_be_bytes(bytes: FieldBytes<C>) -> CtOption<Self> {
-        Self::new(C::UInt::from_be_byte_array(bytes))
+        Self::new(C::Uint::from_be_byte_array(bytes))
     }
 
     /// Decode [`ScalarCore`] from a big endian byte slice.
     pub fn from_be_slice(slice: &[u8]) -> Result<Self> {
-        if slice.len() == C::UInt::BYTES {
+        if slice.len() == C::Uint::BYTES {
             Option::from(Self::from_be_bytes(GenericArray::clone_from_slice(slice))).ok_or(Error)
         } else {
             Err(Error)
@@ -94,20 +94,20 @@ where
 
     /// Decode [`ScalarCore`] from little endian bytes.
     pub fn from_le_bytes(bytes: FieldBytes<C>) -> CtOption<Self> {
-        Self::new(C::UInt::from_le_byte_array(bytes))
+        Self::new(C::Uint::from_le_byte_array(bytes))
     }
 
     /// Decode [`ScalarCore`] from a little endian byte slice.
     pub fn from_le_slice(slice: &[u8]) -> Result<Self> {
-        if slice.len() == C::UInt::BYTES {
+        if slice.len() == C::Uint::BYTES {
             Option::from(Self::from_le_bytes(GenericArray::clone_from_slice(slice))).ok_or(Error)
         } else {
             Err(Error)
         }
     }
 
-    /// Borrow the inner `C::UInt`.
-    pub fn as_uint(&self) -> &C::UInt {
+    /// Borrow the inner `C::Uint`.
+    pub fn as_uint(&self) -> &C::Uint {
         &self.inner
     }
 
@@ -170,7 +170,7 @@ where
 {
     fn conditional_select(a: &Self, b: &Self, choice: Choice) -> Self {
         Self {
-            inner: C::UInt::conditional_select(&a.inner, &b.inner, choice),
+            inner: C::Uint::conditional_select(&a.inner, &b.inner, choice),
         }
     }
 }
@@ -239,7 +239,7 @@ where
 {
     fn from(n: u64) -> Self {
         Self {
-            inner: C::UInt::from(n),
+            inner: C::Uint::from(n),
         }
     }
 }

--- a/elliptic-curve/src/scalar/nonzero.rs
+++ b/elliptic-curve/src/scalar/nonzero.rs
@@ -63,8 +63,8 @@ where
         Scalar::<C>::from_repr(repr).and_then(Self::new)
     }
 
-    /// Create a [`NonZeroScalar`] from a `C::UInt`.
-    pub fn from_uint(uint: C::UInt) -> CtOption<Self> {
+    /// Create a [`NonZeroScalar`] from a `C::Uint`.
+    pub fn from_uint(uint: C::Uint) -> CtOption<Self> {
         ScalarCore::new(uint).and_then(|scalar| Self::new(scalar.into()))
     }
 }
@@ -262,7 +262,7 @@ where
     type Error = Error;
 
     fn try_from(bytes: &[u8]) -> Result<Self, Error> {
-        if bytes.len() == C::UInt::BYTES {
+        if bytes.len() == C::Uint::BYTES {
             Option::from(NonZeroScalar::from_repr(GenericArray::clone_from_slice(
                 bytes,
             )))

--- a/elliptic-curve/src/secret_key.rs
+++ b/elliptic-curve/src/secret_key.rs
@@ -146,7 +146,7 @@ where
 
     /// Deserialize raw secret scalar as a big endian integer.
     pub fn from_be_bytes(bytes: &[u8]) -> Result<Self> {
-        if bytes.len() != C::UInt::BYTES {
+        if bytes.len() != C::Uint::BYTES {
             return Err(Error);
         }
 


### PR DESCRIPTION
From https://rust-lang.github.io/api-guidelines/naming.html

> In UpperCamelCase, acronyms and contractions of compound words count
> as one word: use Uuid rather than UUID, Usize rather than USize or
> Stdin rather than StdIn.

Based on the `Usize` example, it's pretty clear we should be using `Uint` rather than `UInt`.

This is also consistent with `crypto-bigint`:

https://github.com/RustCrypto/crypto-bigint/pull/143