### PR TITLE
elliptic-curve: add `NonZeroScalar::invert_vartime`

### DIFF
--- a/elliptic-curve/src/arithmetic.rs
+++ b/elliptic-curve/src/arithmetic.rs
@@ -1,7 +1,7 @@
 //! Elliptic curve arithmetic traits.
 
 use crate::{
-    ops::{LinearCombination, MulByGenerator},
+    ops::{LinearCombination, MulByGenerator, Shr1},
     scalar::FromUintUnchecked,
     AffineXCoordinate, AffineYIsOdd, Curve, FieldBytes, IsHigh, PrimeCurve, ScalarPrimitive,
 };
@@ -65,9 +65,11 @@ pub trait CurveArithmetic: Curve {
         + From<ScalarPrimitive<Self>>
         + FromUintUnchecked<Uint = Self::Uint>
         + Into<FieldBytes<Self>>
-        + Into<Self::Uint>
         + Into<ScalarPrimitive<Self>>
+        + Into<Self::Uint>
         + IsHigh
+        + PartialOrd
+        + Shr1
         + ff::Field
         + ff::PrimeField<Repr = FieldBytes<Self>>;
 }

--- a/elliptic-curve/src/dev.rs
+++ b/elliptic-curve/src/dev.rs
@@ -6,7 +6,7 @@
 use crate::{
     bigint::{Limb, U256},
     error::{Error, Result},
-    ops::{LinearCombination, MulByGenerator, Reduce},
+    ops::{LinearCombination, MulByGenerator, Reduce, Shr1},
     pkcs8,
     rand_core::RngCore,
     scalar::FromUintUnchecked,
@@ -90,7 +90,7 @@ impl JwkParameters for MockCurve {
 }
 
 /// Example scalar type
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, PartialOrd, Ord)]
 pub struct Scalar(ScalarPrimitive);
 
 impl Field for Scalar {
@@ -282,6 +282,12 @@ impl Neg for Scalar {
 
     fn neg(self) -> Scalar {
         Self(self.0.neg())
+    }
+}
+
+impl Shr1 for Scalar {
+    fn shr1(&mut self) {
+        self.0.shr1();
     }
 }
 

--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -129,7 +129,7 @@ pub use crate::jwk::{JwkEcKey, JwkParameters};
 #[cfg(feature = "pkcs8")]
 pub use pkcs8;
 
-use core::fmt::Debug;
+use core::{fmt::Debug, ops::ShrAssign};
 use generic_array::GenericArray;
 
 /// Algorithm [`ObjectIdentifier`][`pkcs8::ObjectIdentifier`] for elliptic
@@ -160,7 +160,8 @@ pub trait Curve: 'static + Copy + Clone + Debug + Default + Eq + Ord + Send + Sy
         + bigint::Random
         + bigint::RandomMod
         + bigint::SubMod<Output = Self::Uint>
-        + zeroize::Zeroize;
+        + zeroize::Zeroize
+        + ShrAssign<usize>;
 
     /// Order constant.
     ///

--- a/elliptic-curve/src/ops.rs
+++ b/elliptic-curve/src/ops.rs
@@ -105,8 +105,8 @@ pub trait ReduceNonZero<Uint: Integer + ArrayEncoding>: Sized {
     fn from_uint_reduced_nonzero(n: Uint) -> Self;
 }
 
-/// Right shift this value by one, storing the result in-place.
+/// Right shift this value by one bit, storing the result in-place.
 pub trait Shr1 {
-    /// Right shift this value by one in-place.
+    /// Right shift this value by one bit in-place.
     fn shr1(&mut self);
 }

--- a/elliptic-curve/src/scalar.rs
+++ b/elliptic-curve/src/scalar.rs
@@ -32,7 +32,11 @@ pub trait FromUintUnchecked {
     /// Instantiate scalar from an unsigned integer without checking
     /// whether the value overflows the field modulus.
     ///
-    /// Incorrectly used this can lead to mathematically invalid results.
+    /// ⚠️ WARNING!
+    ///
+    /// Incorrectly used this can lead to mathematically invalid results,
+    /// which can lead to potential security vulnerabilities.
+    ///
     /// Use with care!
     fn from_uint_unchecked(uint: Self::Uint) -> Self;
 }

--- a/elliptic-curve/src/scalar/nonzero.rs
+++ b/elliptic-curve/src/scalar/nonzero.rs
@@ -66,6 +66,19 @@ where
     pub fn from_uint(uint: C::Uint) -> CtOption<Self> {
         ScalarPrimitive::new(uint).and_then(|scalar| Self::new(scalar.into()))
     }
+
+    /// Perform an inversion in variable-time.
+    ///
+    /// ⚠️ WARNING!
+    ///
+    /// This method should not be used with (unblinded) secret scalars, as its
+    /// variable-time operation can potentially leak secrets through
+    /// sidechannels.
+    pub fn invert_vartime(&self) -> Self {
+        Self {
+            scalar: super::invert_vartime::<C>(&self.scalar).expect("nonzero input"),
+        }
+    }
 }
 
 impl<C> AsRef<Scalar<C>> for NonZeroScalar<C>

--- a/elliptic-curve/src/scalar/primitive.rs
+++ b/elliptic-curve/src/scalar/primitive.rs
@@ -2,16 +2,12 @@
 
 use crate::{
     bigint::{prelude::*, Limb, NonZero},
+    ops::{Add, AddAssign, Neg, Shr1, Sub, SubAssign},
     scalar::FromUintUnchecked,
     Curve, Error, FieldBytes, IsHigh, Result,
 };
 use base16ct::HexDisplay;
-use core::{
-    cmp::Ordering,
-    fmt,
-    ops::{Add, AddAssign, Neg, Sub, SubAssign},
-    str,
-};
+use core::{cmp::Ordering, fmt, str};
 use generic_array::GenericArray;
 use rand_core::CryptoRngCore;
 use subtle::{
@@ -361,6 +357,15 @@ where
 
     fn neg(self) -> ScalarPrimitive<C> {
         -*self
+    }
+}
+
+impl<C> Shr1 for ScalarPrimitive<C>
+where
+    C: Curve,
+{
+    fn shr1(&mut self) {
+        self.inner >>= 1;
     }
 }
 


### PR DESCRIPTION
Adds support for variable-time inversions of `NonZeroScalar`, which allows the inversion to be infallible.

An example use case is ECDSA verification, where the `s` component of the signature needs to be inverted.