### PR TITLE
elliptic-curve: consolidate `CurveArithmetic` trait

### DIFF
--- a/elliptic-curve/src/arithmetic.rs
+++ b/elliptic-curve/src/arithmetic.rs
@@ -7,8 +7,8 @@ use core::fmt::Debug;
 use subtle::{ConditionallySelectable, ConstantTimeEq};
 use zeroize::DefaultIsZeroes;
 
-/// Elliptic curve with affine arithmetic implementation.
-pub trait AffineArithmetic: Curve + ScalarArithmetic {
+/// Elliptic curve with an arithmetic implementation.
+pub trait CurveArithmetic: Curve {
     /// Elliptic curve point in affine coordinates.
     type AffinePoint: 'static
         + AffineXCoordinate<Self>
@@ -23,18 +23,7 @@ pub trait AffineArithmetic: Curve + ScalarArithmetic {
         + Sized
         + Send
         + Sync;
-}
 
-/// Prime order elliptic curve with projective arithmetic implementation.
-pub trait PrimeCurveArithmetic:
-    PrimeCurve + ProjectiveArithmetic<ProjectivePoint = Self::CurveGroup>
-{
-    /// Prime order elliptic curve group.
-    type CurveGroup: group::prime::PrimeCurve<Affine = <Self as AffineArithmetic>::AffinePoint>;
-}
-
-/// Elliptic curve with projective arithmetic implementation.
-pub trait ProjectiveArithmetic: Curve + AffineArithmetic {
     /// Elliptic curve point in projective coordinates.
     ///
     /// Note: the following bounds are provided by [`group::Group`]:
@@ -55,12 +44,8 @@ pub trait ProjectiveArithmetic: Curve + AffineArithmetic {
         + LinearCombination
         + group::Curve<AffineRepr = Self::AffinePoint>
         + group::Group<Scalar = Self::Scalar>;
-}
 
-/// Scalar arithmetic.
-#[cfg(feature = "arithmetic")]
-pub trait ScalarArithmetic: Curve {
-    /// Scalar field type.
+    /// Scalar field modulo this curve's order.
     ///
     /// Note: the following bounds are provided by [`ff::Field`]:
     /// - `'static`
@@ -79,4 +64,12 @@ pub trait ScalarArithmetic: Curve {
         + IsHigh
         + ff::Field
         + ff::PrimeField<Repr = FieldBytes<Self>>;
+}
+
+/// Prime order elliptic curve with projective arithmetic implementation.
+pub trait PrimeCurveArithmetic:
+    PrimeCurve + CurveArithmetic<ProjectivePoint = Self::CurveGroup>
+{
+    /// Prime order elliptic curve group.
+    type CurveGroup: group::prime::PrimeCurve<Affine = <Self as CurveArithmetic>::AffinePoint>;
 }

--- a/elliptic-curve/src/dev.rs
+++ b/elliptic-curve/src/dev.rs
@@ -12,8 +12,7 @@ use crate::{
     sec1::{CompressedPoint, FromEncodedPoint, ToEncodedPoint},
     subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption},
     zeroize::DefaultIsZeroes,
-    AffineArithmetic, AffineXCoordinate, Curve, IsHigh, PrimeCurve, ProjectiveArithmetic,
-    ScalarArithmetic,
+    AffineXCoordinate, Curve, CurveArithmetic, IsHigh, PrimeCurve,
 };
 use core::{
     iter::{Product, Sum},
@@ -73,15 +72,9 @@ impl Curve for MockCurve {
 
 impl PrimeCurve for MockCurve {}
 
-impl AffineArithmetic for MockCurve {
+impl CurveArithmetic for MockCurve {
     type AffinePoint = AffinePoint;
-}
-
-impl ProjectiveArithmetic for MockCurve {
     type ProjectivePoint = ProjectivePoint;
-}
-
-impl ScalarArithmetic for MockCurve {
     type Scalar = Scalar;
 }
 

--- a/elliptic-curve/src/ecdh.rs
+++ b/elliptic-curve/src/ecdh.rs
@@ -27,8 +27,8 @@
 //! [SIGMA]: https://webee.technion.ac.il/~hugo/sigma-pdf.pdf
 
 use crate::{
-    AffineArithmetic, AffinePoint, AffineXCoordinate, Curve, FieldBytes, NonZeroScalar,
-    ProjectiveArithmetic, ProjectivePoint, PublicKey,
+    AffinePoint, AffineXCoordinate, Curve, CurveArithmetic, FieldBytes, NonZeroScalar,
+    ProjectivePoint, PublicKey,
 };
 use core::borrow::Borrow;
 use digest::{crypto_common::BlockSizeUser, Digest};
@@ -62,7 +62,7 @@ pub fn diffie_hellman<C>(
     public_key: impl Borrow<AffinePoint<C>>,
 ) -> SharedSecret<C>
 where
-    C: Curve + ProjectiveArithmetic,
+    C: CurveArithmetic,
 {
     let public_point = ProjectivePoint::<C>::from(*public_key.borrow());
     let secret_point = (public_point * secret_key.borrow().as_ref()).to_affine();
@@ -92,14 +92,14 @@ where
 /// takes further steps to authenticate the peers in a key exchange.
 pub struct EphemeralSecret<C>
 where
-    C: Curve + ProjectiveArithmetic,
+    C: CurveArithmetic,
 {
     scalar: NonZeroScalar<C>,
 }
 
 impl<C> EphemeralSecret<C>
 where
-    C: Curve + ProjectiveArithmetic,
+    C: CurveArithmetic,
 {
     /// Generate a cryptographically random [`EphemeralSecret`].
     pub fn random(rng: impl CryptoRng + RngCore) -> Self {
@@ -124,7 +124,7 @@ where
 
 impl<C> From<&EphemeralSecret<C>> for PublicKey<C>
 where
-    C: Curve + ProjectiveArithmetic,
+    C: CurveArithmetic,
 {
     fn from(ephemeral_secret: &EphemeralSecret<C>) -> Self {
         ephemeral_secret.public_key()
@@ -133,18 +133,18 @@ where
 
 impl<C> Zeroize for EphemeralSecret<C>
 where
-    C: Curve + ProjectiveArithmetic,
+    C: CurveArithmetic,
 {
     fn zeroize(&mut self) {
         self.scalar.zeroize()
     }
 }
 
-impl<C> ZeroizeOnDrop for EphemeralSecret<C> where C: Curve + ProjectiveArithmetic {}
+impl<C> ZeroizeOnDrop for EphemeralSecret<C> where C: CurveArithmetic {}
 
 impl<C> Drop for EphemeralSecret<C>
 where
-    C: Curve + ProjectiveArithmetic,
+    C: CurveArithmetic,
 {
     fn drop(&mut self) {
         self.zeroize();
@@ -162,7 +162,7 @@ impl<C: Curve> SharedSecret<C> {
     #[inline]
     fn new(point: AffinePoint<C>) -> Self
     where
-        C: AffineArithmetic,
+        C: CurveArithmetic,
     {
         Self {
             secret_bytes: point.x(),

--- a/elliptic-curve/src/hash2curve/group_digest.rs
+++ b/elliptic-curve/src/hash2curve/group_digest.rs
@@ -1,11 +1,11 @@
 //! Traits for handling hash to curve.
 
 use super::{hash_to_field, ExpandMsg, FromOkm, MapToCurve};
-use crate::{ProjectiveArithmetic, ProjectivePoint, Result};
+use crate::{CurveArithmetic, ProjectivePoint, Result};
 use group::cofactor::CofactorGroup;
 
 /// Adds hashing arbitrary byte sequences to a valid group element
-pub trait GroupDigest: ProjectiveArithmetic
+pub trait GroupDigest: CurveArithmetic
 where
     ProjectivePoint<Self>: CofactorGroup,
 {

--- a/elliptic-curve/src/jwk.rs
+++ b/elliptic-curve/src/jwk.rs
@@ -26,7 +26,7 @@ use zeroize::{Zeroize, ZeroizeOnDrop};
 use crate::{
     public_key::PublicKey,
     sec1::{FromEncodedPoint, ToEncodedPoint},
-    AffinePoint, ProjectiveArithmetic,
+    AffinePoint, CurveArithmetic,
 };
 
 /// Key Type (`kty`) for elliptic curve keys.
@@ -110,7 +110,7 @@ impl JwkEcKey {
     #[cfg(feature = "arithmetic")]
     pub fn to_public_key<C>(&self) -> Result<PublicKey<C>>
     where
-        C: Curve + JwkParameters + ProjectiveArithmetic,
+        C: CurveArithmetic + JwkParameters,
         AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
         FieldSize<C>: ModulusSize,
     {
@@ -213,7 +213,7 @@ where
 #[cfg(feature = "arithmetic")]
 impl<C> From<SecretKey<C>> for JwkEcKey
 where
-    C: Curve + JwkParameters + ProjectiveArithmetic,
+    C: CurveArithmetic + JwkParameters,
     AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
     FieldSize<C>: ModulusSize,
 {
@@ -225,7 +225,7 @@ where
 #[cfg(feature = "arithmetic")]
 impl<C> From<&SecretKey<C>> for JwkEcKey
 where
-    C: Curve + JwkParameters + ProjectiveArithmetic,
+    C: CurveArithmetic + JwkParameters,
     AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
     FieldSize<C>: ModulusSize,
 {
@@ -241,7 +241,7 @@ where
 #[cfg(feature = "arithmetic")]
 impl<C> TryFrom<JwkEcKey> for PublicKey<C>
 where
-    C: Curve + JwkParameters + ProjectiveArithmetic,
+    C: CurveArithmetic + JwkParameters,
     AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
     FieldSize<C>: ModulusSize,
 {
@@ -255,7 +255,7 @@ where
 #[cfg(feature = "arithmetic")]
 impl<C> TryFrom<&JwkEcKey> for PublicKey<C>
 where
-    C: Curve + JwkParameters + ProjectiveArithmetic,
+    C: CurveArithmetic + JwkParameters,
     AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
     FieldSize<C>: ModulusSize,
 {
@@ -269,7 +269,7 @@ where
 #[cfg(feature = "arithmetic")]
 impl<C> From<PublicKey<C>> for JwkEcKey
 where
-    C: Curve + JwkParameters + ProjectiveArithmetic,
+    C: CurveArithmetic + JwkParameters,
     AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
     FieldSize<C>: ModulusSize,
 {
@@ -281,7 +281,7 @@ where
 #[cfg(feature = "arithmetic")]
 impl<C> From<&PublicKey<C>> for JwkEcKey
 where
-    C: Curve + JwkParameters + ProjectiveArithmetic,
+    C: CurveArithmetic + JwkParameters,
     AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
     FieldSize<C>: ModulusSize,
 {

--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -104,9 +104,7 @@ pub use zeroize;
 #[cfg(feature = "arithmetic")]
 pub use {
     crate::{
-        arithmetic::{
-            AffineArithmetic, PrimeCurveArithmetic, ProjectiveArithmetic, ScalarArithmetic,
-        },
+        arithmetic::{CurveArithmetic, PrimeCurveArithmetic},
         public_key::PublicKey,
         scalar::{nonzero::NonZeroScalar, Scalar},
     },
@@ -175,12 +173,12 @@ pub type FieldBytes<C> = GenericArray<u8, FieldSize<C>>;
 /// Affine point type for a given curve with a [`ProjectiveArithmetic`]
 /// implementation.
 #[cfg(feature = "arithmetic")]
-pub type AffinePoint<C> = <C as AffineArithmetic>::AffinePoint;
+pub type AffinePoint<C> = <C as CurveArithmetic>::AffinePoint;
 
 /// Projective point type for a given curve with a [`ProjectiveArithmetic`]
 /// implementation.
 #[cfg(feature = "arithmetic")]
-pub type ProjectivePoint<C> = <C as ProjectiveArithmetic>::ProjectivePoint;
+pub type ProjectivePoint<C> = <C as CurveArithmetic>::ProjectivePoint;
 
 /// Elliptic curve parameters used by VOPRF.
 #[cfg(feature = "voprf")]

--- a/elliptic-curve/src/public_key.rs
+++ b/elliptic-curve/src/public_key.rs
@@ -1,8 +1,7 @@
 //! Elliptic curve public keys.
 
 use crate::{
-    point::NonIdentity, AffinePoint, Curve, Error, NonZeroScalar, ProjectiveArithmetic,
-    ProjectivePoint, Result,
+    point::NonIdentity, AffinePoint, CurveArithmetic, Error, NonZeroScalar, ProjectivePoint, Result,
 };
 use core::fmt::Debug;
 use group::{Curve as _, Group};
@@ -20,7 +19,7 @@ use core::str::FromStr;
 use {
     crate::{
         sec1::{EncodedPoint, FromEncodedPoint, ModulusSize, ToEncodedPoint},
-        FieldSize, PointCompression,
+        Curve, FieldSize, PointCompression,
     },
     core::cmp::Ordering,
     subtle::CtOption,
@@ -83,14 +82,14 @@ use {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct PublicKey<C>
 where
-    C: Curve + ProjectiveArithmetic,
+    C: CurveArithmetic,
 {
     point: AffinePoint<C>,
 }
 
 impl<C> PublicKey<C>
 where
-    C: Curve + ProjectiveArithmetic,
+    C: CurveArithmetic,
 {
     /// Convert an [`AffinePoint`] into a [`PublicKey`]
     pub fn from_affine(point: AffinePoint<C>) -> Result<Self> {
@@ -136,7 +135,7 @@ where
     #[cfg(feature = "alloc")]
     pub fn to_sec1_bytes(&self) -> Box<[u8]>
     where
-        C: Curve + ProjectiveArithmetic + PointCompression,
+        C: CurveArithmetic + PointCompression,
         AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
         FieldSize<C>: ModulusSize,
     {
@@ -203,19 +202,19 @@ where
 
 impl<C> AsRef<AffinePoint<C>> for PublicKey<C>
 where
-    C: Curve + ProjectiveArithmetic,
+    C: CurveArithmetic,
 {
     fn as_ref(&self) -> &AffinePoint<C> {
         self.as_affine()
     }
 }
 
-impl<C> Copy for PublicKey<C> where C: Curve + ProjectiveArithmetic {}
+impl<C> Copy for PublicKey<C> where C: CurveArithmetic {}
 
 #[cfg(feature = "sec1")]
 impl<C> FromEncodedPoint<C> for PublicKey<C>
 where
-    C: Curve + ProjectiveArithmetic,
+    C: CurveArithmetic,
     AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
     FieldSize<C>: ModulusSize,
 {
@@ -231,7 +230,7 @@ where
 #[cfg(feature = "sec1")]
 impl<C> ToEncodedPoint<C> for PublicKey<C>
 where
-    C: Curve + ProjectiveArithmetic,
+    C: CurveArithmetic,
     AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
     FieldSize<C>: ModulusSize,
 {
@@ -245,7 +244,7 @@ where
 #[cfg(feature = "sec1")]
 impl<C> From<PublicKey<C>> for EncodedPoint<C>
 where
-    C: Curve + ProjectiveArithmetic + PointCompression,
+    C: CurveArithmetic + PointCompression,
     AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
     FieldSize<C>: ModulusSize,
 {
@@ -257,7 +256,7 @@ where
 #[cfg(feature = "sec1")]
 impl<C> From<&PublicKey<C>> for EncodedPoint<C>
 where
-    C: Curve + ProjectiveArithmetic + PointCompression,
+    C: CurveArithmetic + PointCompression,
     AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
     FieldSize<C>: ModulusSize,
 {
@@ -268,7 +267,7 @@ where
 
 impl<C, P> From<NonIdentity<P>> for PublicKey<C>
 where
-    C: Curve + ProjectiveArithmetic,
+    C: CurveArithmetic,
     P: Copy + Into<AffinePoint<C>>,
 {
     fn from(value: NonIdentity<P>) -> Self {
@@ -278,7 +277,7 @@ where
 
 impl<C, P> From<&NonIdentity<P>> for PublicKey<C>
 where
-    C: Curve + ProjectiveArithmetic,
+    C: CurveArithmetic,
     P: Copy + Into<AffinePoint<C>>,
 {
     fn from(value: &NonIdentity<P>) -> Self {
@@ -291,7 +290,7 @@ where
 #[cfg(feature = "sec1")]
 impl<C> PartialOrd for PublicKey<C>
 where
-    C: Curve + ProjectiveArithmetic,
+    C: CurveArithmetic,
     AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
     FieldSize<C>: ModulusSize,
 {
@@ -303,7 +302,7 @@ where
 #[cfg(feature = "sec1")]
 impl<C> Ord for PublicKey<C>
 where
-    C: Curve + ProjectiveArithmetic,
+    C: CurveArithmetic,
     AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
     FieldSize<C>: ModulusSize,
 {
@@ -318,7 +317,7 @@ where
 #[cfg(all(feature = "pkcs8", feature = "sec1"))]
 impl<C> TryFrom<pkcs8::SubjectPublicKeyInfo<'_>> for PublicKey<C>
 where
-    C: Curve + AssociatedOid + ProjectiveArithmetic,
+    C: AssociatedOid + CurveArithmetic,
     AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
     FieldSize<C>: ModulusSize,
 {
@@ -334,7 +333,7 @@ where
 #[cfg(all(feature = "pkcs8", feature = "sec1"))]
 impl<C> DecodePublicKey for PublicKey<C>
 where
-    C: Curve + AssociatedOid + ProjectiveArithmetic,
+    C: AssociatedOid + CurveArithmetic,
     AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
     FieldSize<C>: ModulusSize,
 {
@@ -343,7 +342,7 @@ where
 #[cfg(all(feature = "alloc", feature = "pkcs8"))]
 impl<C> EncodePublicKey for PublicKey<C>
 where
-    C: Curve + AssociatedOid + ProjectiveArithmetic,
+    C: AssociatedOid + CurveArithmetic,
     AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
     FieldSize<C>: ModulusSize,
 {
@@ -366,7 +365,7 @@ where
 #[cfg(feature = "pem")]
 impl<C> FromStr for PublicKey<C>
 where
-    C: Curve + AssociatedOid + ProjectiveArithmetic,
+    C: AssociatedOid + CurveArithmetic,
     AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
     FieldSize<C>: ModulusSize,
 {
@@ -380,7 +379,7 @@ where
 #[cfg(feature = "pem")]
 impl<C> ToString for PublicKey<C>
 where
-    C: Curve + AssociatedOid + ProjectiveArithmetic,
+    C: AssociatedOid + CurveArithmetic,
     AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
     FieldSize<C>: ModulusSize,
 {
@@ -393,7 +392,7 @@ where
 #[cfg(all(feature = "pkcs8", feature = "serde"))]
 impl<C> Serialize for PublicKey<C>
 where
-    C: Curve + AssociatedOid + ProjectiveArithmetic,
+    C: AssociatedOid + CurveArithmetic,
     AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
     FieldSize<C>: ModulusSize,
 {
@@ -409,7 +408,7 @@ where
 #[cfg(all(feature = "pkcs8", feature = "serde"))]
 impl<'de, C> Deserialize<'de> for PublicKey<C>
 where
-    C: Curve + AssociatedOid + ProjectiveArithmetic,
+    C: AssociatedOid + CurveArithmetic,
     AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
     FieldSize<C>: ModulusSize,
 {

--- a/elliptic-curve/src/scalar.rs
+++ b/elliptic-curve/src/scalar.rs
@@ -8,11 +8,11 @@ pub(crate) mod core;
 pub(crate) mod nonzero;
 
 #[cfg(feature = "arithmetic")]
-use crate::ScalarArithmetic;
+use crate::CurveArithmetic;
 
 /// Scalar field element for a particular elliptic curve.
 #[cfg(feature = "arithmetic")]
-pub type Scalar<C> = <C as ScalarArithmetic>::Scalar;
+pub type Scalar<C> = <C as CurveArithmetic>::Scalar;
 
 /// Bit representation of a scalar field element of a given curve.
 #[cfg(feature = "bits")]

--- a/elliptic-curve/src/scalar/core.rs
+++ b/elliptic-curve/src/scalar/core.rs
@@ -21,7 +21,7 @@ use zeroize::DefaultIsZeroes;
 
 #[cfg(feature = "arithmetic")]
 use {
-    super::{Scalar, ScalarArithmetic},
+    super::{CurveArithmetic, Scalar},
     ff::PrimeField,
 };
 
@@ -41,7 +41,7 @@ use serdect::serde::{de, ser, Deserialize, Serialize};
 ///
 /// The serialization is a fixed-width big endian encoding. When used with
 /// textual formats, the binary data is encoded as hexadecimal.
-// TODO(tarcieri): make this a fully generic `Scalar` type and use it for `ScalarArithmetic`
+// TODO(tarcieri): make this a fully generic `Scalar` type and use it for `CurveArithmetic`
 #[derive(Copy, Clone, Debug, Default)]
 pub struct ScalarCore<C: Curve> {
     /// Inner unsigned integer type.
@@ -144,7 +144,7 @@ where
 #[cfg(feature = "arithmetic")]
 impl<C> ScalarCore<C>
 where
-    C: Curve + ScalarArithmetic,
+    C: CurveArithmetic,
 {
     /// Convert [`ScalarCore`] into a given curve's scalar type
     // TODO(tarcieri): replace curve-specific scalars with `ScalarCore`

--- a/elliptic-curve/src/scalar/nonzero.rs
+++ b/elliptic-curve/src/scalar/nonzero.rs
@@ -3,7 +3,7 @@
 use crate::{
     ops::{Invert, Reduce, ReduceNonZero},
     rand_core::{CryptoRng, RngCore},
-    Curve, Error, FieldBytes, IsHigh, PrimeCurve, Scalar, ScalarArithmetic, ScalarCore, SecretKey,
+    CurveArithmetic, Error, FieldBytes, IsHigh, PrimeCurve, Scalar, ScalarCore, SecretKey,
 };
 use base16ct::HexDisplay;
 use core::{
@@ -31,14 +31,14 @@ use serdect::serde::{de, ser, Deserialize, Serialize};
 #[derive(Clone)]
 pub struct NonZeroScalar<C>
 where
-    C: Curve + ScalarArithmetic,
+    C: CurveArithmetic,
 {
     scalar: Scalar<C>,
 }
 
 impl<C> NonZeroScalar<C>
 where
-    C: Curve + ScalarArithmetic,
+    C: CurveArithmetic,
 {
     /// Generate a random `NonZeroScalar`.
     pub fn random(mut rng: impl CryptoRng + RngCore) -> Self {
@@ -70,7 +70,7 @@ where
 
 impl<C> AsRef<Scalar<C>> for NonZeroScalar<C>
 where
-    C: Curve + ScalarArithmetic,
+    C: CurveArithmetic,
 {
     fn as_ref(&self) -> &Scalar<C> {
         &self.scalar
@@ -79,7 +79,7 @@ where
 
 impl<C> ConditionallySelectable for NonZeroScalar<C>
 where
-    C: Curve + ScalarArithmetic,
+    C: CurveArithmetic,
 {
     fn conditional_select(a: &Self, b: &Self, choice: Choice) -> Self {
         Self {
@@ -90,18 +90,18 @@ where
 
 impl<C> ConstantTimeEq for NonZeroScalar<C>
 where
-    C: Curve + ScalarArithmetic,
+    C: CurveArithmetic,
 {
     fn ct_eq(&self, other: &Self) -> Choice {
         self.scalar.ct_eq(&other.scalar)
     }
 }
 
-impl<C> Copy for NonZeroScalar<C> where C: Curve + ScalarArithmetic {}
+impl<C> Copy for NonZeroScalar<C> where C: CurveArithmetic {}
 
 impl<C> Deref for NonZeroScalar<C>
 where
-    C: Curve + ScalarArithmetic,
+    C: CurveArithmetic,
 {
     type Target = Scalar<C>;
 
@@ -112,7 +112,7 @@ where
 
 impl<C> From<NonZeroScalar<C>> for FieldBytes<C>
 where
-    C: Curve + ScalarArithmetic,
+    C: CurveArithmetic,
 {
     fn from(scalar: NonZeroScalar<C>) -> FieldBytes<C> {
         Self::from(&scalar)
@@ -121,7 +121,7 @@ where
 
 impl<C> From<&NonZeroScalar<C>> for FieldBytes<C>
 where
-    C: Curve + ScalarArithmetic,
+    C: CurveArithmetic,
 {
     fn from(scalar: &NonZeroScalar<C>) -> FieldBytes<C> {
         scalar.to_repr()
@@ -130,7 +130,7 @@ where
 
 impl<C> From<NonZeroScalar<C>> for ScalarCore<C>
 where
-    C: Curve + ScalarArithmetic,
+    C: CurveArithmetic,
 {
     fn from(scalar: NonZeroScalar<C>) -> ScalarCore<C> {
         ScalarCore::from_be_bytes(scalar.to_repr()).unwrap()
@@ -139,7 +139,7 @@ where
 
 impl<C> From<&NonZeroScalar<C>> for ScalarCore<C>
 where
-    C: Curve + ScalarArithmetic,
+    C: CurveArithmetic,
 {
     fn from(scalar: &NonZeroScalar<C>) -> ScalarCore<C> {
         ScalarCore::from_be_bytes(scalar.to_repr()).unwrap()
@@ -148,7 +148,7 @@ where
 
 impl<C> From<SecretKey<C>> for NonZeroScalar<C>
 where
-    C: Curve + ScalarArithmetic,
+    C: CurveArithmetic,
 {
     fn from(sk: SecretKey<C>) -> NonZeroScalar<C> {
         Self::from(&sk)
@@ -157,7 +157,7 @@ where
 
 impl<C> From<&SecretKey<C>> for NonZeroScalar<C>
 where
-    C: Curve + ScalarArithmetic,
+    C: CurveArithmetic,
 {
     fn from(sk: &SecretKey<C>) -> NonZeroScalar<C> {
         let scalar = sk.as_scalar_core().to_scalar();
@@ -168,7 +168,7 @@ where
 
 impl<C> Invert for NonZeroScalar<C>
 where
-    C: Curve + ScalarArithmetic,
+    C: CurveArithmetic,
 {
     type Output = Self;
 
@@ -182,7 +182,7 @@ where
 
 impl<C> IsHigh for NonZeroScalar<C>
 where
-    C: Curve + ScalarArithmetic,
+    C: CurveArithmetic,
 {
     fn is_high(&self) -> Choice {
         self.scalar.is_high()
@@ -191,7 +191,7 @@ where
 
 impl<C> Neg for NonZeroScalar<C>
 where
-    C: Curve + ScalarArithmetic,
+    C: CurveArithmetic,
 {
     type Output = NonZeroScalar<C>;
 
@@ -204,7 +204,7 @@ where
 
 impl<C> Mul<NonZeroScalar<C>> for NonZeroScalar<C>
 where
-    C: PrimeCurve + ScalarArithmetic,
+    C: PrimeCurve + CurveArithmetic,
 {
     type Output = Self;
 
@@ -216,7 +216,7 @@ where
 
 impl<C> Mul<&NonZeroScalar<C>> for NonZeroScalar<C>
 where
-    C: PrimeCurve + ScalarArithmetic,
+    C: PrimeCurve + CurveArithmetic,
 {
     type Output = Self;
 
@@ -232,7 +232,7 @@ where
 /// Note: implementation is the same as `ReduceNonZero`
 impl<C, I> Reduce<I> for NonZeroScalar<C>
 where
-    C: Curve + ScalarArithmetic,
+    C: CurveArithmetic,
     I: Integer + ArrayEncoding,
     Scalar<C>: ReduceNonZero<I>,
 {
@@ -243,7 +243,7 @@ where
 
 impl<C, I> ReduceNonZero<I> for NonZeroScalar<C>
 where
-    C: Curve + ScalarArithmetic,
+    C: CurveArithmetic,
     I: Integer + ArrayEncoding,
     Scalar<C>: ReduceNonZero<I>,
 {
@@ -256,7 +256,7 @@ where
 
 impl<C> TryFrom<&[u8]> for NonZeroScalar<C>
 where
-    C: Curve + ScalarArithmetic,
+    C: CurveArithmetic,
 {
     type Error = Error;
 
@@ -274,7 +274,7 @@ where
 
 impl<C> Zeroize for NonZeroScalar<C>
 where
-    C: Curve + ScalarArithmetic,
+    C: CurveArithmetic,
 {
     fn zeroize(&mut self) {
         // Use zeroize's volatile writes to ensure value is cleared.
@@ -288,7 +288,7 @@ where
 
 impl<C> fmt::Display for NonZeroScalar<C>
 where
-    C: Curve + ScalarArithmetic,
+    C: CurveArithmetic,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{:X}", self)
@@ -297,7 +297,7 @@ where
 
 impl<C> fmt::LowerHex for NonZeroScalar<C>
 where
-    C: Curve + ScalarArithmetic,
+    C: CurveArithmetic,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{:x}", HexDisplay(&self.to_repr()))
@@ -306,7 +306,7 @@ where
 
 impl<C> fmt::UpperHex for NonZeroScalar<C>
 where
-    C: Curve + ScalarArithmetic,
+    C: CurveArithmetic,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{:}", HexDisplay(&self.to_repr()))
@@ -315,7 +315,7 @@ where
 
 impl<C> str::FromStr for NonZeroScalar<C>
 where
-    C: Curve + ScalarArithmetic,
+    C: CurveArithmetic,
 {
     type Err = Error;
 
@@ -333,7 +333,7 @@ where
 #[cfg(feature = "serde")]
 impl<C> Serialize for NonZeroScalar<C>
 where
-    C: Curve + ScalarArithmetic,
+    C: CurveArithmetic,
 {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -346,7 +346,7 @@ where
 #[cfg(feature = "serde")]
 impl<'de, C> Deserialize<'de> for NonZeroScalar<C>
 where
-    C: Curve + ScalarArithmetic,
+    C: CurveArithmetic,
 {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where

--- a/elliptic-curve/src/sec1.rs
+++ b/elliptic-curve/src/sec1.rs
@@ -9,7 +9,7 @@ use generic_array::GenericArray;
 use subtle::CtOption;
 
 #[cfg(feature = "arithmetic")]
-use crate::{AffinePoint, Error, ProjectiveArithmetic};
+use crate::{AffinePoint, CurveArithmetic, Error};
 
 /// Encoded elliptic curve point with point compression.
 pub type CompressedPoint<C> = GenericArray<u8, CompressedPointSize<C>>;
@@ -96,7 +96,7 @@ where
 #[cfg(all(feature = "arithmetic"))]
 impl<C> ValidatePublicKey for C
 where
-    C: Curve + ProjectiveArithmetic,
+    C: CurveArithmetic,
     AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
     FieldSize<C>: ModulusSize,
 {

--- a/elliptic-curve/src/secret_key.rs
+++ b/elliptic-curve/src/secret_key.rs
@@ -28,7 +28,7 @@ use {
 #[cfg(feature = "arithmetic")]
 use crate::{
     rand_core::{CryptoRng, RngCore},
-    NonZeroScalar, ProjectiveArithmetic, PublicKey,
+    CurveArithmetic, NonZeroScalar, PublicKey,
 };
 
 #[cfg(feature = "jwk")]
@@ -99,7 +99,7 @@ where
     #[cfg(feature = "arithmetic")]
     pub fn random(rng: impl CryptoRng + RngCore) -> Self
     where
-        C: ProjectiveArithmetic,
+        C: CurveArithmetic,
     {
         Self {
             inner: NonZeroScalar::<C>::random(rng).into(),
@@ -132,7 +132,7 @@ where
     #[cfg(feature = "arithmetic")]
     pub fn to_nonzero_scalar(&self) -> NonZeroScalar<C>
     where
-        C: Curve + ProjectiveArithmetic,
+        C: CurveArithmetic,
     {
         self.into()
     }
@@ -141,7 +141,7 @@ where
     #[cfg(feature = "arithmetic")]
     pub fn public_key(&self) -> PublicKey<C>
     where
-        C: Curve + ProjectiveArithmetic,
+        C: CurveArithmetic,
     {
         PublicKey::from_secret_scalar(&self.to_nonzero_scalar())
     }
@@ -185,7 +185,7 @@ where
     #[cfg(all(feature = "alloc", feature = "arithmetic", feature = "sec1"))]
     pub fn to_sec1_der(&self) -> der::Result<Zeroizing<Vec<u8>>>
     where
-        C: Curve + ProjectiveArithmetic,
+        C: CurveArithmetic,
         AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
         FieldSize<C>: ModulusSize,
     {
@@ -237,7 +237,7 @@ where
     #[cfg(feature = "pem")]
     pub fn to_pem(&self, line_ending: pem::LineEnding) -> Result<Zeroizing<String>>
     where
-        C: Curve + ProjectiveArithmetic,
+        C: CurveArithmetic,
         AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
         FieldSize<C>: ModulusSize,
     {
@@ -272,7 +272,7 @@ where
     #[cfg(all(feature = "arithmetic", feature = "jwk"))]
     pub fn to_jwk(&self) -> JwkEcKey
     where
-        C: Curve + JwkParameters + ProjectiveArithmetic,
+        C: CurveArithmetic + JwkParameters,
         AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
         FieldSize<C>: ModulusSize,
     {
@@ -283,7 +283,7 @@ where
     #[cfg(all(feature = "arithmetic", feature = "jwk"))]
     pub fn to_jwk_string(&self) -> Zeroizing<String>
     where
-        C: Curve + JwkParameters + ProjectiveArithmetic,
+        C: CurveArithmetic + JwkParameters,
         AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
         FieldSize<C>: ModulusSize,
     {
@@ -361,7 +361,7 @@ where
 #[cfg(feature = "arithmetic")]
 impl<C> From<NonZeroScalar<C>> for SecretKey<C>
 where
-    C: Curve + ProjectiveArithmetic,
+    C: CurveArithmetic,
 {
     fn from(scalar: NonZeroScalar<C>) -> SecretKey<C> {
         SecretKey::from(&scalar)
@@ -371,7 +371,7 @@ where
 #[cfg(feature = "arithmetic")]
 impl<C> From<&NonZeroScalar<C>> for SecretKey<C>
 where
-    C: Curve + ProjectiveArithmetic,
+    C: CurveArithmetic,
 {
     fn from(scalar: &NonZeroScalar<C>) -> SecretKey<C> {
         SecretKey {

--- a/elliptic-curve/src/secret_key/pkcs8.rs
+++ b/elliptic-curve/src/secret_key/pkcs8.rs
@@ -13,7 +13,7 @@ use sec1::EcPrivateKey;
 use {
     crate::{
         sec1::{FromEncodedPoint, ToEncodedPoint},
-        AffinePoint, ProjectiveArithmetic,
+        AffinePoint, CurveArithmetic,
     },
     pkcs8::{der, EncodePrivateKey},
 };
@@ -52,7 +52,7 @@ where
 #[cfg(all(feature = "alloc", feature = "arithmetic"))]
 impl<C> EncodePrivateKey for SecretKey<C>
 where
-    C: Curve + AssociatedOid + ProjectiveArithmetic,
+    C: AssociatedOid + CurveArithmetic,
     AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
     FieldSize<C>: ModulusSize,
 {


### PR DESCRIPTION
Consolidates the following former three traits into a single trait:

- `AffineArithmetic`
- `ProjectiveArithmetic`
- `ScalarArithmetic`

It doesn't make sense to impl one of these traits without impl'ing them all, so this commit combines them into a single trait.