### PR TITLE
elliptic-curve: rename `ScalarCore` to `ScalarPrimitive`

### DIFF
--- a/elliptic-curve/src/arithmetic.rs
+++ b/elliptic-curve/src/arithmetic.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     ops::{LinearCombination, MulByGenerator},
-    AffineXCoordinate, AffineYIsOdd, Curve, FieldBytes, IsHigh, PrimeCurve, ScalarCore,
+    AffineXCoordinate, AffineYIsOdd, Curve, FieldBytes, IsHigh, PrimeCurve, ScalarPrimitive,
 };
 use core::fmt::Debug;
 use subtle::{ConditionallySelectable, ConstantTimeEq};
@@ -61,7 +61,7 @@ pub trait CurveArithmetic: Curve {
     /// - [`Send`]
     /// - [`Sync`]
     type Scalar: DefaultIsZeroes
-        + From<ScalarCore<Self>>
+        + From<ScalarPrimitive<Self>>
         + Into<FieldBytes<Self>>
         + Into<Self::Uint>
         + IsHigh

--- a/elliptic-curve/src/dev.rs
+++ b/elliptic-curve/src/dev.rs
@@ -47,9 +47,9 @@ pub type PublicKey = crate::PublicKey<MockCurve>;
 /// Secret key.
 pub type SecretKey = crate::SecretKey<MockCurve>;
 
-/// Scalar core.
-// TODO(tarcieri): make this the scalar type
-pub type ScalarCore = crate::ScalarCore<MockCurve>;
+/// Scalar primitive type.
+// TODO(tarcieri): make this the scalar type when it's more capable
+pub type ScalarPrimitive = crate::ScalarPrimitive<MockCurve>;
 
 /// Scalar bits.
 #[cfg(feature = "bits")]
@@ -90,11 +90,11 @@ impl JwkParameters for MockCurve {
 
 /// Example scalar type
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
-pub struct Scalar(ScalarCore);
+pub struct Scalar(ScalarPrimitive);
 
 impl Field for Scalar {
-    const ZERO: Self = Self(ScalarCore::ZERO);
-    const ONE: Self = Self(ScalarCore::ONE);
+    const ZERO: Self = Self(ScalarPrimitive::ZERO);
+    const ONE: Self = Self(ScalarPrimitive::ONE);
 
     fn random(mut rng: impl RngCore) -> Self {
         let mut bytes = FieldBytes::default();
@@ -149,7 +149,7 @@ impl PrimeField for Scalar {
     const DELTA: Self = Self::ZERO; // BOGUS!
 
     fn from_repr(bytes: FieldBytes) -> CtOption<Self> {
-        ScalarCore::from_be_bytes(bytes).map(Self)
+        ScalarPrimitive::from_be_bytes(bytes).map(Self)
     }
 
     fn to_repr(&self) -> FieldBytes {
@@ -182,7 +182,7 @@ impl TryFrom<U256> for Scalar {
     type Error = Error;
 
     fn try_from(w: U256) -> Result<Self> {
-        Option::from(ScalarCore::new(w)).map(Self).ok_or(Error)
+        Option::from(ScalarPrimitive::new(w)).map(Self).ok_or(Error)
     }
 }
 
@@ -194,7 +194,7 @@ impl From<Scalar> for U256 {
 
 impl ConditionallySelectable for Scalar {
     fn conditional_select(a: &Self, b: &Self, choice: Choice) -> Self {
-        Self(ScalarCore::conditional_select(&a.0, &b.0, choice))
+        Self(ScalarPrimitive::conditional_select(&a.0, &b.0, choice))
     }
 }
 
@@ -327,7 +327,7 @@ impl Reduce<U256> for Scalar {
         let (r, underflow) = w.sbb(&MockCurve::ORDER, Limb::ZERO);
         let underflow = Choice::from((underflow.0 >> (Limb::BITS - 1)) as u8);
         let reduced = U256::conditional_select(&w, &r, !underflow);
-        Self(ScalarCore::new(reduced).unwrap())
+        Self(ScalarPrimitive::new(reduced).unwrap())
     }
 }
 
@@ -337,8 +337,8 @@ impl From<u64> for Scalar {
     }
 }
 
-impl From<ScalarCore> for Scalar {
-    fn from(scalar: ScalarCore) -> Scalar {
+impl From<ScalarPrimitive> for Scalar {
+    fn from(scalar: ScalarPrimitive) -> Scalar {
         Self(scalar)
     }
 }

--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -49,7 +49,7 @@
 //!
 //! - [`JwkEcKey`]
 //! - [`PublicKey`]
-//! - [`ScalarCore`]
+//! - [`ScalarPrimitive`]
 //!
 //! Please see type-specific documentation for more information.
 //!
@@ -100,7 +100,7 @@ pub use crate::{
         AffineXCoordinate, AffineYIsOdd, DecompactPoint, DecompressPoint, PointCompaction,
         PointCompression,
     },
-    scalar::{IsHigh, ScalarCore},
+    scalar::{IsHigh, ScalarPrimitive},
     secret_key::SecretKey,
 };
 pub use crypto_bigint as bigint;

--- a/elliptic-curve/src/scalar.rs
+++ b/elliptic-curve/src/scalar.rs
@@ -1,12 +1,12 @@
 //! Scalar types.
 
-mod core;
 #[cfg(feature = "arithmetic")]
 mod invert;
 #[cfg(feature = "arithmetic")]
 mod nonzero;
+mod primitive;
 
-pub use self::core::ScalarCore;
+pub use self::primitive::ScalarPrimitive;
 #[cfg(feature = "arithmetic")]
 pub use self::{invert::invert_vartime, nonzero::NonZeroScalar};
 

--- a/elliptic-curve/src/scalar/nonzero.rs
+++ b/elliptic-curve/src/scalar/nonzero.rs
@@ -3,7 +3,7 @@
 use crate::{
     ops::{Invert, Reduce, ReduceNonZero},
     rand_core::{CryptoRng, RngCore},
-    CurveArithmetic, Error, FieldBytes, IsHigh, PrimeCurve, Scalar, ScalarCore, SecretKey,
+    CurveArithmetic, Error, FieldBytes, IsHigh, PrimeCurve, Scalar, ScalarPrimitive, SecretKey,
 };
 use base16ct::HexDisplay;
 use core::{
@@ -64,7 +64,7 @@ where
 
     /// Create a [`NonZeroScalar`] from a `C::Uint`.
     pub fn from_uint(uint: C::Uint) -> CtOption<Self> {
-        ScalarCore::new(uint).and_then(|scalar| Self::new(scalar.into()))
+        ScalarPrimitive::new(uint).and_then(|scalar| Self::new(scalar.into()))
     }
 }
 
@@ -128,21 +128,21 @@ where
     }
 }
 
-impl<C> From<NonZeroScalar<C>> for ScalarCore<C>
+impl<C> From<NonZeroScalar<C>> for ScalarPrimitive<C>
 where
     C: CurveArithmetic,
 {
-    fn from(scalar: NonZeroScalar<C>) -> ScalarCore<C> {
-        ScalarCore::from_be_bytes(scalar.to_repr()).unwrap()
+    fn from(scalar: NonZeroScalar<C>) -> ScalarPrimitive<C> {
+        ScalarPrimitive::from_be_bytes(scalar.to_repr()).unwrap()
     }
 }
 
-impl<C> From<&NonZeroScalar<C>> for ScalarCore<C>
+impl<C> From<&NonZeroScalar<C>> for ScalarPrimitive<C>
 where
     C: CurveArithmetic,
 {
-    fn from(scalar: &NonZeroScalar<C>) -> ScalarCore<C> {
-        ScalarCore::from_be_bytes(scalar.to_repr()).unwrap()
+    fn from(scalar: &NonZeroScalar<C>) -> ScalarPrimitive<C> {
+        ScalarPrimitive::from_be_bytes(scalar.to_repr()).unwrap()
     }
 }
 
@@ -339,7 +339,7 @@ where
     where
         S: ser::Serializer,
     {
-        ScalarCore::from(self).serialize(serializer)
+        ScalarPrimitive::from(self).serialize(serializer)
     }
 }
 
@@ -352,7 +352,8 @@ where
     where
         D: de::Deserializer<'de>,
     {
-        Option::from(Self::new(ScalarCore::deserialize(deserializer)?.into()))
+        let scalar = ScalarPrimitive::deserialize(deserializer)?;
+        Option::from(Self::new(scalar.into()))
             .ok_or_else(|| de::Error::custom("expected non-zero scalar"))
     }
 }

--- a/elliptic-curve/src/secret_key.rs
+++ b/elliptic-curve/src/secret_key.rs
@@ -8,7 +8,7 @@
 #[cfg(all(feature = "pkcs8", feature = "sec1"))]
 mod pkcs8;
 
-use crate::{Curve, Error, FieldBytes, Result, ScalarCore};
+use crate::{Curve, Error, FieldBytes, Result, ScalarPrimitive};
 use core::fmt::{self, Debug};
 use crypto_bigint::Integer;
 use generic_array::GenericArray;
@@ -88,7 +88,7 @@ pub(crate) const SEC1_PEM_TYPE_LABEL: &str = "EC PRIVATE KEY";
 #[derive(Clone)]
 pub struct SecretKey<C: Curve> {
     /// Scalar value
-    inner: ScalarCore<C>,
+    inner: ScalarPrimitive<C>,
 }
 
 impl<C> SecretKey<C>
@@ -107,18 +107,18 @@ where
     }
 
     /// Create a new secret key from a scalar value.
-    pub fn new(scalar: ScalarCore<C>) -> Self {
+    pub fn new(scalar: ScalarPrimitive<C>) -> Self {
         Self { inner: scalar }
     }
 
-    /// Borrow the inner secret [`ScalarCore`] value.
+    /// Borrow the inner secret [`ScalarPrimitive`] value.
     ///
     /// # ⚠️ Warning
     ///
     /// This value is key material.
     ///
     /// Please treat it with the care it deserves!
-    pub fn as_scalar_core(&self) -> &ScalarCore<C> {
+    pub fn as_scalar_core(&self) -> &ScalarPrimitive<C> {
         &self.inner
     }
 
@@ -152,7 +152,7 @@ where
             return Err(Error);
         }
 
-        let inner: ScalarCore<C> = Option::from(ScalarCore::from_be_bytes(
+        let inner: ScalarPrimitive<C> = Option::from(ScalarPrimitive::from_be_bytes(
             GenericArray::clone_from_slice(bytes),
         ))
         .ok_or(Error)?;


### PR DESCRIPTION
This is a slightly more descriptive name: `ScalarPrimitive` is a scalar type with primitive functionality.