### PR TITLE
Expand `NonIdentity` usage

### DIFF
--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -113,6 +113,7 @@ pub use zeroize;
 pub use {
     crate::{
         arithmetic::{CurveArithmetic, PrimeCurveArithmetic},
+        point::NonIdentity,
         public_key::PublicKey,
         scalar::{NonZeroScalar, Scalar},
     },

--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -69,6 +69,7 @@ extern crate alloc;
 extern crate std;
 
 pub mod ops;
+pub mod point;
 pub mod scalar;
 
 #[cfg(feature = "dev")]
@@ -83,7 +84,6 @@ pub mod sec1;
 pub mod weierstrass;
 
 mod error;
-mod point;
 mod secret_key;
 
 #[cfg(feature = "arithmetic")]
@@ -113,7 +113,6 @@ pub use zeroize;
 pub use {
     crate::{
         arithmetic::{CurveArithmetic, PrimeCurveArithmetic},
-        point::NonIdentity,
         public_key::PublicKey,
         scalar::{NonZeroScalar, Scalar},
     },

--- a/elliptic-curve/src/public_key.rs
+++ b/elliptic-curve/src/public_key.rs
@@ -155,6 +155,11 @@ where
         self.point.into()
     }
 
+    /// Convert this [`PublicKey`] to a [`NonIdentity`] of the inner [`AffinePoint`]
+    pub fn to_non_identity(&self) -> NonIdentity<AffinePoint<C>> {
+        NonIdentity::new_unchecked(self.point)
+    }
+
     /// Parse a [`JwkEcKey`] JSON Web Key (JWK) into a [`PublicKey`].
     #[cfg(feature = "jwk")]
     pub fn from_jwk(jwk: &JwkEcKey) -> Result<Self>
@@ -271,7 +276,7 @@ where
     P: Copy + Into<AffinePoint<C>>,
 {
     fn from(value: NonIdentity<P>) -> Self {
-        PublicKey::from(&value)
+        Self::from(&value)
     }
 }
 
@@ -284,6 +289,24 @@ where
         Self {
             point: value.to_point().into(),
         }
+    }
+}
+
+impl<C> From<PublicKey<C>> for NonIdentity<AffinePoint<C>>
+where
+    C: CurveArithmetic,
+{
+    fn from(value: PublicKey<C>) -> Self {
+        Self::from(&value)
+    }
+}
+
+impl<C> From<&PublicKey<C>> for NonIdentity<AffinePoint<C>>
+where
+    C: CurveArithmetic,
+{
+    fn from(value: &PublicKey<C>) -> Self {
+        PublicKey::to_non_identity(value)
     }
 }
 


### PR DESCRIPTION
Follow-up to #1176.
IANAC, as far as I understand multiplying a non-zero-scalar with a non-identity-point can never yield the identity-point.

Also realized that I forgot to make the type public :sweat_smile:.