### PR TITLE
elliptic-curve: add `AffineYIsOdd` trait

### DIFF
--- a/elliptic-curve/src/arithmetic.rs
+++ b/elliptic-curve/src/arithmetic.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     ops::{LinearCombination, MulByGenerator},
-    AffineXCoordinate, Curve, FieldBytes, IsHigh, PrimeCurve, ScalarCore,
+    AffineXCoordinate, AffineYIsOdd, Curve, FieldBytes, IsHigh, PrimeCurve, ScalarCore,
 };
 use core::fmt::Debug;
 use subtle::{ConditionallySelectable, ConstantTimeEq};
@@ -12,7 +12,8 @@ use zeroize::DefaultIsZeroes;
 pub trait CurveArithmetic: Curve {
     /// Elliptic curve point in affine coordinates.
     type AffinePoint: 'static
-        + AffineXCoordinate<Self>
+        + AffineXCoordinate<FieldRepr = FieldBytes<Self>>
+        + AffineYIsOdd
         + Copy
         + ConditionallySelectable
         + ConstantTimeEq

--- a/elliptic-curve/src/dev.rs
+++ b/elliptic-curve/src/dev.rs
@@ -12,7 +12,7 @@ use crate::{
     sec1::{CompressedPoint, FromEncodedPoint, ToEncodedPoint},
     subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption},
     zeroize::DefaultIsZeroes,
-    AffineXCoordinate, Curve, CurveArithmetic, IsHigh, PrimeCurve,
+    AffineXCoordinate, AffineYIsOdd, Curve, CurveArithmetic, IsHigh, PrimeCurve,
 };
 use core::{
     iter::{Product, Sum},
@@ -377,8 +377,16 @@ pub enum AffinePoint {
     Other(EncodedPoint),
 }
 
-impl AffineXCoordinate<MockCurve> for AffinePoint {
+impl AffineXCoordinate for AffinePoint {
+    type FieldRepr = FieldBytes;
+
     fn x(&self) -> FieldBytes {
+        unimplemented!();
+    }
+}
+
+impl AffineYIsOdd for AffinePoint {
+    fn y_is_odd(&self) -> Choice {
         unimplemented!();
     }
 }

--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -97,7 +97,8 @@ mod jwk;
 pub use crate::{
     error::{Error, Result},
     point::{
-        AffineXCoordinate, DecompactPoint, DecompressPoint, PointCompaction, PointCompression,
+        AffineXCoordinate, AffineYIsOdd, DecompactPoint, DecompressPoint, PointCompaction,
+        PointCompression,
     },
     scalar::{core::ScalarCore, IsHigh},
     secret_key::SecretKey,

--- a/elliptic-curve/src/point.rs
+++ b/elliptic-curve/src/point.rs
@@ -10,9 +10,18 @@ use crate::{Curve, FieldBytes};
 use subtle::{Choice, CtOption};
 
 /// Obtain the affine x-coordinate of an elliptic curve point.
-pub trait AffineXCoordinate<C: Curve> {
+pub trait AffineXCoordinate {
+    /// Field element representation.
+    type FieldRepr: AsRef<[u8]>;
+
     /// Get the affine x-coordinate as a serialized field element.
-    fn x(&self) -> FieldBytes<C>;
+    fn x(&self) -> Self::FieldRepr;
+}
+
+/// Is the affine y-coordinate of this elliptic curve point odd?
+pub trait AffineYIsOdd {
+    /// Is the affine y-coordinate odd?
+    fn y_is_odd(&self) -> Choice;
 }
 
 /// Decompress an elliptic curve point.


### PR DESCRIPTION
This trait is useful for generic point compression implementations which are also useful for a generic implementation of recoverable ECDSA signing, which presently isn't possible due to an inability to query this information