### PR TITLE
elliptic-curve: replace `Shr1` with `ShrAssign`

### DIFF
--- a/elliptic-curve/src/arithmetic.rs
+++ b/elliptic-curve/src/arithmetic.rs
@@ -1,7 +1,7 @@
 //! Elliptic curve arithmetic traits.
 
 use crate::{
-    ops::{LinearCombination, MulByGenerator, Shr1},
+    ops::{LinearCombination, MulByGenerator, ShrAssign},
     scalar::FromUintUnchecked,
     AffineXCoordinate, AffineYIsOdd, Curve, FieldBytes, IsHigh, PrimeCurve, ScalarPrimitive,
 };
@@ -70,7 +70,7 @@ pub trait CurveArithmetic: Curve {
         + Into<Self::Uint>
         + IsHigh
         + PartialOrd
-        + Shr1
+        + ShrAssign<usize>
         + ff::Field
         + ff::PrimeField<Repr = FieldBytes<Self>>;
 }

--- a/elliptic-curve/src/dev.rs
+++ b/elliptic-curve/src/dev.rs
@@ -7,7 +7,7 @@ use crate::{
     bigint::{Limb, U256},
     error::{Error, Result},
     generic_array::typenum::U32,
-    ops::{LinearCombination, MulByGenerator, Reduce, Shr1},
+    ops::{LinearCombination, MulByGenerator, Reduce, ShrAssign},
     pkcs8,
     rand_core::RngCore,
     scalar::FromUintUnchecked,
@@ -293,9 +293,9 @@ impl Neg for Scalar {
     }
 }
 
-impl Shr1 for Scalar {
-    fn shr1(&mut self) {
-        self.0.shr1();
+impl ShrAssign<usize> for Scalar {
+    fn shr_assign(&mut self, rhs: usize) {
+        self.0 >>= rhs;
     }
 }
 

--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -173,8 +173,8 @@ pub trait Curve: 'static + Copy + Clone + Debug + Default + Eq + Ord + Send + Sy
     type FieldBytesSize: ArrayLength<u8> + Add + Eq;
 
     /// Integer type used to represent field elements of this elliptic curve.
-    type Uint: bigint::AddMod<Output = Self::Uint>
-        + ArrayEncoding
+    type Uint: ArrayEncoding
+        + bigint::AddMod<Output = Self::Uint>
         + bigint::Encoding
         + bigint::Integer
         + bigint::NegMod<Output = Self::Uint>

--- a/elliptic-curve/src/ops.rs
+++ b/elliptic-curve/src/ops.rs
@@ -1,6 +1,6 @@
 //! Traits for arithmetic operations on elliptic curve field elements.
 
-pub use core::ops::{Add, AddAssign, Mul, Neg, Sub, SubAssign};
+pub use core::ops::{Add, AddAssign, Mul, Neg, Shr, ShrAssign, Sub, SubAssign};
 
 use crypto_bigint::{ArrayEncoding, ByteArray, Integer};
 
@@ -103,10 +103,4 @@ pub trait Reduce<Uint: Integer + ArrayEncoding>: Sized {
 pub trait ReduceNonZero<Uint: Integer + ArrayEncoding>: Sized {
     /// Perform a modular reduction, returning a field element.
     fn from_uint_reduced_nonzero(n: Uint) -> Self;
-}
-
-/// Right shift this value by one bit, storing the result in-place.
-pub trait Shr1 {
-    /// Right shift this value by one bit in-place.
-    fn shr1(&mut self);
 }

--- a/elliptic-curve/src/scalar/invert.rs
+++ b/elliptic-curve/src/scalar/invert.rs
@@ -1,5 +1,5 @@
 use super::FromUintUnchecked;
-use crate::{ops::Shr1, CurveArithmetic, Scalar};
+use crate::{CurveArithmetic, Scalar};
 use ff::{Field, PrimeField};
 use subtle::CtOption;
 
@@ -23,10 +23,10 @@ where
     while !bool::from(u.is_zero()) {
         // u-loop
         while bool::from(u.is_even()) {
-            u.shr1();
+            u >>= 1;
 
             let was_odd: bool = A.is_odd().into();
-            A.shr1();
+            A >>= 1;
 
             if was_odd {
                 A += order_div_2;
@@ -36,10 +36,10 @@ where
 
         // v-loop
         while bool::from(v.is_even()) {
-            v.shr1();
+            v >>= 1;
 
             let was_odd: bool = C.is_odd().into();
-            C.shr1();
+            C >>= 1;
 
             if was_odd {
                 C += order_div_2;

--- a/elliptic-curve/src/scalar/primitive.rs
+++ b/elliptic-curve/src/scalar/primitive.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     bigint::{prelude::*, Limb, NonZero},
-    ops::{Add, AddAssign, Neg, Shr1, Sub, SubAssign},
+    ops::{Add, AddAssign, Neg, ShrAssign, Sub, SubAssign},
     scalar::FromUintUnchecked,
     Curve, Error, FieldBytes, IsHigh, Result,
 };
@@ -341,12 +341,12 @@ where
     }
 }
 
-impl<C> Shr1 for ScalarPrimitive<C>
+impl<C> ShrAssign<usize> for ScalarPrimitive<C>
 where
     C: Curve,
 {
-    fn shr1(&mut self) {
-        self.inner >>= 1;
+    fn shr_assign(&mut self, rhs: usize) {
+        self.inner >>= rhs;
     }
 }
 


### PR DESCRIPTION
Eliminates a bespoke point solution trait with a standard core trait.

Since `C::Uint` already bounds on `ShrAssign<usize>` this should be fairly trivial to support, even in generic code.