### PR TITLE
elliptic-curve: remove `Reduce` methods

### DIFF
--- a/elliptic-curve/src/dev.rs
+++ b/elliptic-curve/src/dev.rs
@@ -325,7 +325,7 @@ impl<'a> Product<&'a Scalar> for Scalar {
 }
 
 impl Reduce<U256> for Scalar {
-    fn from_uint_reduced(w: U256) -> Self {
+    fn reduce(w: U256) -> Self {
         let (r, underflow) = w.sbb(&MockCurve::ORDER, Limb::ZERO);
         let underflow = Choice::from((underflow.0 >> (Limb::BITS - 1)) as u8);
         let reduced = U256::conditional_select(&w, &r, !underflow);

--- a/elliptic-curve/src/ops.rs
+++ b/elliptic-curve/src/ops.rs
@@ -2,13 +2,10 @@
 
 pub use core::ops::{Add, AddAssign, Mul, Neg, Shr, ShrAssign, Sub, SubAssign};
 
-use crypto_bigint::{ArrayEncoding, ByteArray, Integer};
+use crypto_bigint::Integer;
 
 #[cfg(feature = "arithmetic")]
 use {group::Group, subtle::CtOption};
-
-#[cfg(feature = "digest")]
-use digest::FixedOutput;
 
 /// Perform an inversion on a field element (i.e. base field element or scalar)
 pub trait Invert {
@@ -56,41 +53,9 @@ pub trait MulByGenerator: Group {
 }
 
 /// Modular reduction.
-pub trait Reduce<Uint: Integer + ArrayEncoding>: Sized {
+pub trait Reduce<Uint: Integer>: Sized {
     /// Perform a modular reduction, returning a field element.
-    fn from_uint_reduced(n: Uint) -> Self;
-
-    /// Interpret the given byte array as a big endian integer and perform
-    /// a modular reduction.
-    fn from_be_bytes_reduced(bytes: ByteArray<Uint>) -> Self {
-        Self::from_uint_reduced(Uint::from_be_byte_array(bytes))
-    }
-
-    /// Interpret the given byte array as a little endian integer and perform a
-    /// modular reduction.
-    fn from_le_bytes_reduced(bytes: ByteArray<Uint>) -> Self {
-        Self::from_uint_reduced(Uint::from_le_byte_array(bytes))
-    }
-
-    /// Interpret a digest as a big endian integer and perform a modular
-    /// reduction.
-    #[cfg(feature = "digest")]
-    fn from_be_digest_reduced<D>(digest: D) -> Self
-    where
-        D: FixedOutput<OutputSize = Uint::ByteSize>,
-    {
-        Self::from_be_bytes_reduced(digest.finalize_fixed())
-    }
-
-    /// Interpret a digest as a little endian integer and perform a modular
-    /// reduction.
-    #[cfg(feature = "digest")]
-    fn from_le_digest_reduced<D>(digest: D) -> Self
-    where
-        D: FixedOutput<OutputSize = Uint::ByteSize>,
-    {
-        Self::from_le_bytes_reduced(digest.finalize_fixed())
-    }
+    fn reduce(n: Uint) -> Self;
 }
 
 /// Modular reduction to a non-zero output.
@@ -100,7 +65,7 @@ pub trait Reduce<Uint: Integer + ArrayEncoding>: Sized {
 ///
 /// End users should use the [`Reduce`] impl on
 /// [`NonZeroScalar`][`crate::NonZeroScalar`] instead.
-pub trait ReduceNonZero<Uint: Integer + ArrayEncoding>: Sized {
+pub trait ReduceNonZero<Uint: Integer>: Sized {
     /// Perform a modular reduction, returning a field element.
-    fn from_uint_reduced_nonzero(n: Uint) -> Self;
+    fn reduce_nonzero(n: Uint) -> Self;
 }

--- a/elliptic-curve/src/public_key.rs
+++ b/elliptic-curve/src/public_key.rs
@@ -157,7 +157,7 @@ where
     }
 
     /// Convert this [`PublicKey`] to a [`NonIdentity`] of the inner [`AffinePoint`]
-    pub fn to_non_identity(&self) -> NonIdentity<AffinePoint<C>> {
+    pub fn to_nonidentity(&self) -> NonIdentity<AffinePoint<C>> {
         NonIdentity::new_unchecked(self.point)
     }
 
@@ -307,7 +307,7 @@ where
     C: CurveArithmetic,
 {
     fn from(value: &PublicKey<C>) -> Self {
-        PublicKey::to_non_identity(value)
+        PublicKey::to_nonidentity(value)
     }
 }
 

--- a/elliptic-curve/src/scalar/nonzero.rs
+++ b/elliptic-curve/src/scalar/nonzero.rs
@@ -251,8 +251,8 @@ where
     I: Integer + ArrayEncoding,
     Scalar<C>: ReduceNonZero<I>,
 {
-    fn from_uint_reduced(n: I) -> Self {
-        Self::from_uint_reduced_nonzero(n)
+    fn reduce(n: I) -> Self {
+        Self::reduce_nonzero(n)
     }
 }
 
@@ -262,8 +262,8 @@ where
     I: Integer + ArrayEncoding,
     Scalar<C>: ReduceNonZero<I>,
 {
-    fn from_uint_reduced_nonzero(n: I) -> Self {
-        let scalar = Scalar::<C>::from_uint_reduced_nonzero(n);
+    fn reduce_nonzero(n: I) -> Self {
+        let scalar = Scalar::<C>::reduce_nonzero(n);
         debug_assert!(!bool::from(scalar.is_zero()));
         Self::new(scalar).unwrap()
     }


### PR DESCRIPTION
Removes all methods from `Reduce` except the newly renamed `Reduce::reduce` (formerly `from_uint_reduced`).

This follows #1220 which changed APIs to handle discrepancies between the serialized size of the big integer type used to represent field elements and the on-the-wire serialization which respects the size of the curve's field modulus and order.