### PR TITLE
elliptic-curve: Allow multiple `dst`s in the hash2curve API

### DIFF
--- a/elliptic-curve/src/hash2curve/group_digest.rs
+++ b/elliptic-curve/src/hash2curve/group_digest.rs
@@ -48,10 +48,10 @@ where
     /// [`ExpandMsgXof`]: crate::hash2curve::ExpandMsgXof
     fn hash_from_bytes<'a, X: ExpandMsg<'a>>(
         msgs: &[&[u8]],
-        dst: &'a [u8],
+        dsts: &'a [&'a [u8]],
     ) -> Result<ProjectivePoint<Self>> {
         let mut u = [Self::FieldElement::default(), Self::FieldElement::default()];
-        hash_to_field::<X, _>(msgs, dst, &mut u)?;
+        hash_to_field::<X, _>(msgs, dsts, &mut u)?;
         let q0 = u[0].map_to_curve();
         let q1 = u[1].map_to_curve();
         // Ideally we could add and then clear cofactor once
@@ -88,10 +88,10 @@ where
     /// [`ExpandMsgXof`]: crate::hash2curve::ExpandMsgXof
     fn encode_from_bytes<'a, X: ExpandMsg<'a>>(
         msgs: &[&[u8]],
-        dst: &'a [u8],
+        dsts: &'a [&'a [u8]],
     ) -> Result<ProjectivePoint<Self>> {
         let mut u = [Self::FieldElement::default()];
-        hash_to_field::<X, _>(msgs, dst, &mut u)?;
+        hash_to_field::<X, _>(msgs, dsts, &mut u)?;
         let q0 = u[0].map_to_curve();
         Ok(q0.clear_cofactor().into())
     }
@@ -109,12 +109,15 @@ where
     ///
     /// [`ExpandMsgXmd`]: crate::hash2curve::ExpandMsgXmd
     /// [`ExpandMsgXof`]: crate::hash2curve::ExpandMsgXof
-    fn hash_to_scalar<'a, X: ExpandMsg<'a>>(msgs: &[&[u8]], dst: &'a [u8]) -> Result<Self::Scalar>
+    fn hash_to_scalar<'a, X: ExpandMsg<'a>>(
+        msgs: &[&[u8]],
+        dsts: &'a [&'a [u8]],
+    ) -> Result<Self::Scalar>
     where
         Self::Scalar: FromOkm,
     {
         let mut u = [Self::Scalar::default()];
-        hash_to_field::<X, _>(msgs, dst, &mut u)?;
+        hash_to_field::<X, _>(msgs, dsts, &mut u)?;
         Ok(u[0])
     }
 }

--- a/elliptic-curve/src/hash2curve/hash2field.rs
+++ b/elliptic-curve/src/hash2curve/hash2field.rs
@@ -32,7 +32,7 @@ pub trait FromOkm {
 /// [`ExpandMsgXmd`]: crate::hash2field::ExpandMsgXmd
 /// [`ExpandMsgXof`]: crate::hash2field::ExpandMsgXof
 #[doc(hidden)]
-pub fn hash_to_field<'a, E, T>(data: &[&[u8]], domain: &'a [u8], out: &mut [T]) -> Result<()>
+pub fn hash_to_field<'a, E, T>(data: &[&[u8]], domain: &'a [&'a [u8]], out: &mut [T]) -> Result<()>
 where
     E: ExpandMsg<'a>,
     T: FromOkm + Default,


### PR DESCRIPTION
After https://github.com/RustCrypto/traits/pull/1175 got merged I attempted to go ahead and update voprf and opaque-ke, but quickly hit the same problem that required https://github.com/RustCrypto/traits/pull/876.

The change to the OPRF ID now being a string instead of a byte made it impossible to generate a fixed size array to hold the DST. So I decided to apply the same solution I did in https://github.com/RustCrypto/traits/pull/876.

There are only two changes:
- All hash2curve APIs now take `&[&[u8]]` instead of `&[u8]` as the `dst` parameter.
- `ExpandMsgXmd` now requires `Default + FixedOutput + HashMarker` instead of `Digest`.