### PR TITLE
elliptic-curve: add `MulByGenerator` trait

### DIFF
--- a/elliptic-curve/src/arithmetic.rs
+++ b/elliptic-curve/src/arithmetic.rs
@@ -1,7 +1,8 @@
 //! Elliptic curve arithmetic traits.
 
 use crate::{
-    ops::LinearCombination, AffineXCoordinate, Curve, FieldBytes, IsHigh, PrimeCurve, ScalarCore,
+    ops::{LinearCombination, MulByGenerator},
+    AffineXCoordinate, Curve, FieldBytes, IsHigh, PrimeCurve, ScalarCore,
 };
 use core::fmt::Debug;
 use subtle::{ConditionallySelectable, ConstantTimeEq};
@@ -42,6 +43,7 @@ pub trait CurveArithmetic: Curve {
         + From<Self::AffinePoint>
         + Into<Self::AffinePoint>
         + LinearCombination
+        + MulByGenerator
         + group::Curve<AffineRepr = Self::AffinePoint>
         + group::Group<Scalar = Self::Scalar>;
 

--- a/elliptic-curve/src/dev.rs
+++ b/elliptic-curve/src/dev.rs
@@ -6,7 +6,7 @@
 use crate::{
     bigint::{Limb, U256},
     error::{Error, Result},
-    ops::{LinearCombination, Reduce},
+    ops::{LinearCombination, MulByGenerator, Reduce},
     pkcs8,
     rand_core::RngCore,
     sec1::{CompressedPoint, FromEncodedPoint, ToEncodedPoint},
@@ -765,6 +765,8 @@ impl MulAssign<&Scalar> for ProjectivePoint {
         unimplemented!();
     }
 }
+
+impl MulByGenerator for ProjectivePoint {}
 
 impl Neg for ProjectivePoint {
     type Output = ProjectivePoint;

--- a/elliptic-curve/src/ops.rs
+++ b/elliptic-curve/src/ops.rs
@@ -42,6 +42,19 @@ pub trait LinearCombination: Group {
     }
 }
 
+/// Multiplication by the generator.
+///
+/// May use optimizations (e.g. precomputed tables) when available.
+// TODO(tarcieri): replace this with `Group::mul_by_generator``? (see zkcrypto/group#44)
+#[cfg(feature = "arithmetic")]
+pub trait MulByGenerator: Group {
+    /// Multiply by the generator of the prime-order subgroup.
+    #[must_use]
+    fn mul_by_generator(scalar: &Self::Scalar) -> Self {
+        Self::generator() * scalar
+    }
+}
+
 /// Modular reduction.
 pub trait Reduce<Uint: Integer + ArrayEncoding>: Sized {
     /// Perform a modular reduction, returning a field element.


### PR DESCRIPTION
Adds a trait for performing scalar multiplication by the generator point, which may use optimizations (e.g. precomputed tables) when available