### PR TITLE
elliptic-curve: rename `SecretKey::to_sec1_pem`

### DIFF
--- a/elliptic-curve/src/secret_key.rs
+++ b/elliptic-curve/src/secret_key.rs
@@ -235,7 +235,7 @@ where
     ///
     /// Pass `Default::default()` to use the OS's native line endings.
     #[cfg(feature = "pem")]
-    pub fn to_pem(&self, line_ending: pem::LineEnding) -> Result<Zeroizing<String>>
+    pub fn to_sec1_pem(&self, line_ending: pem::LineEnding) -> Result<Zeroizing<String>>
     where
         C: CurveArithmetic,
         AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,


### PR DESCRIPTION
Was formerly `SecretKey::to_pem` which is ambiguous as to what PEM serialization is used. PKCS#8 is also possible (and preferred).