### PR TITLE
elliptic-curve: test docs in CI

### DIFF
--- a/.github/workflows/elliptic-curve.yml
+++ b/.github/workflows/elliptic-curve.yml
@@ -16,6 +16,7 @@ defaults:
 env:
   CARGO_INCREMENTAL: 0
   RUSTFLAGS: "-Dwarnings"
+  RUSTDOCFLAGS: "-Dwarnings"
 
 jobs:
   build:
@@ -93,3 +94,14 @@ jobs:
       - run: cargo test --no-default-features
       - run: cargo test
       - run: cargo test --all-features
+
+  doc:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+          profile: minimal
+      - run: cargo doc --all-features

--- a/elliptic-curve/src/ecdh.rs
+++ b/elliptic-curve/src/ecdh.rs
@@ -1,7 +1,7 @@
 //! Elliptic Curve Diffie-Hellman Support.
 //!
 //! This module contains a generic ECDH implementation which is usable with
-//! any elliptic curve which implements the [`ProjectiveArithmetic`] trait (presently
+//! any elliptic curve which implements the [`CurveArithmetic`] trait (presently
 //! the `k256` and `p256` crates)
 //!
 //! # ECDH Ephemeral (ECDHE) Usage

--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -178,12 +178,12 @@ pub type FieldSize<C> = <<C as Curve>::Uint as bigint::ArrayEncoding>::ByteSize;
 /// Byte representation of a base/scalar field element of a given curve.
 pub type FieldBytes<C> = GenericArray<u8, FieldSize<C>>;
 
-/// Affine point type for a given curve with a [`ProjectiveArithmetic`]
+/// Affine point type for a given curve with a [`CurveArithmetic`]
 /// implementation.
 #[cfg(feature = "arithmetic")]
 pub type AffinePoint<C> = <C as CurveArithmetic>::AffinePoint;
 
-/// Projective point type for a given curve with a [`ProjectiveArithmetic`]
+/// Projective point type for a given curve with a [`CurveArithmetic`]
 /// implementation.
 #[cfg(feature = "arithmetic")]
 pub type ProjectivePoint<C> = <C as CurveArithmetic>::ProjectivePoint;

--- a/elliptic-curve/src/sec1.rs
+++ b/elliptic-curve/src/sec1.rs
@@ -68,7 +68,7 @@ where
 /// Validate that the given [`EncodedPoint`] represents the encoded public key
 /// value of the given secret.
 ///
-/// Curve implementations which also impl [`ProjectiveArithmetic`] will receive
+/// Curve implementations which also impl [`CurveArithmetic`] will receive
 /// a blanket default impl of this trait.
 pub trait ValidatePublicKey
 where

--- a/elliptic-curve/src/secret_key.rs
+++ b/elliptic-curve/src/secret_key.rs
@@ -55,7 +55,7 @@ use crate::{
     FieldSize,
 };
 
-#[cfg(all(docsrs, feature = "pkcs8"))]
+#[cfg(all(doc, feature = "pkcs8"))]
 use {crate::pkcs8::DecodePrivateKey, core::str::FromStr};
 
 /// Type label for PEM-encoded SEC1 private keys.


### PR DESCRIPTION
Ensures `cargo doc` builds successfully