### PR TITLE
elliptic-curve: use `doc_auto_cfg`

### DIFF
--- a/elliptic-curve/src/arithmetic.rs
+++ b/elliptic-curve/src/arithmetic.rs
@@ -8,13 +8,11 @@ use subtle::{ConditionallySelectable, ConstantTimeEq};
 use zeroize::DefaultIsZeroes;
 
 /// Elliptic curve with affine arithmetic implementation.
-#[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
 pub trait AffineArithmetic: Curve + ScalarArithmetic {
     /// Elliptic curve point in affine coordinates.
     type AffinePoint: 'static
         + AffineXCoordinate<Self>
         + Copy
-        + Clone
         + ConditionallySelectable
         + ConstantTimeEq
         + Debug
@@ -28,7 +26,6 @@ pub trait AffineArithmetic: Curve + ScalarArithmetic {
 }
 
 /// Prime order elliptic curve with projective arithmetic implementation.
-#[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
 pub trait PrimeCurveArithmetic:
     PrimeCurve + ProjectiveArithmetic<ProjectivePoint = Self::CurveGroup>
 {
@@ -37,7 +34,6 @@ pub trait PrimeCurveArithmetic:
 }
 
 /// Elliptic curve with projective arithmetic implementation.
-#[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
 pub trait ProjectiveArithmetic: Curve + AffineArithmetic {
     /// Elliptic curve point in projective coordinates.
     ///
@@ -63,7 +59,6 @@ pub trait ProjectiveArithmetic: Curve + AffineArithmetic {
 
 /// Scalar arithmetic.
 #[cfg(feature = "arithmetic")]
-#[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
 pub trait ScalarArithmetic: Curve {
     /// Scalar field type.
     ///

--- a/elliptic-curve/src/dev.rs
+++ b/elliptic-curve/src/dev.rs
@@ -91,7 +91,6 @@ impl AssociatedOid for MockCurve {
 }
 
 #[cfg(feature = "jwk")]
-#[cfg_attr(docsrs, doc(cfg(feature = "jwk")))]
 impl JwkParameters for MockCurve {
     const CRV: &'static str = "P-256";
 }

--- a/elliptic-curve/src/jwk.rs
+++ b/elliptic-curve/src/jwk.rs
@@ -42,7 +42,6 @@ const JWK_TYPE_NAME: &str = "JwkEcKey";
 const FIELDS: &[&str] = &["kty", "crv", "x", "y", "d"];
 
 /// Elliptic curve parameters used by JSON Web Keys.
-#[cfg_attr(docsrs, doc(cfg(feature = "jwk")))]
 pub trait JwkParameters: Curve {
     /// The `crv` parameter which identifies a particular elliptic curve
     /// as defined in RFC 7518 Section 6.2.1.1:
@@ -64,7 +63,6 @@ pub trait JwkParameters: Curve {
 /// [1]: https://tools.ietf.org/html/rfc7518#section-6
 // TODO(tarcieri): eagerly decode or validate `x`, `y`, and `d` as Base64
 #[derive(Clone)]
-#[cfg_attr(docsrs, doc(cfg(feature = "jwk")))]
 pub struct JwkEcKey {
     /// The `crv` parameter which identifies a particular elliptic curve
     /// as defined in RFC 7518 Section 6.2.1.1:
@@ -110,7 +108,6 @@ impl JwkEcKey {
 
     /// Decode a JWK into a [`PublicKey`].
     #[cfg(feature = "arithmetic")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
     pub fn to_public_key<C>(&self) -> Result<PublicKey<C>>
     where
         C: Curve + JwkParameters + ProjectiveArithmetic,
@@ -154,7 +151,6 @@ impl JwkEcKey {
 
     /// Decode a JWK into a [`SecretKey`].
     #[cfg(feature = "arithmetic")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
     pub fn to_secret_key<C>(&self) -> Result<SecretKey<C>>
     where
         C: Curve + JwkParameters + ValidatePublicKey,
@@ -178,7 +174,6 @@ impl ToString for JwkEcKey {
     }
 }
 
-#[cfg_attr(docsrs, doc(cfg(feature = "jwk")))]
 impl<C> TryFrom<JwkEcKey> for SecretKey<C>
 where
     C: Curve + JwkParameters + ValidatePublicKey,
@@ -191,7 +186,6 @@ where
     }
 }
 
-#[cfg_attr(docsrs, doc(cfg(feature = "jwk")))]
 impl<C> TryFrom<&JwkEcKey> for SecretKey<C>
 where
     C: Curve + JwkParameters + ValidatePublicKey,
@@ -217,8 +211,6 @@ where
 }
 
 #[cfg(feature = "arithmetic")]
-#[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
-#[cfg_attr(docsrs, doc(cfg(feature = "jwk")))]
 impl<C> From<SecretKey<C>> for JwkEcKey
 where
     C: Curve + JwkParameters + ProjectiveArithmetic,
@@ -231,8 +223,6 @@ where
 }
 
 #[cfg(feature = "arithmetic")]
-#[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
-#[cfg_attr(docsrs, doc(cfg(feature = "jwk")))]
 impl<C> From<&SecretKey<C>> for JwkEcKey
 where
     C: Curve + JwkParameters + ProjectiveArithmetic,
@@ -249,8 +239,6 @@ where
 }
 
 #[cfg(feature = "arithmetic")]
-#[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
-#[cfg_attr(docsrs, doc(cfg(feature = "jwk")))]
 impl<C> TryFrom<JwkEcKey> for PublicKey<C>
 where
     C: Curve + JwkParameters + ProjectiveArithmetic,
@@ -265,8 +253,6 @@ where
 }
 
 #[cfg(feature = "arithmetic")]
-#[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
-#[cfg_attr(docsrs, doc(cfg(feature = "jwk")))]
 impl<C> TryFrom<&JwkEcKey> for PublicKey<C>
 where
     C: Curve + JwkParameters + ProjectiveArithmetic,
@@ -281,8 +267,6 @@ where
 }
 
 #[cfg(feature = "arithmetic")]
-#[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
-#[cfg_attr(docsrs, doc(cfg(feature = "jwk")))]
 impl<C> From<PublicKey<C>> for JwkEcKey
 where
     C: Curve + JwkParameters + ProjectiveArithmetic,
@@ -295,8 +279,6 @@ where
 }
 
 #[cfg(feature = "arithmetic")]
-#[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
-#[cfg_attr(docsrs, doc(cfg(feature = "jwk")))]
 impl<C> From<&PublicKey<C>> for JwkEcKey
 where
     C: Curve + JwkParameters + ProjectiveArithmetic,

--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![doc = include_str!("../README.md")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
@@ -58,34 +58,20 @@
 #[allow(unused_imports)]
 #[macro_use]
 extern crate alloc;
-
 #[cfg(feature = "std")]
 extern crate std;
-
-#[cfg(feature = "rand_core")]
-#[cfg_attr(docsrs, doc(cfg(feature = "rand_core")))]
-pub use rand_core;
 
 pub mod ops;
 
 #[cfg(feature = "dev")]
-#[cfg_attr(docsrs, doc(cfg(feature = "dev")))]
 pub mod dev;
-
 #[cfg(feature = "ecdh")]
-#[cfg_attr(docsrs, doc(cfg(feature = "ecdh")))]
 pub mod ecdh;
-
 #[cfg(feature = "hash2curve")]
-#[cfg_attr(docsrs, doc(cfg(feature = "hash2curve")))]
 pub mod hash2curve;
-
 #[cfg(feature = "sec1")]
-#[cfg_attr(docsrs, doc(cfg(feature = "sec1")))]
 pub mod sec1;
-
 #[cfg(feature = "arithmetic")]
-#[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
 pub mod weierstrass;
 
 mod error;
@@ -145,7 +131,6 @@ use generic_array::GenericArray;
 ///
 /// <http://oid-info.com/get/1.2.840.10045.2.1>
 #[cfg(feature = "pkcs8")]
-#[cfg_attr(docsrs, doc(cfg(feature = "pkcs8")))]
 pub const ALGORITHM_OID: pkcs8::ObjectIdentifier =
     pkcs8::ObjectIdentifier::new_unwrap("1.2.840.10045.2.1");
 
@@ -189,19 +174,16 @@ pub type FieldBytes<C> = GenericArray<u8, FieldSize<C>>;
 
 /// Affine point type for a given curve with a [`ProjectiveArithmetic`]
 /// implementation.
-#[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
 #[cfg(feature = "arithmetic")]
 pub type AffinePoint<C> = <C as AffineArithmetic>::AffinePoint;
 
 /// Projective point type for a given curve with a [`ProjectiveArithmetic`]
 /// implementation.
 #[cfg(feature = "arithmetic")]
-#[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
 pub type ProjectivePoint<C> = <C as ProjectiveArithmetic>::ProjectivePoint;
 
 /// Elliptic curve parameters used by VOPRF.
 #[cfg(feature = "voprf")]
-#[cfg_attr(docsrs, doc(cfg(feature = "voprf")))]
 pub trait VoprfParameters: Curve {
     /// The `ID` parameter which identifies a particular elliptic curve
     /// as defined in [section 4 of `draft-irtf-cfrg-voprf-08`][voprf].

--- a/elliptic-curve/src/ops.rs
+++ b/elliptic-curve/src/ops.rs
@@ -35,7 +35,6 @@ impl<F: ff::Field> Invert for F {
 /// non-optimized implementation.
 // TODO(tarcieri): replace this with a trait from the `group` crate? (see zkcrypto/group#25)
 #[cfg(feature = "arithmetic")]
-#[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
 pub trait LinearCombination: Group {
     /// Calculates `x * k + y * l`.
     fn lincomb(x: &Self, k: &Self::Scalar, y: &Self, l: &Self::Scalar) -> Self {
@@ -63,7 +62,6 @@ pub trait Reduce<Uint: Integer + ArrayEncoding>: Sized {
     /// Interpret a digest as a big endian integer and perform a modular
     /// reduction.
     #[cfg(feature = "digest")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "digest")))]
     fn from_be_digest_reduced<D>(digest: D) -> Self
     where
         D: FixedOutput<OutputSize = Uint::ByteSize>,
@@ -74,7 +72,6 @@ pub trait Reduce<Uint: Integer + ArrayEncoding>: Sized {
     /// Interpret a digest as a little endian integer and perform a modular
     /// reduction.
     #[cfg(feature = "digest")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "digest")))]
     fn from_le_digest_reduced<D>(digest: D) -> Self
     where
         D: FixedOutput<OutputSize = Uint::ByteSize>,

--- a/elliptic-curve/src/point.rs
+++ b/elliptic-curve/src/point.rs
@@ -1,7 +1,6 @@
 //! Traits for elliptic curve points.
 
 #[cfg(feature = "arithmetic")]
-#[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
 mod non_identity;
 
 #[cfg(feature = "arithmetic")]

--- a/elliptic-curve/src/point/non_identity.rs
+++ b/elliptic-curve/src/point/non_identity.rs
@@ -15,7 +15,6 @@ use serdect::serde::{de, ser, Deserialize, Serialize};
 ///
 /// In the context of ECC, it's useful for ensuring that certain arithmetic
 /// cannot result in the identity point.
-#[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
 #[derive(Clone, Copy)]
 pub struct NonIdentity<P> {
     point: P,
@@ -131,7 +130,6 @@ where
 }
 
 #[cfg(feature = "serde")]
-#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 impl<P> Serialize for NonIdentity<P>
 where
     P: Serialize,
@@ -145,7 +143,6 @@ where
 }
 
 #[cfg(feature = "serde")]
-#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 impl<'de, P> Deserialize<'de> for NonIdentity<P>
 where
     P: ConditionallySelectable + ConstantTimeEq + Default + Deserialize<'de> + GroupEncoding,

--- a/elliptic-curve/src/public_key.rs
+++ b/elliptic-curve/src/public_key.rs
@@ -77,7 +77,6 @@ use alloc::boxed::Box;
 /// Subject Public Key Info (SPKI) as the encoding format.
 ///
 /// For a more text-friendly encoding of public keys, use [`JwkEcKey`] instead.
-#[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct PublicKey<C>
 where
@@ -156,7 +155,6 @@ where
 
     /// Parse a [`JwkEcKey`] JSON Web Key (JWK) into a [`PublicKey`].
     #[cfg(feature = "jwk")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "jwk")))]
     pub fn from_jwk(jwk: &JwkEcKey) -> Result<Self>
     where
         C: Curve + JwkParameters,
@@ -168,7 +166,6 @@ where
 
     /// Parse a string containing a JSON Web Key (JWK) into a [`PublicKey`].
     #[cfg(feature = "jwk")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "jwk")))]
     pub fn from_jwk_str(jwk: &str) -> Result<Self>
     where
         C: Curve + JwkParameters,
@@ -180,7 +177,6 @@ where
 
     /// Serialize this public key as [`JwkEcKey`] JSON Web Key (JWK).
     #[cfg(feature = "jwk")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "jwk")))]
     pub fn to_jwk(&self) -> JwkEcKey
     where
         C: Curve + JwkParameters,
@@ -192,7 +188,6 @@ where
 
     /// Serialize this public key as JSON Web Key (JWK) string.
     #[cfg(feature = "jwk")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "jwk")))]
     pub fn to_jwk_string(&self) -> String
     where
         C: Curve + JwkParameters,
@@ -215,7 +210,6 @@ where
 impl<C> Copy for PublicKey<C> where C: Curve + ProjectiveArithmetic {}
 
 #[cfg(feature = "sec1")]
-#[cfg_attr(docsrs, doc(cfg(feature = "sec1")))]
 impl<C> FromEncodedPoint<C> for PublicKey<C>
 where
     C: Curve + ProjectiveArithmetic,
@@ -232,7 +226,6 @@ where
 }
 
 #[cfg(feature = "sec1")]
-#[cfg_attr(docsrs, doc(cfg(feature = "sec1")))]
 impl<C> ToEncodedPoint<C> for PublicKey<C>
 where
     C: Curve + ProjectiveArithmetic,
@@ -247,7 +240,6 @@ where
 }
 
 #[cfg(feature = "sec1")]
-#[cfg_attr(docsrs, doc(cfg(feature = "sec1")))]
 impl<C> From<PublicKey<C>> for EncodedPoint<C>
 where
     C: Curve + ProjectiveArithmetic + PointCompression,
@@ -260,7 +252,6 @@ where
 }
 
 #[cfg(feature = "sec1")]
-#[cfg_attr(docsrs, doc(cfg(feature = "sec1")))]
 impl<C> From<&PublicKey<C>> for EncodedPoint<C>
 where
     C: Curve + ProjectiveArithmetic + PointCompression,
@@ -295,7 +286,6 @@ where
 }
 
 #[cfg(feature = "sec1")]
-#[cfg_attr(docsrs, doc(cfg(feature = "sec1")))]
 impl<C> PartialOrd for PublicKey<C>
 where
     C: Curve + ProjectiveArithmetic,
@@ -308,7 +298,6 @@ where
 }
 
 #[cfg(feature = "sec1")]
-#[cfg_attr(docsrs, doc(cfg(feature = "sec1")))]
 impl<C> Ord for PublicKey<C>
 where
     C: Curve + ProjectiveArithmetic,
@@ -324,7 +313,6 @@ where
 }
 
 #[cfg(all(feature = "pkcs8", feature = "sec1"))]
-#[cfg_attr(docsrs, doc(cfg(all(feature = "pkcs8", feature = "sec1"))))]
 impl<C> TryFrom<pkcs8::SubjectPublicKeyInfo<'_>> for PublicKey<C>
 where
     C: Curve + AssociatedOid + ProjectiveArithmetic,
@@ -341,7 +329,6 @@ where
 }
 
 #[cfg(all(feature = "pkcs8", feature = "sec1"))]
-#[cfg_attr(docsrs, doc(cfg(all(feature = "pkcs8", feature = "sec1"))))]
 impl<C> DecodePublicKey for PublicKey<C>
 where
     C: Curve + AssociatedOid + ProjectiveArithmetic,
@@ -351,7 +338,6 @@ where
 }
 
 #[cfg(all(feature = "alloc", feature = "pkcs8"))]
-#[cfg_attr(docsrs, doc(cfg(all(feature = "alloc", feature = "pkcs8"))))]
 impl<C> EncodePublicKey for PublicKey<C>
 where
     C: Curve + AssociatedOid + ProjectiveArithmetic,
@@ -375,7 +361,6 @@ where
 }
 
 #[cfg(feature = "pem")]
-#[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
 impl<C> FromStr for PublicKey<C>
 where
     C: Curve + AssociatedOid + ProjectiveArithmetic,
@@ -390,7 +375,6 @@ where
 }
 
 #[cfg(feature = "pem")]
-#[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
 impl<C> ToString for PublicKey<C>
 where
     C: Curve + AssociatedOid + ProjectiveArithmetic,
@@ -404,7 +388,6 @@ where
 }
 
 #[cfg(feature = "serde")]
-#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 impl<C> Serialize for PublicKey<C>
 where
     C: Curve + AssociatedOid + ProjectiveArithmetic,
@@ -421,7 +404,6 @@ where
 }
 
 #[cfg(feature = "serde")]
-#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 impl<'de, C> Deserialize<'de> for PublicKey<C>
 where
     C: Curve + AssociatedOid + ProjectiveArithmetic,

--- a/elliptic-curve/src/scalar.rs
+++ b/elliptic-curve/src/scalar.rs
@@ -12,12 +12,10 @@ use crate::ScalarArithmetic;
 
 /// Scalar field element for a particular elliptic curve.
 #[cfg(feature = "arithmetic")]
-#[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
 pub type Scalar<C> = <C as ScalarArithmetic>::Scalar;
 
 /// Bit representation of a scalar field element of a given curve.
 #[cfg(feature = "bits")]
-#[cfg_attr(docsrs, doc(cfg(feature = "bits")))]
 pub type ScalarBits<C> = ff::FieldBits<<Scalar<C> as ff::PrimeFieldBits>::ReprBits>;
 
 /// Is this scalar greater than n / 2?

--- a/elliptic-curve/src/scalar/core.rs
+++ b/elliptic-curve/src/scalar/core.rs
@@ -43,7 +43,6 @@ use serdect::serde::{de, ser, Deserialize, Serialize};
 /// textual formats, the binary data is encoded as hexadecimal.
 // TODO(tarcieri): make this a fully generic `Scalar` type and use it for `ScalarArithmetic`
 #[derive(Copy, Clone, Debug, Default)]
-#[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
 pub struct ScalarCore<C: Curve> {
     /// Inner unsigned integer type.
     inner: C::Uint,
@@ -403,7 +402,6 @@ where
 }
 
 #[cfg(feature = "serde")]
-#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 impl<C> Serialize for ScalarCore<C>
 where
     C: Curve,
@@ -417,7 +415,6 @@ where
 }
 
 #[cfg(feature = "serde")]
-#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 impl<'de, C> Deserialize<'de> for ScalarCore<C>
 where
     C: Curve,

--- a/elliptic-curve/src/scalar/nonzero.rs
+++ b/elliptic-curve/src/scalar/nonzero.rs
@@ -28,7 +28,6 @@ use serdect::serde::{de, ser, Deserialize, Serialize};
 ///
 /// In the context of ECC, it's useful for ensuring that scalar multiplication
 /// cannot result in the point at infinity.
-#[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
 #[derive(Clone)]
 pub struct NonZeroScalar<C>
 where
@@ -332,7 +331,6 @@ where
 }
 
 #[cfg(feature = "serde")]
-#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 impl<C> Serialize for NonZeroScalar<C>
 where
     C: Curve + ScalarArithmetic,
@@ -346,7 +344,6 @@ where
 }
 
 #[cfg(feature = "serde")]
-#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 impl<'de, C> Deserialize<'de> for NonZeroScalar<C>
 where
     C: Curve + ScalarArithmetic,

--- a/elliptic-curve/src/secret_key.rs
+++ b/elliptic-curve/src/secret_key.rs
@@ -92,7 +92,6 @@ where
 {
     /// Generate a random [`SecretKey`].
     #[cfg(feature = "arithmetic")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
     pub fn random(rng: impl CryptoRng + RngCore) -> Self
     where
         C: ProjectiveArithmetic,
@@ -126,7 +125,6 @@ where
     ///
     /// Please treat it with the care it deserves!
     #[cfg(feature = "arithmetic")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
     pub fn to_nonzero_scalar(&self) -> NonZeroScalar<C>
     where
         C: Curve + ProjectiveArithmetic,
@@ -136,7 +134,6 @@ where
 
     /// Get the [`PublicKey`] which corresponds to this secret key
     #[cfg(feature = "arithmetic")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
     pub fn public_key(&self) -> PublicKey<C>
     where
         C: Curve + ProjectiveArithmetic,
@@ -169,7 +166,6 @@ where
 
     /// Deserialize secret key encoded in the SEC1 ASN.1 DER `ECPrivateKey` format.
     #[cfg(all(feature = "sec1"))]
-    #[cfg_attr(docsrs, doc(cfg(feature = "sec1")))]
     pub fn from_sec1_der(der_bytes: &[u8]) -> Result<Self>
     where
         C: Curve + ValidatePublicKey,
@@ -182,10 +178,6 @@ where
 
     /// Serialize secret key in the SEC1 ASN.1 DER `ECPrivateKey` format.
     #[cfg(all(feature = "alloc", feature = "arithmetic", feature = "sec1"))]
-    #[cfg_attr(
-        docsrs,
-        doc(cfg(all(feature = "alloc", feature = "arithmetic", feature = "sec1")))
-    )]
     pub fn to_sec1_der(&self) -> der::Result<Zeroizing<Vec<u8>>>
     where
         C: Curve + ProjectiveArithmetic,
@@ -219,7 +211,6 @@ where
     /// -----BEGIN EC PRIVATE KEY-----
     /// ```
     #[cfg(feature = "pem")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
     pub fn from_sec1_pem(s: &str) -> Result<Self>
     where
         C: Curve + ValidatePublicKey,
@@ -239,7 +230,6 @@ where
     ///
     /// Pass `Default::default()` to use the OS's native line endings.
     #[cfg(feature = "pem")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
     pub fn to_pem(&self, line_ending: pem::LineEnding) -> Result<Zeroizing<String>>
     where
         C: Curve + ProjectiveArithmetic,
@@ -255,7 +245,6 @@ where
 
     /// Parse a [`JwkEcKey`] JSON Web Key (JWK) into a [`SecretKey`].
     #[cfg(feature = "jwk")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "jwk")))]
     pub fn from_jwk(jwk: &JwkEcKey) -> Result<Self>
     where
         C: JwkParameters + ValidatePublicKey,
@@ -266,7 +255,6 @@ where
 
     /// Parse a string containing a JSON Web Key (JWK) into a [`SecretKey`].
     #[cfg(feature = "jwk")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "jwk")))]
     pub fn from_jwk_str(jwk: &str) -> Result<Self>
     where
         C: JwkParameters + ValidatePublicKey,
@@ -277,8 +265,6 @@ where
 
     /// Serialize this secret key as [`JwkEcKey`] JSON Web Key (JWK).
     #[cfg(all(feature = "arithmetic", feature = "jwk"))]
-    #[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
-    #[cfg_attr(docsrs, doc(cfg(feature = "jwk")))]
     pub fn to_jwk(&self) -> JwkEcKey
     where
         C: Curve + JwkParameters + ProjectiveArithmetic,
@@ -290,8 +276,6 @@ where
 
     /// Serialize this secret key as JSON Web Key (JWK) string.
     #[cfg(all(feature = "arithmetic", feature = "jwk"))]
-    #[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
-    #[cfg_attr(docsrs, doc(cfg(feature = "jwk")))]
     pub fn to_jwk_string(&self) -> Zeroizing<String>
     where
         C: Curve + JwkParameters + ProjectiveArithmetic,
@@ -344,7 +328,6 @@ where
 }
 
 #[cfg(all(feature = "sec1"))]
-#[cfg_attr(docsrs, doc(cfg(feature = "sec1")))]
 impl<C> TryFrom<sec1::EcPrivateKey<'_>> for SecretKey<C>
 where
     C: Curve + ValidatePublicKey,
@@ -371,7 +354,6 @@ where
 }
 
 #[cfg(feature = "arithmetic")]
-#[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
 impl<C> From<NonZeroScalar<C>> for SecretKey<C>
 where
     C: Curve + ProjectiveArithmetic,
@@ -382,7 +364,6 @@ where
 }
 
 #[cfg(feature = "arithmetic")]
-#[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
 impl<C> From<&NonZeroScalar<C>> for SecretKey<C>
 where
     C: Curve + ProjectiveArithmetic,

--- a/elliptic-curve/src/secret_key/pkcs8.rs
+++ b/elliptic-curve/src/secret_key/pkcs8.rs
@@ -27,7 +27,6 @@ use {
     core::str::FromStr,
 };
 
-#[cfg_attr(docsrs, doc(cfg(feature = "pkcs8")))]
 impl<C> TryFrom<pkcs8::PrivateKeyInfo<'_>> for SecretKey<C>
 where
     C: Curve + AssociatedOid + ValidatePublicKey,
@@ -45,7 +44,6 @@ where
     }
 }
 
-#[cfg_attr(docsrs, doc(cfg(feature = "pkcs8")))]
 impl<C> DecodePrivateKey for SecretKey<C>
 where
     C: Curve + AssociatedOid + ValidatePublicKey,
@@ -57,8 +55,6 @@ where
 // It doesn't strictly depend on `pkcs8/pem` but we can't easily activate `pkcs8/alloc`
 // without adding a separate crate feature just for this functionality.
 #[cfg(all(feature = "arithmetic", feature = "pem"))]
-#[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
-#[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
 impl<C> EncodePrivateKey for SecretKey<C>
 where
     C: Curve + AssociatedOid + ProjectiveArithmetic,
@@ -78,7 +74,6 @@ where
 }
 
 #[cfg(feature = "pem")]
-#[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
 impl<C> FromStr for SecretKey<C>
 where
     C: Curve + AssociatedOid + ValidatePublicKey,


### PR DESCRIPTION
Replaces manual `cfg(doc(...))` annotations with `doc_auto_cfg`, which populates them automatically