### PR TITLE
elliptic-curve: lint improvements

### DIFF
--- a/elliptic-curve/src/ecdh.rs
+++ b/elliptic-curve/src/ecdh.rs
@@ -118,7 +118,7 @@ where
     /// Compute a Diffie-Hellman shared secret from an ephemeral secret and the
     /// public key of the other participant in the exchange.
     pub fn diffie_hellman(&self, public_key: &PublicKey<C>) -> SharedSecret<C> {
-        diffie_hellman(&self.scalar, public_key.as_affine())
+        diffie_hellman(self.scalar, public_key.as_affine())
     }
 }
 

--- a/elliptic-curve/src/hash2curve/hash2field/expand_msg.rs
+++ b/elliptic-curve/src/hash2curve/hash2field/expand_msg.rs
@@ -94,7 +94,7 @@ where
     pub fn data(&self) -> &[u8] {
         match self {
             Self::Hashed(d) => &d[..],
-            Self::Array(d) => *d,
+            Self::Array(d) => d,
         }
     }
 

--- a/elliptic-curve/src/hash2curve/osswu.rs
+++ b/elliptic-curve/src/hash2curve/osswu.rs
@@ -64,7 +64,7 @@ pub trait OsswuMap: Field + Sgn0 {
         tv2 = gx1 * gxd; // gx1 * gxd
         tv4 *= tv2;
 
-        let y1 = tv4.pow_vartime(&Self::PARAMS.c1) * tv2; // tv4^C1 * tv2
+        let y1 = tv4.pow_vartime(Self::PARAMS.c1) * tv2; // tv4^C1 * tv2
         let x2n = tv3 * x1n; // tv3 * x1n
 
         let y2 = y1 * Self::PARAMS.c2 * tv1 * self; // y1 * c2 * tv1 * u

--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -5,8 +5,15 @@
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg"
 )]
-#![forbid(unsafe_code, clippy::unwrap_used)]
-#![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
+#![forbid(unsafe_code)]
+#![warn(
+    clippy::mod_module_files,
+    clippy::unwrap_used,
+    missing_docs,
+    rust_2018_idioms,
+    unused_lifetimes,
+    unused_qualifications
+)]
 
 //! ## Usage
 //!

--- a/elliptic-curve/src/secret_key.rs
+++ b/elliptic-curve/src/secret_key.rs
@@ -227,7 +227,7 @@ where
             return Err(Error);
         }
 
-        Self::from_sec1_der(&*der_bytes).map_err(|_| Error)
+        Self::from_sec1_der(&der_bytes).map_err(|_| Error)
     }
 
     /// Serialize private key as self-zeroizing PEM-encoded SEC1 `ECPrivateKey`


### PR DESCRIPTION
Adopts the following lints:

```rust
    #![warn(
        clippy::mod_module_files,
        clippy::unwrap_used,
        missing_docs,
        rust_2018_idioms,
        unused_lifetimes,
        unused_qualifications
    )]
```