### PR TITLE
elliptic-curve: interpolate variables in format strings

### DIFF
--- a/elliptic-curve/src/jwk.rs
+++ b/elliptic-curve/src/jwk.rs
@@ -440,7 +440,7 @@ impl<'de> Deserialize<'de> for JwkEcKey {
                     .ok_or_else(|| de::Error::invalid_length(0, &DE_ERROR_MSG))?;
 
                 if kty != EC_KTY {
-                    return Err(de::Error::custom(format!("unsupported JWK kty: {:?}", kty)));
+                    return Err(de::Error::custom(format!("unsupported JWK kty: {kty:?}")));
                 }
 
                 let crv = de::SeqAccess::next_element::<String>(&mut seq)?
@@ -512,7 +512,7 @@ impl<'de> Deserialize<'de> for JwkEcKey {
                 let kty = kty.ok_or_else(|| de::Error::missing_field("kty"))?;
 
                 if kty != EC_KTY {
-                    return Err(de::Error::custom(format!("unsupported JWK kty: {}", kty)));
+                    return Err(de::Error::custom(format!("unsupported JWK kty: {kty}")));
                 }
 
                 let crv = crv.ok_or_else(|| de::Error::missing_field("crv"))?;

--- a/elliptic-curve/src/scalar/nonzero.rs
+++ b/elliptic-curve/src/scalar/nonzero.rs
@@ -305,7 +305,7 @@ where
     C: CurveArithmetic,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:X}", self)
+        write!(f, "{self:X}")
     }
 }
 

--- a/elliptic-curve/src/scalar/primitive.rs
+++ b/elliptic-curve/src/scalar/primitive.rs
@@ -365,7 +365,7 @@ where
     C: Curve,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:X}", self)
+        write!(f, "{self:X}")
     }
 }
 


### PR DESCRIPTION
Uses the newly added support for interpolating variables in format strings instead of passing them as arguments.