### PR TITLE
kem: remove copypasta from README.md

### DIFF
--- a/kem/README.md
+++ b/kem/README.md
@@ -24,10 +24,6 @@ done with a minor version bump.
 
 - All on-by-default features of this library are covered by SemVer
 - MSRV is considered exempt from SemVer as noted above
-- The off-by-default features `derive-preview` and `digest-preview` are
-  unstable "preview" features which are also considered exempt from SemVer.
-  Breaking changes to these features will, like MSRV, be done with a minor
-  version bump.
 
 ## License
 


### PR DESCRIPTION
This seems to have originally come from the `signature` crate