### PR TITLE
signature v2.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,7 +53,7 @@ name = "async-signature"
 version = "0.3.0-pre"
 dependencies = [
  "async-trait",
- "signature 2.0.0-rc.1",
+ "signature 2.0.0",
 ]
 
 [[package]]
@@ -255,7 +255,7 @@ dependencies = [
  "digest 0.10.6",
  "elliptic-curve 0.12.3",
  "password-hash",
- "signature 2.0.0-rc.1",
+ "signature 2.0.0",
  "universal-hash 0.5.0",
 ]
 
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "2.0.0-rc.1"
+version = "2.0.0"
 dependencies = [
  "digest 0.10.6",
  "hex-literal",
@@ -968,7 +968,7 @@ dependencies = [
 
 [[package]]
 name = "signature_derive"
-version = "2.0.0-pre.0"
+version = "2.0.0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -23,7 +23,7 @@ cipher = { version = "0.4", optional = true }
 digest = { version = "0.10", optional = true, features = ["mac"] }
 elliptic-curve = { version = "0.12", optional = true } # path = "../elliptic-curve"
 password-hash = { version = "=0.5.0-pre.0", optional = true, path = "../password-hash" }
-signature = { version = "=2.0.0-rc.1", optional = true, default-features = false, path = "../signature" }
+signature = { version = "2", optional = true, default-features = false, path = "../signature" }
 universal-hash = { version = "0.5", optional = true, path = "../universal-hash" }
 
 [features]

--- a/signature/CHANGELOG.md
+++ b/signature/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.0.0 (2023-01-15)
+### Added
+- `SignatureEncoding` trait as a replacement for `Signature` trait and the
+  now removed `AsRef<[u8]>` bound on signatures ([#1141])
+- New `Keypair` trait which returns owned keys instead of borrowed ([#1141])
+
+### Changed
+- `derive-preview` has been renamed to `derive` and stabilized ([#1141])
+- `digest-preview` renamed to `digest`, still unstable ([#1210])
+- `hazmat-preview` feature stabilized and removed, always on ([#1141])
+- `rand-preview` renamed to `rand_core`, still unstable ([#1210])
+- `std` feature is no longer enabled by default ([#1141])
+- Old `Keypair` trait renamed to `KeypairRef` ([#1141])
+- Signature generic parameter removed from `Keypair`/`KeypairRef` ([#1141])
+- Use `&mut impl CryptoRngCore` RNG arguments ([#1147])
+
+### Removed
+- `Signature` trait - replaced by `SignatureEncoding` ([#1141])
+- `hazmat-preview` feature, now always on ([#1141])
+
+[#1141]: https://github.com/RustCrypto/traits/pull/1141
+[#1147]: https://github.com/RustCrypto/traits/pull/1147
+[#1210]: https://github.com/RustCrypto/traits/pull/1141
+
 ## 1.6.4 (2022-10-06)
 ### Added
 - `RandomizedPrehashSigner` trait in `hazmat` module ([#1130])

--- a/signature/Cargo.toml
+++ b/signature/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name          = "signature"
 description   = "Traits for cryptographic signature algorithms (e.g. ECDSA, Ed25519)"
-version       = "2.0.0-rc.1"
+version       = "2.0.0"
 authors       = ["RustCrypto Developers"]
 license       = "Apache-2.0 OR MIT"
 documentation = "https://docs.rs/signature"
@@ -13,7 +13,7 @@ keywords      = ["crypto", "ecdsa", "ed25519", "signature", "signing"]
 categories    = ["cryptography", "no-std"]
 
 [dependencies]
-derive = { package = "signature_derive", version = "=2.0.0-pre.0", optional = true, path = "derive" }
+derive = { package = "signature_derive", version = "2", optional = true, path = "derive" }
 digest = { version = "0.10.6", optional = true, default-features = false }
 rand_core = { version = "0.6.4", optional = true, default-features = false }
 

--- a/signature/LICENSE-MIT
+++ b/signature/LICENSE-MIT
@@ -1,4 +1,4 @@
-Copyright (c) 2018-2022 RustCrypto Developers
+Copyright (c) 2018-2023 RustCrypto Developers
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated

--- a/signature/async/Cargo.toml
+++ b/signature/async/Cargo.toml
@@ -14,7 +14,7 @@ rust-version  = "1.56"
 
 [dependencies]
 async-trait = "0.1.9"
-signature = { version = "=2.0.0-rc.1", path = ".." }
+signature = { version = "2", path = ".." }
 
 [features]
 digest = ["signature/digest"]

--- a/signature/derive/CHANGELOG.md
+++ b/signature/derive/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.0.0 (2023-01-15)
+### Changed
+- `Signature` trait has been removed, so don't emit it in custom derive ([#1141])
+
+[#1141]: https://github.com/RustCrypto/traits/pull/1141
+
 ## 1.0.0-pre.7 (2022-09-16)
 ### Fixed
 - Support for `where` bounds ([#1118])

--- a/signature/derive/Cargo.toml
+++ b/signature/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "signature_derive"
-version       = "2.0.0-pre.0"
+version       = "2.0.0"
 authors       = ["RustCrypto Developers"]
 license       = "Apache-2.0 OR MIT"
 description   = "Custom derive support for the 'signature' crate"

--- a/signature/src/lib.rs
+++ b/signature/src/lib.rs
@@ -6,7 +6,14 @@
 )]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![forbid(unsafe_code)]
-#![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
+#![warn(
+    clippy::mod_module_files,
+    clippy::unwrap_used,
+    missing_docs,
+    rust_2018_idioms,
+    unused_lifetimes,
+    unused_qualifications
+)]
 
 //! # Design
 //!


### PR DESCRIPTION
### Added
- `SignatureEncoding` trait as a replacement for `Signature` trait and the now removed `AsRef<[u8]>` bound on signatures ([#1141])
- New `Keypair` trait which returns owned keys instead of borrowed ([#1141])

### Changed
- `derive-preview` has been renamed to `derive` and stabilized ([#1141])
- `digest-preview` renamed to `digest`, still unstable ([#1210])
- `hazmat-preview` feature stabilized and removed, always on ([#1141])
- `rand-preview` renamed to `rand_core`, still unstable ([#1210])
- `std` feature is no longer enabled by default ([#1141])
- Old `Keypair` trait renamed to `KeypairRef` ([#1141])
- Signature generic parameter removed from `Keypair`/`KeypairRef` ([#1141])
- Use `&mut impl CryptoRngCore` RNG arguments ([#1147])

### Removed
- `Signature` trait - replaced by `SignatureEncoding` ([#1141])
- `hazmat-preview` feature, now always on ([#1141])

[#1141]: https://github.com/RustCrypto/traits/pull/1141
[#1147]: https://github.com/RustCrypto/traits/pull/1147
[#1210]: https://github.com/RustCrypto/traits/pull/1141