### PR TITLE
elliptic-curve: refactor field element decoding/encoding

### DIFF
--- a/elliptic-curve/src/dev.rs
+++ b/elliptic-curve/src/dev.rs
@@ -6,6 +6,7 @@
 use crate::{
     bigint::{Limb, U256},
     error::{Error, Result},
+    generic_array::typenum::U32,
     ops::{LinearCombination, MulByGenerator, Reduce, Shr1},
     pkcs8,
     rand_core::RngCore,
@@ -65,6 +66,7 @@ pub type ScalarBits = crate::ScalarBits<MockCurve>;
 pub struct MockCurve;
 
 impl Curve for MockCurve {
+    type FieldBytesSize = U32;
     type Uint = U256;
 
     const ORDER: U256 =
@@ -150,11 +152,11 @@ impl PrimeField for Scalar {
     const DELTA: Self = Self::ZERO; // BOGUS!
 
     fn from_repr(bytes: FieldBytes) -> CtOption<Self> {
-        ScalarPrimitive::from_be_bytes(bytes).map(Self)
+        ScalarPrimitive::from_bytes(&bytes).map(Self)
     }
 
     fn to_repr(&self) -> FieldBytes {
-        self.0.to_be_bytes()
+        self.0.to_bytes()
     }
 
     fn is_odd(&self) -> Choice {

--- a/elliptic-curve/src/field.rs
+++ b/elliptic-curve/src/field.rs
@@ -1,0 +1,10 @@
+//! Field elements.
+
+use crate::Curve;
+use generic_array::GenericArray;
+
+/// Size of serialized field elements of this elliptic curve.
+pub type FieldBytesSize<C> = <C as Curve>::FieldBytesSize;
+
+/// Byte representation of a base/scalar field element of a given curve.
+pub type FieldBytes<C> = GenericArray<u8, FieldBytesSize<C>>;

--- a/elliptic-curve/src/point.rs
+++ b/elliptic-curve/src/point.rs
@@ -4,10 +4,20 @@
 mod non_identity;
 
 #[cfg(feature = "arithmetic")]
-pub use self::non_identity::NonIdentity;
+pub use {self::non_identity::NonIdentity, crate::CurveArithmetic};
 
 use crate::{Curve, FieldBytes};
 use subtle::{Choice, CtOption};
+
+/// Affine point type for a given curve with a [`CurveArithmetic`]
+/// implementation.
+#[cfg(feature = "arithmetic")]
+pub type AffinePoint<C> = <C as CurveArithmetic>::AffinePoint;
+
+/// Projective point type for a given curve with a [`CurveArithmetic`]
+/// implementation.
+#[cfg(feature = "arithmetic")]
+pub type ProjectivePoint<C> = <C as CurveArithmetic>::ProjectivePoint;
 
 /// Obtain the affine x-coordinate of an elliptic curve point.
 pub trait AffineXCoordinate {

--- a/elliptic-curve/src/public_key.rs
+++ b/elliptic-curve/src/public_key.rs
@@ -19,7 +19,7 @@ use core::str::FromStr;
 use {
     crate::{
         sec1::{EncodedPoint, FromEncodedPoint, ModulusSize, ToEncodedPoint},
-        Curve, FieldSize, PointCompression,
+        Curve, FieldBytesSize, PointCompression,
     },
     core::cmp::Ordering,
     subtle::CtOption,
@@ -119,7 +119,7 @@ where
     pub fn from_sec1_bytes(bytes: &[u8]) -> Result<Self>
     where
         C: Curve,
-        FieldSize<C>: ModulusSize,
+        FieldBytesSize<C>: ModulusSize,
         AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
     {
         let point = EncodedPoint::<C>::from_bytes(bytes).map_err(|_| Error)?;
@@ -137,7 +137,7 @@ where
     where
         C: CurveArithmetic + PointCompression,
         AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
-        FieldSize<C>: ModulusSize,
+        FieldBytesSize<C>: ModulusSize,
     {
         let point = EncodedPoint::<C>::from(self);
         point.to_bytes()
@@ -166,7 +166,7 @@ where
     where
         C: Curve + JwkParameters,
         AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
-        FieldSize<C>: ModulusSize,
+        FieldBytesSize<C>: ModulusSize,
     {
         jwk.to_public_key::<C>()
     }
@@ -177,7 +177,7 @@ where
     where
         C: Curve + JwkParameters,
         AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
-        FieldSize<C>: ModulusSize,
+        FieldBytesSize<C>: ModulusSize,
     {
         jwk.parse::<JwkEcKey>().and_then(|jwk| Self::from_jwk(&jwk))
     }
@@ -188,7 +188,7 @@ where
     where
         C: Curve + JwkParameters,
         AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
-        FieldSize<C>: ModulusSize,
+        FieldBytesSize<C>: ModulusSize,
     {
         self.into()
     }
@@ -199,7 +199,7 @@ where
     where
         C: Curve + JwkParameters,
         AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
-        FieldSize<C>: ModulusSize,
+        FieldBytesSize<C>: ModulusSize,
     {
         self.to_jwk().to_string()
     }
@@ -221,7 +221,7 @@ impl<C> FromEncodedPoint<C> for PublicKey<C>
 where
     C: CurveArithmetic,
     AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
-    FieldSize<C>: ModulusSize,
+    FieldBytesSize<C>: ModulusSize,
 {
     /// Initialize [`PublicKey`] from an [`EncodedPoint`]
     fn from_encoded_point(encoded_point: &EncodedPoint<C>) -> CtOption<Self> {
@@ -237,7 +237,7 @@ impl<C> ToEncodedPoint<C> for PublicKey<C>
 where
     C: CurveArithmetic,
     AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
-    FieldSize<C>: ModulusSize,
+    FieldBytesSize<C>: ModulusSize,
 {
     /// Serialize this [`PublicKey`] as a SEC1 [`EncodedPoint`], optionally applying
     /// point compression
@@ -251,7 +251,7 @@ impl<C> From<PublicKey<C>> for EncodedPoint<C>
 where
     C: CurveArithmetic + PointCompression,
     AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
-    FieldSize<C>: ModulusSize,
+    FieldBytesSize<C>: ModulusSize,
 {
     fn from(public_key: PublicKey<C>) -> EncodedPoint<C> {
         EncodedPoint::<C>::from(&public_key)
@@ -263,7 +263,7 @@ impl<C> From<&PublicKey<C>> for EncodedPoint<C>
 where
     C: CurveArithmetic + PointCompression,
     AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
-    FieldSize<C>: ModulusSize,
+    FieldBytesSize<C>: ModulusSize,
 {
     fn from(public_key: &PublicKey<C>) -> EncodedPoint<C> {
         public_key.to_encoded_point(C::COMPRESS_POINTS)
@@ -315,7 +315,7 @@ impl<C> PartialOrd for PublicKey<C>
 where
     C: CurveArithmetic,
     AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
-    FieldSize<C>: ModulusSize,
+    FieldBytesSize<C>: ModulusSize,
 {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
@@ -327,7 +327,7 @@ impl<C> Ord for PublicKey<C>
 where
     C: CurveArithmetic,
     AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
-    FieldSize<C>: ModulusSize,
+    FieldBytesSize<C>: ModulusSize,
 {
     fn cmp(&self, other: &Self) -> Ordering {
         // TODO(tarcieri): more efficient implementation?
@@ -342,7 +342,7 @@ impl<C> TryFrom<pkcs8::SubjectPublicKeyInfo<'_>> for PublicKey<C>
 where
     C: AssociatedOid + CurveArithmetic,
     AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
-    FieldSize<C>: ModulusSize,
+    FieldBytesSize<C>: ModulusSize,
 {
     type Error = pkcs8::spki::Error;
 
@@ -358,7 +358,7 @@ impl<C> DecodePublicKey for PublicKey<C>
 where
     C: AssociatedOid + CurveArithmetic,
     AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
-    FieldSize<C>: ModulusSize,
+    FieldBytesSize<C>: ModulusSize,
 {
 }
 
@@ -367,7 +367,7 @@ impl<C> EncodePublicKey for PublicKey<C>
 where
     C: AssociatedOid + CurveArithmetic,
     AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
-    FieldSize<C>: ModulusSize,
+    FieldBytesSize<C>: ModulusSize,
 {
     fn to_public_key_der(&self) -> pkcs8::spki::Result<der::Document> {
         let algorithm = pkcs8::AlgorithmIdentifier {
@@ -390,7 +390,7 @@ impl<C> FromStr for PublicKey<C>
 where
     C: AssociatedOid + CurveArithmetic,
     AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
-    FieldSize<C>: ModulusSize,
+    FieldBytesSize<C>: ModulusSize,
 {
     type Err = Error;
 
@@ -404,7 +404,7 @@ impl<C> ToString for PublicKey<C>
 where
     C: AssociatedOid + CurveArithmetic,
     AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
-    FieldSize<C>: ModulusSize,
+    FieldBytesSize<C>: ModulusSize,
 {
     fn to_string(&self) -> String {
         self.to_public_key_pem(Default::default())
@@ -417,7 +417,7 @@ impl<C> Serialize for PublicKey<C>
 where
     C: AssociatedOid + CurveArithmetic,
     AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
-    FieldSize<C>: ModulusSize,
+    FieldBytesSize<C>: ModulusSize,
 {
     fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
@@ -433,7 +433,7 @@ impl<'de, C> Deserialize<'de> for PublicKey<C>
 where
     C: AssociatedOid + CurveArithmetic,
     AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
-    FieldSize<C>: ModulusSize,
+    FieldBytesSize<C>: ModulusSize,
 {
     fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where

--- a/elliptic-curve/src/scalar/nonzero.rs
+++ b/elliptic-curve/src/scalar/nonzero.rs
@@ -145,8 +145,9 @@ impl<C> From<NonZeroScalar<C>> for ScalarPrimitive<C>
 where
     C: CurveArithmetic,
 {
+    #[inline]
     fn from(scalar: NonZeroScalar<C>) -> ScalarPrimitive<C> {
-        ScalarPrimitive::from_be_bytes(scalar.to_repr()).unwrap()
+        Self::from(&scalar)
     }
 }
 
@@ -155,7 +156,7 @@ where
     C: CurveArithmetic,
 {
     fn from(scalar: &NonZeroScalar<C>) -> ScalarPrimitive<C> {
-        ScalarPrimitive::from_be_bytes(scalar.to_repr()).unwrap()
+        ScalarPrimitive::from_bytes(&scalar.to_repr()).unwrap()
     }
 }
 

--- a/elliptic-curve/src/sec1.rs
+++ b/elliptic-curve/src/sec1.rs
@@ -4,7 +4,7 @@
 
 pub use sec1::point::{Coordinates, ModulusSize, Tag};
 
-use crate::{Curve, FieldSize, Result, SecretKey};
+use crate::{Curve, FieldBytesSize, Result, SecretKey};
 use generic_array::GenericArray;
 use subtle::CtOption;
 
@@ -15,16 +15,16 @@ use crate::{AffinePoint, CurveArithmetic, Error};
 pub type CompressedPoint<C> = GenericArray<u8, CompressedPointSize<C>>;
 
 /// Size of a compressed elliptic curve point.
-pub type CompressedPointSize<C> = <FieldSize<C> as ModulusSize>::CompressedPointSize;
+pub type CompressedPointSize<C> = <FieldBytesSize<C> as ModulusSize>::CompressedPointSize;
 
 /// Encoded elliptic curve point sized appropriately for a given curve.
-pub type EncodedPoint<C> = sec1::point::EncodedPoint<FieldSize<C>>;
+pub type EncodedPoint<C> = sec1::point::EncodedPoint<FieldBytesSize<C>>;
 
 /// Encoded elliptic curve point *without* point compression.
 pub type UncompressedPoint<C> = GenericArray<u8, UncompressedPointSize<C>>;
 
 /// Size of an uncompressed elliptic curve point.
-pub type UncompressedPointSize<C> = <FieldSize<C> as ModulusSize>::UncompressedPointSize;
+pub type UncompressedPointSize<C> = <FieldBytesSize<C> as ModulusSize>::UncompressedPointSize;
 
 /// Trait for deserializing a value from a SEC1 encoded curve point.
 ///
@@ -33,7 +33,7 @@ pub trait FromEncodedPoint<C>
 where
     Self: Sized,
     C: Curve,
-    FieldSize<C>: ModulusSize,
+    FieldBytesSize<C>: ModulusSize,
 {
     /// Deserialize the type this trait is impl'd on from an [`EncodedPoint`].
     fn from_encoded_point(point: &EncodedPoint<C>) -> CtOption<Self>;
@@ -45,7 +45,7 @@ where
 pub trait ToEncodedPoint<C>
 where
     C: Curve,
-    FieldSize<C>: ModulusSize,
+    FieldBytesSize<C>: ModulusSize,
 {
     /// Serialize this value as a SEC1 [`EncodedPoint`], optionally applying
     /// point compression.
@@ -58,7 +58,7 @@ where
 pub trait ToCompactEncodedPoint<C>
 where
     C: Curve,
-    FieldSize<C>: ModulusSize,
+    FieldBytesSize<C>: ModulusSize,
 {
     /// Serialize this value as a SEC1 [`EncodedPoint`], optionally applying
     /// point compression.
@@ -73,7 +73,7 @@ where
 pub trait ValidatePublicKey
 where
     Self: Curve,
-    FieldSize<Self>: ModulusSize,
+    FieldBytesSize<Self>: ModulusSize,
 {
     /// Validate that the given [`EncodedPoint`] is a valid public key for the
     /// provided secret value.
@@ -98,7 +98,7 @@ impl<C> ValidatePublicKey for C
 where
     C: CurveArithmetic,
     AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
-    FieldSize<C>: ModulusSize,
+    FieldBytesSize<C>: ModulusSize,
 {
     fn validate_public_key(secret_key: &SecretKey<C>, public_key: &EncodedPoint<C>) -> Result<()> {
         let pk = secret_key

--- a/elliptic-curve/src/secret_key/pkcs8.rs
+++ b/elliptic-curve/src/secret_key/pkcs8.rs
@@ -4,7 +4,7 @@ use super::SecretKey;
 use crate::{
     pkcs8::{self, der::Decode, AssociatedOid, DecodePrivateKey},
     sec1::{ModulusSize, ValidatePublicKey},
-    Curve, FieldSize, ALGORITHM_OID,
+    Curve, FieldBytesSize, ALGORITHM_OID,
 };
 use sec1::EcPrivateKey;
 
@@ -28,7 +28,7 @@ use {
 impl<C> TryFrom<pkcs8::PrivateKeyInfo<'_>> for SecretKey<C>
 where
     C: Curve + AssociatedOid + ValidatePublicKey,
-    FieldSize<C>: ModulusSize,
+    FieldBytesSize<C>: ModulusSize,
 {
     type Error = pkcs8::Error;
 
@@ -45,7 +45,7 @@ where
 impl<C> DecodePrivateKey for SecretKey<C>
 where
     C: Curve + AssociatedOid + ValidatePublicKey,
-    FieldSize<C>: ModulusSize,
+    FieldBytesSize<C>: ModulusSize,
 {
 }
 
@@ -54,7 +54,7 @@ impl<C> EncodePrivateKey for SecretKey<C>
 where
     C: AssociatedOid + CurveArithmetic,
     AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
-    FieldSize<C>: ModulusSize,
+    FieldBytesSize<C>: ModulusSize,
 {
     fn to_pkcs8_der(&self) -> pkcs8::Result<der::SecretDocument> {
         let algorithm_identifier = pkcs8::AlgorithmIdentifier {
@@ -72,7 +72,7 @@ where
 impl<C> FromStr for SecretKey<C>
 where
     C: Curve + AssociatedOid + ValidatePublicKey,
-    FieldSize<C>: ModulusSize,
+    FieldBytesSize<C>: ModulusSize,
 {
     type Err = Error;
 

--- a/elliptic-curve/src/voprf.rs
+++ b/elliptic-curve/src/voprf.rs
@@ -1,0 +1,20 @@
+//! Verifiable Oblivious Pseudorandom Function (VOPRF) using prime order groups
+//!
+//! <https://datatracker.ietf.org/doc/draft-irtf-cfrg-voprf/>
+
+use crate::PrimeCurve;
+
+/// Elliptic curve parameters used by VOPRF.
+pub trait VoprfParameters: PrimeCurve {
+    /// The `ID` parameter which identifies a particular elliptic curve
+    /// as defined in [section 4 of `draft-irtf-cfrg-voprf-08`][voprf].
+    ///
+    /// [voprf]: https://www.ietf.org/archive/id/draft-irtf-cfrg-voprf-08.html#section-4
+    const ID: u16;
+
+    /// The `Hash` parameter which assigns a particular hash function to this
+    /// ciphersuite as defined in [section 4 of `draft-irtf-cfrg-voprf-08`][voprf].
+    ///
+    /// [voprf]: https://www.ietf.org/archive/id/draft-irtf-cfrg-voprf-08.html#section-4
+    type Hash: digest::Digest;
+}

--- a/elliptic-curve/tests/pkcs8.rs
+++ b/elliptic-curve/tests/pkcs8.rs
@@ -23,7 +23,7 @@ const EXAMPLE_SCALAR: [u8; 32] =
 
 /// Example PKCS#8 private key
 fn example_private_key() -> der::SecretDocument {
-    SecretKey::from_be_bytes(&EXAMPLE_SCALAR)
+    SecretKey::from_slice(&EXAMPLE_SCALAR)
         .unwrap()
         .to_pkcs8_der()
         .unwrap()
@@ -32,7 +32,7 @@ fn example_private_key() -> der::SecretDocument {
 #[test]
 fn decode_pkcs8_private_key_from_der() {
     let secret_key = SecretKey::from_pkcs8_der(example_private_key().as_bytes()).unwrap();
-    assert_eq!(secret_key.to_be_bytes().as_slice(), &EXAMPLE_SCALAR);
+    assert_eq!(secret_key.to_bytes().as_slice(), &EXAMPLE_SCALAR);
 }
 
 #[test]

--- a/elliptic-curve/tests/secret_key.rs
+++ b/elliptic-curve/tests/secret_key.rs
@@ -6,5 +6,5 @@ use elliptic_curve::dev::SecretKey;
 
 #[test]
 fn undersize_secret_key() {
-    assert!(SecretKey::from_be_bytes(&[]).is_err());
+    assert!(SecretKey::from_slice(&[]).is_err());
 }


### PR DESCRIPTION
Previously `FieldBytes` was defined in terms of `C::Uint::ByteSize`, which lead to it being improperly sized for curves with unusual modulus sizes like P-224 and P-521 (which aren't multiples of 64).

This commit adds an associated `C::FieldBytesSize` which makes it possible to specifically define the size of a serialized field element. The previous `FieldSize<C>` type alias is retained as `FieldBytesSize`, which handles specifying that the associated type should be accessed using `Curve::FieldBytesSize`.

To handle potential discrepancies between `C::Uint::ByteSize` and `C::FieldBytesSize`, provided `Curve::decode_field_bytes` and `Curve::encode_field_bytes` methods have been added for handling decoding/encoding serialized field elements to/from `C::Uint`.

The methods use a default big endian serialization. Now that curves can customize the endianness used for encoding field elements, this eliminates the need to have separate `from_be_bytes`/`from_le_bytes` and `to_be_bytes`/`to_le_bytes` methods. Instead the endianness can be known a priori, which eliminates the need for the caller to select a specific endianness. As such, this PR folds these methods (defined on e.g. `ScalarPrimitive` and `NonZeroScalar`) into `from_bytes` and `to_bytes`.