### PR TITLE
elliptic-curve: add `Invert::invert_vartime`

### DIFF
--- a/elliptic-curve/src/ops.rs
+++ b/elliptic-curve/src/ops.rs
@@ -12,6 +12,17 @@ pub trait Invert {
 
     /// Invert a field element.
     fn invert(&self) -> Self::Output;
+
+    /// Invert a field element in variable time.
+    ///
+    /// ⚠️ WARNING!
+    ///
+    /// This method should not be used with secret values, as its variable-time
+    /// operation can potentially leak secrets through sidechannels.
+    fn invert_vartime(&self) -> Self::Output {
+        // Fall back on constant-time implementation by default.
+        self.invert()
+    }
 }
 
 impl<F: ff::Field> Invert for F {

--- a/elliptic-curve/src/scalar/invert.rs
+++ b/elliptic-curve/src/scalar/invert.rs
@@ -8,6 +8,14 @@ use subtle::CtOption;
 /// Returns none if the scalar is zero.
 ///
 /// <https://link.springer.com/article/10.1007/s13389-016-0135-4>
+///
+/// ⚠️ WARNING!
+///
+/// This generic implementation relies on special properties of the scalar
+/// field implementation and may not work correctly! Please ensure your use
+/// cases are well-tested!
+///
+/// USE AT YOUR OWN RISK!
 #[allow(non_snake_case)]
 pub fn invert_vartime<C>(scalar: &Scalar<C>) -> CtOption<Scalar<C>>
 where

--- a/elliptic-curve/src/scalar/nonzero.rs
+++ b/elliptic-curve/src/scalar/nonzero.rs
@@ -184,13 +184,21 @@ where
 impl<C> Invert for NonZeroScalar<C>
 where
     C: CurveArithmetic,
+    Scalar<C>: Invert<Output = CtOption<Scalar<C>>>,
 {
     type Output = Self;
 
     fn invert(&self) -> Self {
         Self {
             // This will always succeed since `scalar` will never be 0
-            scalar: ff::Field::invert(&self.scalar).unwrap(),
+            scalar: Invert::invert(&self.scalar).unwrap(),
+        }
+    }
+
+    fn invert_vartime(&self) -> Self::Output {
+        Self {
+            // This will always succeed since `scalar` will never be 0
+            scalar: Invert::invert_vartime(&self.scalar).unwrap(),
         }
     }
 }


### PR DESCRIPTION
Adds support for optimized variable-time inversions via the `Invert` trait.

By default, the implementation uses a constant-time inversion by calling `Invert::invert`.