### PR TITLE
elliptic-curve: remove direct `der` crate dependency

### DIFF
--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -18,7 +18,6 @@ rust-version = "1.61"
 [dependencies]
 base16ct = "0.1.1"
 crypto-bigint = { version = "=0.5.0-pre.1", default-features = false, features = ["rand_core", "generic-array", "zeroize"] }
-der = { version = "0.6", default-features = false, features = ["oid"] }
 generic-array = { version = "0.14", default-features = false }
 rand_core = { version = "0.6", default-features = false }
 subtle = { version = "2", default-features = false }
@@ -44,8 +43,19 @@ sha3 = "0.10"
 
 [features]
 default = ["arithmetic"]
-alloc = ["base16ct/alloc", "der/alloc", "ff?/alloc", "group?/alloc", "sec1?/alloc", "zeroize/alloc"]
-std = ["alloc", "rand_core/std", "sec1?/std"]
+alloc = [
+    "base16ct/alloc",
+    "ff?/alloc",
+    "group?/alloc",
+    "pkcs8?/alloc",
+    "sec1?/alloc",
+    "zeroize/alloc"
+]
+std = [
+    "alloc",
+    "rand_core/std",
+    "sec1?/std"
+]
 
 arithmetic = ["group"]
 bits = ["arithmetic", "ff/bits"]
@@ -56,8 +66,8 @@ group = ["dep:group", "ff"]
 hazmat = []
 jwk = ["alloc", "base64ct/alloc", "serde", "serde_json", "zeroize/alloc"]
 pkcs8 = ["dep:pkcs8", "sec1"]
-pem = ["alloc", "arithmetic", "der/pem", "pem-rfc7468/alloc", "pkcs8", "sec1/pem"]
-serde = ["alloc", "pkcs8", "sec1/serde", "serdect"]
+pem = ["alloc", "arithmetic", "pem-rfc7468/alloc", "pkcs8", "sec1/pem"]
+serde = ["alloc", "sec1/serde", "serdect"]
 voprf = ["digest"]
 
 [package.metadata.docs.rs]

--- a/elliptic-curve/src/public_key.rs
+++ b/elliptic-curve/src/public_key.rs
@@ -7,14 +7,11 @@ use crate::{
 use core::fmt::Debug;
 use group::{Curve as _, Group};
 
+#[cfg(feature = "alloc")]
+use alloc::boxed::Box;
+
 #[cfg(feature = "jwk")]
 use crate::{JwkEcKey, JwkParameters};
-
-#[cfg(all(feature = "sec1", feature = "pkcs8"))]
-use crate::{
-    pkcs8::{self, AssociatedOid, DecodePublicKey},
-    ALGORITHM_OID,
-};
 
 #[cfg(feature = "pem")]
 use core::str::FromStr;
@@ -29,17 +26,23 @@ use {
     subtle::CtOption,
 };
 
-#[cfg(feature = "serde")]
-use serdect::serde::{de, ser, Deserialize, Serialize};
-
 #[cfg(all(feature = "alloc", feature = "pkcs8"))]
 use pkcs8::EncodePublicKey;
 
 #[cfg(any(feature = "jwk", feature = "pem"))]
 use alloc::string::{String, ToString};
 
-#[cfg(feature = "alloc")]
-use alloc::boxed::Box;
+#[cfg(all(feature = "pkcs8", feature = "serde"))]
+use serdect::serde::{de, ser, Deserialize, Serialize};
+
+#[cfg(all(feature = "sec1", feature = "pkcs8"))]
+use {
+    crate::{
+        pkcs8::{self, AssociatedOid, DecodePublicKey},
+        ALGORITHM_OID,
+    },
+    pkcs8::der,
+};
 
 /// Elliptic curve public keys.
 ///
@@ -387,7 +390,7 @@ where
     }
 }
 
-#[cfg(feature = "serde")]
+#[cfg(all(feature = "pkcs8", feature = "serde"))]
 impl<C> Serialize for PublicKey<C>
 where
     C: Curve + AssociatedOid + ProjectiveArithmetic,
@@ -403,7 +406,7 @@ where
     }
 }
 
-#[cfg(feature = "serde")]
+#[cfg(all(feature = "pkcs8", feature = "serde"))]
 impl<'de, C> Deserialize<'de> for PublicKey<C>
 where
     C: Curve + AssociatedOid + ProjectiveArithmetic,

--- a/elliptic-curve/src/secret_key.rs
+++ b/elliptic-curve/src/secret_key.rs
@@ -22,7 +22,6 @@ use {
         AffinePoint,
     },
     alloc::vec::Vec,
-    der::Encode,
     zeroize::Zeroizing,
 };
 
@@ -34,6 +33,12 @@ use crate::{
 
 #[cfg(feature = "jwk")]
 use crate::jwk::{JwkEcKey, JwkParameters};
+
+#[cfg(feature = "sec1")]
+use sec1::der;
+
+#[cfg(all(feature = "alloc", feature = "arithmetic", feature = "sec1"))]
+use sec1::der::Encode;
 
 #[cfg(all(feature = "arithmetic", any(feature = "jwk", feature = "pem")))]
 use alloc::string::String;

--- a/elliptic-curve/src/secret_key/pkcs8.rs
+++ b/elliptic-curve/src/secret_key/pkcs8.rs
@@ -2,11 +2,10 @@
 
 use super::SecretKey;
 use crate::{
-    pkcs8::{self, AssociatedOid, DecodePrivateKey},
+    pkcs8::{self, der::Decode, AssociatedOid, DecodePrivateKey},
     sec1::{ModulusSize, ValidatePublicKey},
     Curve, FieldSize, ALGORITHM_OID,
 };
-use der::Decode;
 use sec1::EcPrivateKey;
 
 // Imports for the `EncodePrivateKey` impl
@@ -16,7 +15,7 @@ use {
         sec1::{FromEncodedPoint, ToEncodedPoint},
         AffinePoint, ProjectiveArithmetic,
     },
-    pkcs8::EncodePrivateKey,
+    pkcs8::{der, EncodePrivateKey},
 };
 
 // Imports for actual PEM support

--- a/elliptic-curve/tests/pkcs8.rs
+++ b/elliptic-curve/tests/pkcs8.rs
@@ -8,6 +8,7 @@ use elliptic_curve::{
     sec1::ToEncodedPoint,
 };
 use hex_literal::hex;
+use pkcs8::der;
 
 /// DER-encoded PKCS#8 public key
 const PKCS8_PUBLIC_KEY_DER: &[u8; 91] = include_bytes!("examples/pkcs8-public-key.der");


### PR DESCRIPTION
This removes a hard dependency on the `der` crate.

With weak feature activation it now becomes possible to pull in the `der` crate transitively via the `pkcs8` and `sec1` crates.