### PR TITLE
async-signature v0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "async-signature"
-version = "0.3.0-pre"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "signature 2.0.0",

--- a/signature/async/CHANGELOG.md
+++ b/signature/async/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.3.0 (2022-01-15)
+### Changed
+- Bump `signature` to v2 ([#1141], [#1211])
+
+### Removed
+- `AsyncKeypair` is no longer needed due to `signature` v2 bounds changes ([#1141])
+
+[#1141]: https://github.com/RustCrypto/traits/pull/1141
+[#1211]: https://github.com/RustCrypto/traits/pull/1211
+
 ## 0.2.1 (2022-09-15)
 ### Changed
 - Relax `AsyncKeypair` bounds ([#1107])

--- a/signature/async/Cargo.toml
+++ b/signature/async/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name          = "async-signature"
 description   = "Traits for cryptographic signature algorithms (e.g. ECDSA, Ed25519)"
-version       = "0.3.0-pre"
+version       = "0.3.0"
 authors       = ["RustCrypto Developers"]
 license       = "Apache-2.0 OR MIT"
 documentation = "https://docs.rs/async-signature"


### PR DESCRIPTION
### Changed
- Bump `signature` to v2 ([#1141], [#1211])

### Removed
- `AsyncKeypair` is no longer needed due to `signature` v2 bounds changes ([#1141])

[#1141]: https://github.com/RustCrypto/traits/pull/1141
[#1211]: https://github.com/RustCrypto/traits/pull/1211