### PR TITLE
elliptic-curve: rename `SecretKey::as_scalar_primitive`

### DIFF
--- a/elliptic-curve/src/scalar/nonzero.rs
+++ b/elliptic-curve/src/scalar/nonzero.rs
@@ -175,7 +175,7 @@ where
     C: CurveArithmetic,
 {
     fn from(sk: &SecretKey<C>) -> NonZeroScalar<C> {
-        let scalar = sk.as_scalar_core().to_scalar();
+        let scalar = sk.as_scalar_primitive().to_scalar();
         debug_assert!(!bool::from(scalar.is_zero()));
         Self { scalar }
     }

--- a/elliptic-curve/src/secret_key.rs
+++ b/elliptic-curve/src/secret_key.rs
@@ -115,7 +115,7 @@ where
     /// This value is key material.
     ///
     /// Please treat it with the care it deserves!
-    pub fn as_scalar_core(&self) -> &ScalarPrimitive<C> {
+    pub fn as_scalar_primitive(&self) -> &ScalarPrimitive<C> {
         &self.inner
     }
 


### PR DESCRIPTION
Formerly `::as_scalar_core`. Follows the renaming of `ScalarCore` => `ScalarPrimitive`.