### PR TITLE
signature: use `doc_auto_cfg`

### DIFF
--- a/.github/workflows/signature.yml
+++ b/.github/workflows/signature.yml
@@ -15,6 +15,7 @@ defaults:
 env:
   CARGO_INCREMENTAL: 0
   RUSTFLAGS: "-Dwarnings"
+  RUSTDOCFLAGS: "-Dwarnings"
 
 jobs:
   build:
@@ -84,3 +85,14 @@ jobs:
           profile: minimal
       - run: cargo test --release
         working-directory: signature/derive
+
+  doc:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+          profile: minimal
+      - run: cargo doc --all-features

--- a/signature/README.md
+++ b/signature/README.md
@@ -61,6 +61,7 @@ dual licensed as above, without any additional terms or conditions.
 
 [//]: # (links)
 
+[RustCrypto]: https://github.com/RustCrypto/
 [digital signatures]: https://en.wikipedia.org/wiki/Digital_signature
 [`dsa`]: https://github.com/RustCrypto/signatures/tree/master/dsa
 [`ecdsa`]: https://github.com/RustCrypto/signatures/tree/master/ecdsa

--- a/signature/async/src/lib.rs
+++ b/signature/async/src/lib.rs
@@ -3,7 +3,7 @@
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg"
 )]
-#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
 
@@ -47,7 +47,6 @@ where
 ///
 /// This trait is an async equivalent of the [`signature::DigestSigner`] trait.
 #[cfg(feature = "digest")]
-#[cfg_attr(docsrs, doc(cfg(feature = "digest")))]
 #[async_trait]
 pub trait AsyncDigestSigner<D, S>
 where

--- a/signature/src/encoding.rs
+++ b/signature/src/encoding.rs
@@ -20,7 +20,6 @@ pub trait SignatureEncoding:
 
     /// Encode signature as a byte vector.
     #[cfg(feature = "alloc")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     fn to_vec(&self) -> Vec<u8> {
         self.to_bytes().as_ref().to_vec()
     }

--- a/signature/src/error.rs
+++ b/signature/src/error.rs
@@ -42,7 +42,6 @@ impl Error {
     /// cases are for propagating errors related to external signers, e.g.
     /// communication/authentication errors with HSMs, KMS, etc.
     #[cfg(feature = "std")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     pub fn from_source(
         source: impl Into<Box<dyn std::error::Error + Send + Sync + 'static>>,
     ) -> Self {

--- a/signature/src/hazmat.rs
+++ b/signature/src/hazmat.rs
@@ -34,7 +34,6 @@ pub trait PrehashSigner<S> {
 
 /// Sign the provided message prehash using the provided external randomness source, returning a digital signature.
 #[cfg(feature = "rand-preview")]
-#[cfg_attr(docsrs, doc(cfg(feature = "rand-preview")))]
 pub trait RandomizedPrehashSigner<S> {
     /// Attempt to sign the given message digest, returning a digital signature
     /// on success, or an error if something went wrong.

--- a/signature/src/lib.rs
+++ b/signature/src/lib.rs
@@ -4,7 +4,7 @@
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg"
 )]
-#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
 
@@ -162,16 +162,13 @@ mod prehash_signature;
 pub use crate::{encoding::*, error::*, keypair::*, signer::*, verifier::*};
 
 #[cfg(feature = "derive")]
-#[cfg_attr(docsrs, doc(cfg(feature = "derive")))]
 pub use derive::{Signer, Verifier};
 
 #[cfg(all(feature = "derive", feature = "digest-preview"))]
-#[cfg_attr(docsrs, doc(cfg(all(feature = "derive", feature = "digest-preview"))))]
 pub use derive::{DigestSigner, DigestVerifier};
 
 #[cfg(feature = "digest-preview")]
 pub use {crate::prehash_signature::*, digest};
 
 #[cfg(feature = "rand-preview")]
-#[cfg_attr(docsrs, doc(cfg(feature = "rand-preview")))]
 pub use rand_core;

--- a/signature/src/prehash_signature.rs
+++ b/signature/src/prehash_signature.rs
@@ -25,7 +25,6 @@ use crate::{
 /// types which impl [`DigestVerifier`].
 ///
 /// [Fiat-Shamir heuristic]: https://en.wikipedia.org/wiki/Fiat%E2%80%93Shamir_heuristic
-#[cfg_attr(docsrs, doc(cfg(feature = "digest")))]
 pub trait PrehashSignature {
     /// Preferred `Digest` algorithm to use when computing this signature type.
     type Digest: digest::Digest;

--- a/signature/src/signer.rs
+++ b/signature/src/signer.rs
@@ -24,10 +24,11 @@ pub trait Signer<S> {
     fn try_sign(&self, msg: &[u8]) -> Result<S, Error>;
 }
 
-/// Sign the provided message bytestring using `&mut Self` (e.g., an evolving
-/// cryptographic key), returning a digital signature.
+/// Sign the provided message bytestring using `&mut Self` (e.g. an evolving
+/// cryptographic key such as a stateful hash-based signature), returning a
+/// digital signature.
 pub trait SignerMut<S> {
-    /// Sign the given message, update the state, and return a digital signature
+    /// Sign the given message, update the state, and return a digital signature.
     fn sign(&mut self, msg: &[u8]) -> S {
         self.try_sign(msg).expect("signature operation failed")
     }
@@ -67,7 +68,6 @@ impl<S, T: Signer<S>> SignerMut<S> for T {
 ///
 /// [Fiat-Shamir heuristic]: https://en.wikipedia.org/wiki/Fiat%E2%80%93Shamir_heuristic
 #[cfg(feature = "digest-preview")]
-#[cfg_attr(docsrs, doc(cfg(feature = "digest-preview")))]
 pub trait DigestSigner<D: Digest, S> {
     /// Sign the given prehashed message [`Digest`], returning a signature.
     ///
@@ -84,7 +84,6 @@ pub trait DigestSigner<D: Digest, S> {
 
 /// Sign the given message using the provided external randomness source.
 #[cfg(feature = "rand-preview")]
-#[cfg_attr(docsrs, doc(cfg(feature = "rand-preview")))]
 pub trait RandomizedSigner<S> {
     /// Sign the given message and return a digital signature
     fn sign_with_rng(&self, rng: &mut impl CryptoRngCore, msg: &[u8]) -> S {
@@ -103,8 +102,6 @@ pub trait RandomizedSigner<S> {
 /// Combination of [`DigestSigner`] and [`RandomizedSigner`] with support for
 /// computing a signature over a digest which requires entropy from an RNG.
 #[cfg(all(feature = "digest-preview", feature = "rand-preview"))]
-#[cfg_attr(docsrs, doc(cfg(feature = "digest-preview")))]
-#[cfg_attr(docsrs, doc(cfg(feature = "rand-preview")))]
 pub trait RandomizedDigestSigner<D: Digest, S> {
     /// Sign the given prehashed message `Digest`, returning a signature.
     ///

--- a/signature/src/verifier.rs
+++ b/signature/src/verifier.rs
@@ -35,7 +35,6 @@ pub trait Verifier<S> {
 ///
 /// [Fiat-Shamir heuristic]: https://en.wikipedia.org/wiki/Fiat%E2%80%93Shamir_heuristic
 #[cfg(feature = "digest-preview")]
-#[cfg_attr(docsrs, doc(cfg(feature = "digest-preview")))]
 pub trait DigestVerifier<D: Digest, S> {
     /// Verify the signature against the given [`Digest`] output.
     fn verify_digest(&self, digest: D, signature: &S) -> Result<(), Error>;


### PR DESCRIPTION
Replaces manual (redundant) feature annotations with automatic feature documentation.

This will hopefully be stable soon as `#[doc(auto_cfg)]`