### PR TITLE
elliptic-curve: use `CryptoRngCore` trait

### DIFF
--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -19,7 +19,7 @@ rust-version = "1.61"
 base16ct = "0.1.1"
 crypto-bigint = { version = "=0.5.0-pre.1", default-features = false, features = ["rand_core", "generic-array", "zeroize"] }
 generic-array = { version = "0.14", default-features = false }
-rand_core = { version = "0.6", default-features = false }
+rand_core = { version = "0.6.4", default-features = false }
 subtle = { version = "2", default-features = false }
 zeroize = { version = "1.5", default-features = false }
 

--- a/elliptic-curve/src/ecdh.rs
+++ b/elliptic-curve/src/ecdh.rs
@@ -34,7 +34,7 @@ use core::borrow::Borrow;
 use digest::{crypto_common::BlockSizeUser, Digest};
 use group::Curve as _;
 use hkdf::{hmac::SimpleHmac, Hkdf};
-use rand_core::{CryptoRng, RngCore};
+use rand_core::CryptoRngCore;
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
 /// Low-level Elliptic Curve Diffie-Hellman (ECDH) function.
@@ -102,7 +102,7 @@ where
     C: CurveArithmetic,
 {
     /// Generate a cryptographically random [`EphemeralSecret`].
-    pub fn random(rng: impl CryptoRng + RngCore) -> Self {
+    pub fn random(rng: &mut impl CryptoRngCore) -> Self {
         Self {
             scalar: NonZeroScalar::random(rng),
         }

--- a/elliptic-curve/src/scalar/nonzero.rs
+++ b/elliptic-curve/src/scalar/nonzero.rs
@@ -2,7 +2,6 @@
 
 use crate::{
     ops::{Invert, Reduce, ReduceNonZero},
-    rand_core::{CryptoRng, RngCore},
     CurveArithmetic, Error, FieldBytes, IsHigh, PrimeCurve, Scalar, ScalarPrimitive, SecretKey,
 };
 use base16ct::HexDisplay;
@@ -14,6 +13,7 @@ use core::{
 use crypto_bigint::{ArrayEncoding, Integer};
 use ff::{Field, PrimeField};
 use generic_array::GenericArray;
+use rand_core::CryptoRngCore;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 use zeroize::Zeroize;
 
@@ -41,7 +41,7 @@ where
     C: CurveArithmetic,
 {
     /// Generate a random `NonZeroScalar`.
-    pub fn random(mut rng: impl CryptoRng + RngCore) -> Self {
+    pub fn random(mut rng: &mut impl CryptoRngCore) -> Self {
         // Use rejection sampling to eliminate zero values.
         // While this method isn't constant-time, the attacker shouldn't learn
         // anything about unrelated outputs so long as `rng` is a secure `CryptoRng`.

--- a/elliptic-curve/src/scalar/primitive.rs
+++ b/elliptic-curve/src/scalar/primitive.rs
@@ -13,7 +13,7 @@ use core::{
     str,
 };
 use generic_array::GenericArray;
-use rand_core::{CryptoRng, RngCore};
+use rand_core::CryptoRngCore;
 use subtle::{
     Choice, ConditionallySelectable, ConstantTimeEq, ConstantTimeGreater, ConstantTimeLess,
     CtOption,
@@ -64,7 +64,7 @@ where
     pub const MODULUS: C::Uint = C::ORDER;
 
     /// Generate a random [`ScalarPrimitive`].
-    pub fn random(rng: impl CryptoRng + RngCore) -> Self {
+    pub fn random(rng: &mut impl CryptoRngCore) -> Self {
         Self {
             inner: C::Uint::random_mod(rng, &NonZero::new(Self::MODULUS).unwrap()),
         }

--- a/elliptic-curve/src/secret_key.rs
+++ b/elliptic-curve/src/secret_key.rs
@@ -26,10 +26,7 @@ use {
 };
 
 #[cfg(feature = "arithmetic")]
-use crate::{
-    rand_core::{CryptoRng, RngCore},
-    CurveArithmetic, NonZeroScalar, PublicKey,
-};
+use crate::{rand_core::CryptoRngCore, CurveArithmetic, NonZeroScalar, PublicKey};
 
 #[cfg(feature = "jwk")]
 use crate::jwk::{JwkEcKey, JwkParameters};
@@ -97,7 +94,7 @@ where
 {
     /// Generate a random [`SecretKey`].
     #[cfg(feature = "arithmetic")]
-    pub fn random(rng: impl CryptoRng + RngCore) -> Self
+    pub fn random(rng: &mut impl CryptoRngCore) -> Self
     where
         C: CurveArithmetic,
     {


### PR DESCRIPTION
Marker trait for `CryptoRng + RngCore`; added in `rand_core` v0.6.4