### PR TITLE
password-hash: proposed API changes for `Salt`/`SaltString`

### DIFF
--- a/password-hash/tests/encoding.rs
+++ b/password-hash/tests/encoding.rs
@@ -8,7 +8,7 @@
 //!
 //! <https://github.com/P-H-C/phc-string-format/blob/master/phc-sf-spec.md#b64>
 
-use password_hash::{Output, Salt};
+use password_hash::{Output, Salt, SaltString};
 
 // Example salt encoded as a B64 string.
 const EXAMPLE_SALT_B64: &str = "REVBREJFRUZERUFEQkVFRg";
@@ -23,10 +23,21 @@ const EXAMPLE_OUTPUT_RAW: &[u8] =
 #[test]
 fn salt_roundtrip() {
     let mut buffer = [0u8; 64];
-    let salt = Salt::new(EXAMPLE_SALT_B64).unwrap();
+    let salt = Salt::from_b64(EXAMPLE_SALT_B64).unwrap();
     assert_eq!(salt.as_ref(), EXAMPLE_SALT_B64);
 
-    let salt_decoded = salt.b64_decode(&mut buffer).unwrap();
+    let salt_decoded = salt.to_raw(&mut buffer).unwrap();
+    assert_eq!(salt_decoded, EXAMPLE_SALT_RAW);
+}
+
+#[test]
+fn saltstring_roundtrip() {
+    let mut buffer = [0u8; 64];
+    let salt = SaltString::from_b64(EXAMPLE_SALT_B64).unwrap();
+    assert_eq!(EXAMPLE_SALT_B64.len(), salt.len());
+    assert_eq!(salt.as_ref(), EXAMPLE_SALT_B64);
+
+    let salt_decoded = salt.to_raw(&mut buffer).unwrap();
     assert_eq!(salt_decoded, EXAMPLE_SALT_RAW);
 }
 

--- a/password-hash/tests/hashing.rs
+++ b/password-hash/tests/hashing.rs
@@ -29,7 +29,7 @@ impl PasswordHasher for StubPasswordHasher {
             }
         }
 
-        for slice in &[b"pw", password, b",salt:", salt.as_bytes()] {
+        for slice in &[b"pw", password, b",salt:", salt.as_str().as_bytes()] {
             output.extend_from_slice(slice);
         }
 
@@ -68,7 +68,7 @@ impl<'a> TryFrom<StubParams> for ParamsString {
 #[test]
 fn verify_password_hash() {
     let valid_password = "test password";
-    let salt = Salt::new("test-salt").unwrap();
+    let salt = Salt::from_b64("test-salt").unwrap();
     let hash = PasswordHash::generate(StubPasswordHasher, valid_password, salt).unwrap();
 
     // Sanity tests for StubFunction impl above

--- a/password-hash/tests/password_hash.rs
+++ b/password-hash/tests/password_hash.rs
@@ -57,7 +57,7 @@ fn salt() {
         algorithm: EXAMPLE_ALGORITHM,
         version: None,
         params: ParamsString::new(),
-        salt: Some(Salt::new(EXAMPLE_SALT).unwrap()),
+        salt: Some(Salt::from_b64(EXAMPLE_SALT).unwrap()),
         hash: None,
     };
 
@@ -77,7 +77,7 @@ fn one_param_and_salt() {
         algorithm: EXAMPLE_ALGORITHM,
         version: None,
         params,
-        salt: Some(Salt::new(EXAMPLE_SALT).unwrap()),
+        salt: Some(Salt::from_b64(EXAMPLE_SALT).unwrap()),
         hash: None,
     };
 
@@ -94,7 +94,7 @@ fn params_and_salt() {
         algorithm: EXAMPLE_ALGORITHM,
         version: None,
         params: example_params(),
-        salt: Some(Salt::new(EXAMPLE_SALT).unwrap()),
+        salt: Some(Salt::from_b64(EXAMPLE_SALT).unwrap()),
         hash: None,
     };
 
@@ -111,7 +111,7 @@ fn salt_and_hash() {
         algorithm: EXAMPLE_ALGORITHM,
         version: None,
         params: ParamsString::default(),
-        salt: Some(Salt::new(EXAMPLE_SALT).unwrap()),
+        salt: Some(Salt::from_b64(EXAMPLE_SALT).unwrap()),
         hash: Some(EXAMPLE_HASH.try_into().unwrap()),
     };
 
@@ -131,7 +131,7 @@ fn all_fields() {
         algorithm: EXAMPLE_ALGORITHM,
         version: None,
         params: example_params(),
-        salt: Some(Salt::new(EXAMPLE_SALT).unwrap()),
+        salt: Some(Salt::from_b64(EXAMPLE_SALT).unwrap()),
         hash: Some(EXAMPLE_HASH.try_into().unwrap()),
     };
 


### PR DESCRIPTION
Making the API for Salt and SaltString better to understand

- Update lints to 2021
- Rustify the API

Initially opened the issue in the wrong repo, sorry for https://github.com/RustCrypto/password-hashes/issues/371