### PR TITLE
elliptic-curve: mandate `scalar::FromUintUnchecked`

### DIFF
--- a/elliptic-curve/src/arithmetic.rs
+++ b/elliptic-curve/src/arithmetic.rs
@@ -2,6 +2,7 @@
 
 use crate::{
     ops::{LinearCombination, MulByGenerator},
+    scalar::FromUintUnchecked,
     AffineXCoordinate, AffineYIsOdd, Curve, FieldBytes, IsHigh, PrimeCurve, ScalarPrimitive,
 };
 use core::fmt::Debug;
@@ -62,8 +63,10 @@ pub trait CurveArithmetic: Curve {
     /// - [`Sync`]
     type Scalar: DefaultIsZeroes
         + From<ScalarPrimitive<Self>>
+        + FromUintUnchecked<Uint = Self::Uint>
         + Into<FieldBytes<Self>>
         + Into<Self::Uint>
+        + Into<ScalarPrimitive<Self>>
         + IsHigh
         + ff::Field
         + ff::PrimeField<Repr = FieldBytes<Self>>;

--- a/elliptic-curve/src/dev.rs
+++ b/elliptic-curve/src/dev.rs
@@ -9,6 +9,7 @@ use crate::{
     ops::{LinearCombination, MulByGenerator, Reduce},
     pkcs8,
     rand_core::RngCore,
+    scalar::FromUintUnchecked,
     sec1::{CompressedPoint, FromEncodedPoint, ToEncodedPoint},
     subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption},
     zeroize::DefaultIsZeroes,
@@ -178,20 +179,6 @@ impl PrimeFieldBits for Scalar {
     }
 }
 
-impl TryFrom<U256> for Scalar {
-    type Error = Error;
-
-    fn try_from(w: U256) -> Result<Self> {
-        Option::from(ScalarPrimitive::new(w)).map(Self).ok_or(Error)
-    }
-}
-
-impl From<Scalar> for U256 {
-    fn from(scalar: Scalar) -> U256 {
-        *scalar.0.as_uint()
-    }
-}
-
 impl ConditionallySelectable for Scalar {
     fn conditional_select(a: &Self, b: &Self, choice: Choice) -> Self {
         Self(ScalarPrimitive::conditional_select(&a.0, &b.0, choice))
@@ -340,6 +327,34 @@ impl From<u64> for Scalar {
 impl From<ScalarPrimitive> for Scalar {
     fn from(scalar: ScalarPrimitive) -> Scalar {
         Self(scalar)
+    }
+}
+
+impl From<Scalar> for ScalarPrimitive {
+    fn from(scalar: Scalar) -> ScalarPrimitive {
+        scalar.0
+    }
+}
+
+impl From<Scalar> for U256 {
+    fn from(scalar: Scalar) -> U256 {
+        scalar.0.to_uint()
+    }
+}
+
+impl TryFrom<U256> for Scalar {
+    type Error = Error;
+
+    fn try_from(w: U256) -> Result<Self> {
+        Option::from(ScalarPrimitive::new(w)).map(Self).ok_or(Error)
+    }
+}
+
+impl FromUintUnchecked for Scalar {
+    type Uint = U256;
+
+    fn from_uint_unchecked(uint: U256) -> Self {
+        Self(ScalarPrimitive::from_uint_unchecked(uint))
     }
 }
 

--- a/elliptic-curve/src/scalar.rs
+++ b/elliptic-curve/src/scalar.rs
@@ -10,10 +10,11 @@ pub use self::primitive::ScalarPrimitive;
 #[cfg(feature = "arithmetic")]
 pub use self::{invert::invert_vartime, nonzero::NonZeroScalar};
 
+use crypto_bigint::Integer;
 use subtle::Choice;
 
 #[cfg(feature = "arithmetic")]
-use crate::{bigint::Integer, CurveArithmetic};
+use crate::CurveArithmetic;
 
 /// Scalar field element for a particular elliptic curve.
 #[cfg(feature = "arithmetic")]
@@ -24,8 +25,7 @@ pub type Scalar<C> = <C as CurveArithmetic>::Scalar;
 pub type ScalarBits<C> = ff::FieldBits<<Scalar<C> as ff::PrimeFieldBits>::ReprBits>;
 
 /// Instantiate a scalar from an unsigned integer without checking for overflow.
-#[cfg(feature = "arithmetic")]
-pub trait FromUintUnchecked: ff::Field {
+pub trait FromUintUnchecked {
     /// Unsigned integer type (i.e. `Curve::Uint`)
     type Uint: Integer;
 


### PR DESCRIPTION
Bounds `CurveArithmetic::Scalar` on this trait and uses it to simplify conversions to/from `ScalarPrimitive`.

Also adds bounds to ensure `ScalarPrimitive` conversions are bidirectional.