### PR TITLE
Add support for `arrayvec` in `aead`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,6 +6,7 @@ version = 3
 name = "aead"
 version = "0.5.1"
 dependencies = [
+ "arrayvec",
  "blobby",
  "bytes",
  "crypto-common 0.1.6",
@@ -47,6 +48,12 @@ dependencies = [
  "ghash",
  "subtle",
 ]
+
+[[package]]
+name = "arrayvec"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
 name = "async-signature"

--- a/aead/Cargo.toml
+++ b/aead/Cargo.toml
@@ -20,6 +20,7 @@ crypto-common = "0.1.4"
 generic-array = { version = "0.14", default-features = false }
 
 # optional dependencies
+arrayvec = { version = "0.7", optional = true, default-features = false }
 blobby = { version = "0.3", optional = true }
 bytes = { version = "1", optional = true, default-features = false }
 heapless = { version = "0.7", optional = true, default-features = false }

--- a/aead/src/lib.rs
+++ b/aead/src/lib.rs
@@ -39,6 +39,10 @@ pub mod stream;
 pub use crypto_common::{Key, KeyInit, KeySizeUser};
 pub use generic_array::{self, typenum::consts};
 
+#[cfg(feature = "arrayvec")]
+#[cfg_attr(docsrs, doc(cfg(feature = "arrayvec")))]
+pub use arrayvec;
+
 #[cfg(feature = "bytes")]
 #[cfg_attr(docsrs, doc(cfg(feature = "bytes")))]
 pub use bytes;
@@ -546,6 +550,17 @@ impl Buffer for BytesMut {
 
     fn truncate(&mut self, len: usize) {
         BytesMut::truncate(self, len);
+    }
+}
+
+#[cfg(feature = "arrayvec")]
+impl<const N: usize> Buffer for arrayvec::ArrayVec<u8, N> {
+    fn extend_from_slice(&mut self, other: &[u8]) -> Result<()> {
+        arrayvec::ArrayVec::try_extend_from_slice(self, other).map_err(|_| Error)
+    }
+
+    fn truncate(&mut self, len: usize) {
+        arrayvec::ArrayVec::truncate(self, len);
     }
 }
 


### PR DESCRIPTION
[`arrayvec`](https://crates.io/crates/arrayvec) is a popular alternative to the `heapless` crate; it has over 65 million all-time downloads and is used in several high-profile crates.

I've added an `arrayvec` feature to `aead`. When enabled, the `aead::Buffer` trait is implemented for [`ArrayVec<u8, N>`](https://docs.rs/arrayvec/0.7.2/arrayvec/struct.ArrayVec.html).

### Example usage

This usage is modeled off of the [`heapless` example](https://github.com/RustCrypto/AEADs/blob/master/aes-gcm-siv/src/lib.rs#L55-L78) from the `aes-gcm-siv` crate documentation.

```rust
fn main() -> Result<(), Box<dyn std::error::Error>> {
    use aes_gcm_siv::{
        aead::{AeadInPlace, KeyInit, OsRng, arrayvec::ArrayVec},
        Aes256GcmSiv, Nonce, // Or `Aes128GcmSiv`
    };

    let key = Aes256GcmSiv::generate_key(&mut OsRng);
    let cipher = Aes256GcmSiv::new(&key);
    let nonce = Nonce::from_slice(b"unique nonce"); // 96-bits; unique per message

    let mut buffer: ArrayVec<u8, 128> = ArrayVec::new(); // Note: buffer needs 16-bytes overhead for auth tag tag
    buffer.try_extend_from_slice(b"plaintext message")?;

    // Encrypt `buffer` in-place, replacing the plaintext contents with ciphertext
    cipher.encrypt_in_place(nonce, b"", &mut buffer)?;

    // `buffer` now contains the message ciphertext
    assert_ne!(buffer, ArrayVec::try_from(&b"plaintext message"[..])?);

    // Decrypt `buffer` in-place, replacing its ciphertext context with the original plaintext
    cipher.decrypt_in_place(nonce, b"", &mut buffer)?;
    assert_eq!(buffer, ArrayVec::try_from(&b"plaintext message"[..])?);

    Ok(())
}
```

Until this is merged and `aes-gcm-siv` is updated with a corresponding `arrayvec` feature, this would need to be run with a `Cargo.toml` with the following dependencies/patch:

```toml
[dependencies]
aes-gcm-siv = { version = "0.11.1", features = [ "std" ] }
arrayvec = { version = "0.7.2", features = [ "std" ] }
aead = { version = "*", features = [ "arrayvec" ] }

[patch.crates-io]
aead = { path = "/path/to/this/branch/of/traits/aead" }
```