### PR TITLE
elliptic-curve: remove blanket impl for `Invert`

### DIFF
--- a/elliptic-curve/src/arithmetic.rs
+++ b/elliptic-curve/src/arithmetic.rs
@@ -1,14 +1,13 @@
 //! Elliptic curve arithmetic traits.
 
 use crate::{
-    ops::{LinearCombination, MulByGenerator, Reduce, ShrAssign},
+    ops::{Invert, LinearCombination, MulByGenerator, Reduce, ShrAssign},
     point::AffineCoordinates,
-    scalar::FromUintUnchecked,
-    scalar::IsHigh,
+    scalar::{FromUintUnchecked, IsHigh},
     Curve, FieldBytes, PrimeCurve, ScalarPrimitive,
 };
 use core::fmt::Debug;
-use subtle::{ConditionallySelectable, ConstantTimeEq};
+use subtle::{ConditionallySelectable, ConstantTimeEq, CtOption};
 use zeroize::DefaultIsZeroes;
 
 /// Elliptic curve with an arithmetic implementation.
@@ -69,6 +68,7 @@ pub trait CurveArithmetic: Curve {
         + Into<FieldBytes<Self>>
         + Into<ScalarPrimitive<Self>>
         + Into<Self::Uint>
+        + Invert<Output = CtOption<Self::Scalar>>
         + IsHigh
         + PartialOrd
         + Reduce<Self::Uint, Bytes = FieldBytes<Self>>

--- a/elliptic-curve/src/dev.rs
+++ b/elliptic-curve/src/dev.rs
@@ -7,7 +7,7 @@ use crate::{
     bigint::{Limb, U256},
     error::{Error, Result},
     generic_array::typenum::U32,
-    ops::{LinearCombination, MulByGenerator, Reduce, ShrAssign},
+    ops::{Invert, LinearCombination, MulByGenerator, Reduce, ShrAssign},
     pkcs8,
     point::AffineCoordinates,
     rand_core::RngCore,
@@ -320,6 +320,14 @@ impl Product for Scalar {
 
 impl<'a> Product<&'a Scalar> for Scalar {
     fn product<I: Iterator<Item = &'a Scalar>>(_iter: I) -> Self {
+        unimplemented!();
+    }
+}
+
+impl Invert for Scalar {
+    type Output = CtOption<Scalar>;
+
+    fn invert(&self) -> CtOption<Scalar> {
         unimplemented!();
     }
 }

--- a/elliptic-curve/src/ops.rs
+++ b/elliptic-curve/src/ops.rs
@@ -3,7 +3,7 @@
 pub use core::ops::{Add, AddAssign, Mul, Neg, Shr, ShrAssign, Sub, SubAssign};
 
 use crypto_bigint::Integer;
-use {group::Group, subtle::CtOption};
+use group::Group;
 
 /// Perform an inversion on a field element (i.e. base field element or scalar)
 pub trait Invert {
@@ -22,14 +22,6 @@ pub trait Invert {
     fn invert_vartime(&self) -> Self::Output {
         // Fall back on constant-time implementation by default.
         self.invert()
-    }
-}
-
-impl<F: ff::Field> Invert for F {
-    type Output = CtOption<F>;
-
-    fn invert(&self) -> CtOption<F> {
-        ff::Field::invert(self)
     }
 }
 


### PR DESCRIPTION
Previously there was a blanket impl for types which impl `ff::Field`, however this precludes implementations being able to define their own `Invert::inert_vartime`.