### PR TITLE
async-signature: fix `signature` version requirement

### DIFF
--- a/signature/async/Cargo.toml
+++ b/signature/async/Cargo.toml
@@ -14,7 +14,7 @@ rust-version  = "1.56"
 
 [dependencies]
 async-trait = "0.1.9"
-signature = { version = "2", path = ".." }
+signature = { version = "2.0, <2.1", path = ".." }
 
 [features]
 digest = ["signature/digest"]


### PR DESCRIPTION
It uses the `digest` feature, which means version updates need to be coordinates around minor versions.