### PR TITLE
elliptic-curve: add (back) reduction from bytes

### DIFF
--- a/elliptic-curve/src/arithmetic.rs
+++ b/elliptic-curve/src/arithmetic.rs
@@ -1,7 +1,7 @@
 //! Elliptic curve arithmetic traits.
 
 use crate::{
-    ops::{LinearCombination, MulByGenerator, ShrAssign},
+    ops::{LinearCombination, MulByGenerator, Reduce, ShrAssign},
     point::{AffineXCoordinate, AffineYIsOdd},
     scalar::FromUintUnchecked,
     scalar::IsHigh,
@@ -72,6 +72,7 @@ pub trait CurveArithmetic: Curve {
         + Into<Self::Uint>
         + IsHigh
         + PartialOrd
+        + Reduce<Self::Uint, Bytes = FieldBytes<Self>>
         + ShrAssign<usize>
         + ff::Field
         + ff::PrimeField<Repr = FieldBytes<Self>>;

--- a/elliptic-curve/src/dev.rs
+++ b/elliptic-curve/src/dev.rs
@@ -325,11 +325,17 @@ impl<'a> Product<&'a Scalar> for Scalar {
 }
 
 impl Reduce<U256> for Scalar {
+    type Bytes = FieldBytes;
+
     fn reduce(w: U256) -> Self {
         let (r, underflow) = w.sbb(&MockCurve::ORDER, Limb::ZERO);
         let underflow = Choice::from((underflow.0 >> (Limb::BITS - 1)) as u8);
         let reduced = U256::conditional_select(&w, &r, !underflow);
         Self(ScalarPrimitive::new(reduced).unwrap())
+    }
+
+    fn reduce_bytes(_: &FieldBytes) -> Self {
+        todo!()
     }
 }
 

--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -72,7 +72,6 @@ extern crate alloc;
 #[cfg(feature = "std")]
 extern crate std;
 
-pub mod ops;
 pub mod point;
 pub mod scalar;
 
@@ -82,6 +81,8 @@ pub mod dev;
 pub mod ecdh;
 #[cfg(feature = "hash2curve")]
 pub mod hash2curve;
+#[cfg(feature = "arithmetic")]
+pub mod ops;
 #[cfg(feature = "sec1")]
 pub mod sec1;
 #[cfg(feature = "arithmetic")]

--- a/elliptic-curve/src/scalar/nonzero.rs
+++ b/elliptic-curve/src/scalar/nonzero.rs
@@ -249,10 +249,16 @@ impl<C, I> Reduce<I> for NonZeroScalar<C>
 where
     C: CurveArithmetic,
     I: Integer + ArrayEncoding,
-    Scalar<C>: ReduceNonZero<I>,
+    Scalar<C>: Reduce<I, Bytes = FieldBytes<C>> + ReduceNonZero<I>,
 {
+    type Bytes = FieldBytes<C>;
+
     fn reduce(n: I) -> Self {
         Self::reduce_nonzero(n)
+    }
+
+    fn reduce_bytes(bytes: &FieldBytes<C>) -> Self {
+        Self::reduce_nonzero_bytes(bytes)
     }
 }
 
@@ -260,10 +266,16 @@ impl<C, I> ReduceNonZero<I> for NonZeroScalar<C>
 where
     C: CurveArithmetic,
     I: Integer + ArrayEncoding,
-    Scalar<C>: ReduceNonZero<I>,
+    Scalar<C>: Reduce<I, Bytes = FieldBytes<C>> + ReduceNonZero<I>,
 {
     fn reduce_nonzero(n: I) -> Self {
         let scalar = Scalar::<C>::reduce_nonzero(n);
+        debug_assert!(!bool::from(scalar.is_zero()));
+        Self::new(scalar).unwrap()
+    }
+
+    fn reduce_nonzero_bytes(bytes: &FieldBytes<C>) -> Self {
+        let scalar = Scalar::<C>::reduce_nonzero_bytes(bytes);
         debug_assert!(!bool::from(scalar.is_zero()));
         Self::new(scalar).unwrap()
     }

--- a/elliptic-curve/src/scalar/primitive.rs
+++ b/elliptic-curve/src/scalar/primitive.rs
@@ -2,13 +2,17 @@
 
 use crate::{
     bigint::{prelude::*, Limb, NonZero},
-    ops::{Add, AddAssign, Neg, ShrAssign, Sub, SubAssign},
     scalar::FromUintUnchecked,
     scalar::IsHigh,
     Curve, Error, FieldBytes, Result,
 };
 use base16ct::HexDisplay;
-use core::{cmp::Ordering, fmt, str};
+use core::{
+    cmp::Ordering,
+    fmt,
+    ops::{Add, AddAssign, Neg, ShrAssign, Sub, SubAssign},
+    str,
+};
 use generic_array::GenericArray;
 use rand_core::CryptoRngCore;
 use subtle::{


### PR DESCRIPTION
As a replacement for the previous methods on `Reduce` which take bytes as input, this adds a new curve-specific method for reducing from bytes to a field element.

Bytes is defined as an associated type rather than inferred from the unsigned integer parameter. This is because the integer size may not map exactly to the size of the input, especially for wide reductions.

Bytes are interpreted according to curve-specific rules.