### PR TITLE
elliptic-curve: factor out `FieldBytesEncoding` trait

### DIFF
--- a/elliptic-curve/src/dev.rs
+++ b/elliptic-curve/src/dev.rs
@@ -15,7 +15,7 @@ use crate::{
     sec1::{CompressedPoint, FromEncodedPoint, ToEncodedPoint},
     subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption},
     zeroize::DefaultIsZeroes,
-    Curve, CurveArithmetic, PrimeCurve,
+    Curve, CurveArithmetic, FieldBytesEncoding, PrimeCurve,
 };
 use core::{
     iter::{Product, Sum},
@@ -338,6 +338,8 @@ impl Reduce<U256> for Scalar {
         todo!()
     }
 }
+
+impl FieldBytesEncoding<MockCurve> for U256 {}
 
 impl From<u64> for Scalar {
     fn from(n: u64) -> Scalar {

--- a/elliptic-curve/src/field.rs
+++ b/elliptic-curve/src/field.rs
@@ -1,10 +1,50 @@
 //! Field elements.
 
-use crate::Curve;
-use generic_array::GenericArray;
+use crate::{
+    bigint::{ArrayEncoding, ByteArray, Integer},
+    Curve,
+};
+use generic_array::{typenum::Unsigned, GenericArray};
 
 /// Size of serialized field elements of this elliptic curve.
 pub type FieldBytesSize<C> = <C as Curve>::FieldBytesSize;
 
 /// Byte representation of a base/scalar field element of a given curve.
 pub type FieldBytes<C> = GenericArray<u8, FieldBytesSize<C>>;
+
+/// Trait for decoding/encoding `Curve::Uint` from/to [`FieldBytes`] using
+/// curve-specific rules.
+///
+/// Namely a curve's modulus may be smaller than the big integer type used to
+/// internally represent field elements (since the latter are multiples of the
+/// limb size), such as in the case of curves like NIST P-224 and P-521, and so
+/// it may need to be padded/truncated to the right length.
+///
+/// Additionally, different curves have different endianness conventions, also
+/// captured here.
+pub trait FieldBytesEncoding<C>: ArrayEncoding + Integer
+where
+    C: Curve,
+{
+    /// Decode unsigned integer from serialized field element.
+    ///
+    /// The default implementation assumes a big endian encoding.
+    fn decode_field_bytes(field_bytes: &FieldBytes<C>) -> Self {
+        debug_assert!(field_bytes.len() <= Self::ByteSize::USIZE);
+        let mut byte_array = ByteArray::<Self>::default();
+        byte_array[..field_bytes.len()].copy_from_slice(field_bytes);
+        Self::from_be_byte_array(byte_array)
+    }
+
+    /// Encode unsigned integer into serialized field element.
+    ///
+    /// The default implementation assumes a big endian encoding.
+    fn encode_field_bytes(&self) -> FieldBytes<C> {
+        let mut field_bytes = FieldBytes::<C>::default();
+        debug_assert!(field_bytes.len() <= Self::ByteSize::USIZE);
+
+        let len = field_bytes.len();
+        field_bytes.copy_from_slice(&self.to_be_byte_array()[..len]);
+        field_bytes
+    }
+}

--- a/elliptic-curve/src/scalar/primitive.rs
+++ b/elliptic-curve/src/scalar/primitive.rs
@@ -4,7 +4,7 @@ use crate::{
     bigint::{prelude::*, Limb, NonZero},
     scalar::FromUintUnchecked,
     scalar::IsHigh,
-    Curve, Error, FieldBytes, Result,
+    Curve, Error, FieldBytes, FieldBytesEncoding, Result,
 };
 use base16ct::HexDisplay;
 use core::{
@@ -78,7 +78,7 @@ where
 
     /// Decode [`ScalarPrimitive`] from a serialized field element
     pub fn from_bytes(bytes: &FieldBytes<C>) -> CtOption<Self> {
-        Self::new(C::decode_field_bytes(bytes))
+        Self::new(C::Uint::decode_field_bytes(bytes))
     }
 
     /// Decode [`ScalarPrimitive`] from a big endian byte slice.
@@ -117,7 +117,7 @@ where
 
     /// Encode [`ScalarPrimitive`] as a serialized field element.
     pub fn to_bytes(&self) -> FieldBytes<C> {
-        C::encode_field_bytes(&self.inner)
+        self.inner.encode_field_bytes()
     }
 
     /// Convert to a `C::Uint`.


### PR DESCRIPTION
Extracts a trait to be impl'd on `Curve::Uint` which provides curve-specific rules for how field elements should be encoded as bytes.

These rules include both endianness and how to pad/truncate bytes to match the size of the integer (which may be larger than the size of the field modulus, to be a multiple of the limb size)