### PR TITLE
elliptic-curve: fewer toplevel re-exports

### DIFF
--- a/elliptic-curve/src/arithmetic.rs
+++ b/elliptic-curve/src/arithmetic.rs
@@ -2,8 +2,10 @@
 
 use crate::{
     ops::{LinearCombination, MulByGenerator, ShrAssign},
+    point::{AffineXCoordinate, AffineYIsOdd},
     scalar::FromUintUnchecked,
-    AffineXCoordinate, AffineYIsOdd, Curve, FieldBytes, IsHigh, PrimeCurve, ScalarPrimitive,
+    scalar::IsHigh,
+    Curve, FieldBytes, PrimeCurve, ScalarPrimitive,
 };
 use core::fmt::Debug;
 use subtle::{ConditionallySelectable, ConstantTimeEq};

--- a/elliptic-curve/src/dev.rs
+++ b/elliptic-curve/src/dev.rs
@@ -9,12 +9,13 @@ use crate::{
     generic_array::typenum::U32,
     ops::{LinearCombination, MulByGenerator, Reduce, ShrAssign},
     pkcs8,
+    point::{AffineXCoordinate, AffineYIsOdd},
     rand_core::RngCore,
-    scalar::FromUintUnchecked,
+    scalar::{FromUintUnchecked, IsHigh},
     sec1::{CompressedPoint, FromEncodedPoint, ToEncodedPoint},
     subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption},
     zeroize::DefaultIsZeroes,
-    AffineXCoordinate, AffineYIsOdd, Curve, CurveArithmetic, IsHigh, PrimeCurve,
+    Curve, CurveArithmetic, PrimeCurve,
 };
 use core::{
     iter::{Product, Sum},
@@ -55,7 +56,7 @@ pub type ScalarPrimitive = crate::ScalarPrimitive<MockCurve>;
 
 /// Scalar bits.
 #[cfg(feature = "bits")]
-pub type ScalarBits = crate::ScalarBits<MockCurve>;
+pub type ScalarBits = crate::scalar::ScalarBits<MockCurve>;
 
 /// Mock elliptic curve type useful for writing tests which require a concrete
 /// curve type.

--- a/elliptic-curve/src/ecdh.rs
+++ b/elliptic-curve/src/ecdh.rs
@@ -27,7 +27,7 @@
 //! [SIGMA]: https://webee.technion.ac.il/~hugo/sigma-pdf.pdf
 
 use crate::{
-    AffinePoint, AffineXCoordinate, Curve, CurveArithmetic, FieldBytes, NonZeroScalar,
+    point::AffineXCoordinate, AffinePoint, Curve, CurveArithmetic, FieldBytes, NonZeroScalar,
     ProjectivePoint, PublicKey,
 };
 use core::borrow::Borrow;

--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -105,11 +105,7 @@ mod voprf;
 pub use crate::{
     error::{Error, Result},
     field::{FieldBytes, FieldBytesSize},
-    point::{
-        AffineXCoordinate, AffineYIsOdd, DecompactPoint, DecompressPoint, PointCompaction,
-        PointCompression,
-    },
-    scalar::{IsHigh, ScalarPrimitive},
+    scalar::ScalarPrimitive,
     secret_key::SecretKey,
 };
 pub use crypto_bigint as bigint;
@@ -129,9 +125,6 @@ pub use {
     ff::{self, Field, PrimeField},
     group::{self, Group},
 };
-
-#[cfg(feature = "bits")]
-pub use crate::scalar::ScalarBits;
 
 #[cfg(feature = "jwk")]
 pub use crate::jwk::{JwkEcKey, JwkParameters};

--- a/elliptic-curve/src/public_key.rs
+++ b/elliptic-curve/src/public_key.rs
@@ -18,8 +18,9 @@ use core::str::FromStr;
 #[cfg(feature = "sec1")]
 use {
     crate::{
+        point::PointCompression,
         sec1::{EncodedPoint, FromEncodedPoint, ModulusSize, ToEncodedPoint},
-        Curve, FieldBytesSize, PointCompression,
+        Curve, FieldBytesSize,
     },
     core::cmp::Ordering,
     subtle::CtOption,

--- a/elliptic-curve/src/scalar/nonzero.rs
+++ b/elliptic-curve/src/scalar/nonzero.rs
@@ -2,7 +2,8 @@
 
 use crate::{
     ops::{Invert, Reduce, ReduceNonZero},
-    CurveArithmetic, Error, FieldBytes, IsHigh, PrimeCurve, Scalar, ScalarPrimitive, SecretKey,
+    scalar::IsHigh,
+    CurveArithmetic, Error, FieldBytes, PrimeCurve, Scalar, ScalarPrimitive, SecretKey,
 };
 use base16ct::HexDisplay;
 use core::{

--- a/elliptic-curve/src/scalar/primitive.rs
+++ b/elliptic-curve/src/scalar/primitive.rs
@@ -4,7 +4,8 @@ use crate::{
     bigint::{prelude::*, Limb, NonZero},
     ops::{Add, AddAssign, Neg, ShrAssign, Sub, SubAssign},
     scalar::FromUintUnchecked,
-    Curve, Error, FieldBytes, IsHigh, Result,
+    scalar::IsHigh,
+    Curve, Error, FieldBytes, Result,
 };
 use base16ct::HexDisplay;
 use core::{cmp::Ordering, fmt, str};


### PR DESCRIPTION
Gets rid of re-exports at the toplevel for modules that are newly `pub` to avoid polluting the namespace.

Only the `AffinePoint`, `ProjectivePoint`, and `Scalar` re-exports are retained.