### PR TITLE
elliptic-curve: add generic implemenation of Stein's algorithm

### DIFF
--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -69,6 +69,7 @@ extern crate alloc;
 extern crate std;
 
 pub mod ops;
+pub mod scalar;
 
 #[cfg(feature = "dev")]
 pub mod dev;
@@ -83,7 +84,6 @@ pub mod weierstrass;
 
 mod error;
 mod point;
-mod scalar;
 mod secret_key;
 
 #[cfg(feature = "arithmetic")]
@@ -100,7 +100,7 @@ pub use crate::{
         AffineXCoordinate, AffineYIsOdd, DecompactPoint, DecompressPoint, PointCompaction,
         PointCompression,
     },
-    scalar::{core::ScalarCore, IsHigh},
+    scalar::{IsHigh, ScalarCore},
     secret_key::SecretKey,
 };
 pub use crypto_bigint as bigint;
@@ -114,7 +114,7 @@ pub use {
     crate::{
         arithmetic::{CurveArithmetic, PrimeCurveArithmetic},
         public_key::PublicKey,
-        scalar::{nonzero::NonZeroScalar, Scalar},
+        scalar::{NonZeroScalar, Scalar},
     },
     ff::{self, Field, PrimeField},
     group::{self, Group},

--- a/elliptic-curve/src/ops.rs
+++ b/elliptic-curve/src/ops.rs
@@ -104,3 +104,9 @@ pub trait ReduceNonZero<Uint: Integer + ArrayEncoding>: Sized {
     /// Perform a modular reduction, returning a field element.
     fn from_uint_reduced_nonzero(n: Uint) -> Self;
 }
+
+/// Right shift this value by one, storing the result in-place.
+pub trait Shr1 {
+    /// Right shift this value by one in-place.
+    fn shr1(&mut self);
+}

--- a/elliptic-curve/src/scalar.rs
+++ b/elliptic-curve/src/scalar.rs
@@ -1,14 +1,19 @@
 //! Scalar types.
 
+mod core;
+#[cfg(feature = "arithmetic")]
+mod invert;
+#[cfg(feature = "arithmetic")]
+mod nonzero;
+
+pub use self::core::ScalarCore;
+#[cfg(feature = "arithmetic")]
+pub use self::{invert::invert_vartime, nonzero::NonZeroScalar};
+
 use subtle::Choice;
 
-pub(crate) mod core;
-
 #[cfg(feature = "arithmetic")]
-pub(crate) mod nonzero;
-
-#[cfg(feature = "arithmetic")]
-use crate::CurveArithmetic;
+use crate::{bigint::Integer, CurveArithmetic};
 
 /// Scalar field element for a particular elliptic curve.
 #[cfg(feature = "arithmetic")]
@@ -17,6 +22,20 @@ pub type Scalar<C> = <C as CurveArithmetic>::Scalar;
 /// Bit representation of a scalar field element of a given curve.
 #[cfg(feature = "bits")]
 pub type ScalarBits<C> = ff::FieldBits<<Scalar<C> as ff::PrimeFieldBits>::ReprBits>;
+
+/// Instantiate a scalar from an unsigned integer without checking for overflow.
+#[cfg(feature = "arithmetic")]
+pub trait FromUintUnchecked: ff::Field {
+    /// Unsigned integer type (i.e. `Curve::Uint`)
+    type Uint: Integer;
+
+    /// Instantiate scalar from an unsigned integer without checking
+    /// whether the value overflows the field modulus.
+    ///
+    /// Incorrectly used this can lead to mathematically invalid results.
+    /// Use with care!
+    fn from_uint_unchecked(uint: Self::Uint) -> Self;
+}
 
 /// Is this scalar greater than n / 2?
 ///

--- a/elliptic-curve/src/scalar/invert.rs
+++ b/elliptic-curve/src/scalar/invert.rs
@@ -1,0 +1,60 @@
+use super::FromUintUnchecked;
+use crate::{ops::Shr1, CurveArithmetic, Scalar};
+use ff::{Field, PrimeField};
+use subtle::{ConstantTimeLess, CtOption};
+
+/// Fast variable-time inversion using Stein's algorithm.
+///
+/// <https://link.springer.com/article/10.1007/s13389-016-0135-4>
+#[allow(non_snake_case)]
+pub fn invert_vartime<C>(scalar: &Scalar<C>) -> CtOption<Scalar<C>>
+where
+    C: CurveArithmetic,
+    Scalar<C>: ConstantTimeLess + FromUintUnchecked<Uint = C::Uint> + Shr1,
+{
+    let order_div_2 = Scalar::<C>::from_uint_unchecked(C::ORDER >> 1);
+
+    let mut u = *scalar;
+    let mut v = Scalar::<C>::from_uint_unchecked(C::ORDER); // note: technically invalid
+    let mut A = Scalar::<C>::ONE;
+    let mut C = Scalar::<C>::ZERO;
+
+    while !bool::from(u.is_zero()) {
+        // u-loop
+        while bool::from(u.is_even()) {
+            u.shr1();
+
+            let was_odd: bool = A.is_odd().into();
+            A.shr1();
+
+            if was_odd {
+                A += order_div_2;
+                A += Scalar::<C>::ONE;
+            }
+        }
+
+        // v-loop
+        while bool::from(v.is_even()) {
+            v.shr1();
+
+            let was_odd: bool = C.is_odd().into();
+            C.shr1();
+
+            if was_odd {
+                C += order_div_2;
+                C += Scalar::<C>::ONE;
+            }
+        }
+
+        // sub-step
+        if bool::from(u.ct_lt(&v)) {
+            v -= &u;
+            C -= &A;
+        } else {
+            u -= &v;
+            A -= &C;
+        }
+    }
+
+    CtOption::new(C, !scalar.is_zero())
+}


### PR DESCRIPTION
Extracted from this implementation in the `p256` crate:

https://github.com/RustCrypto/elliptic-curves/blob/1a03b8a/p256/src/arithmetic/scalar.rs#L145-L194