### PR TITLE
elliptic-curve: have `serde` feature activate `pkcs8`

### DIFF
--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -67,7 +67,7 @@ hazmat = []
 jwk = ["alloc", "base64ct/alloc", "serde", "serde_json", "zeroize/alloc"]
 pkcs8 = ["dep:pkcs8", "sec1"]
 pem = ["alloc", "arithmetic", "pem-rfc7468/alloc", "pkcs8", "sec1/pem"]
-serde = ["alloc", "sec1/serde", "serdect"]
+serde = ["dep:serdect", "alloc", "pkcs8", "sec1/serde"]
 voprf = ["digest"]
 
 [package.metadata.docs.rs]

--- a/elliptic-curve/src/public_key.rs
+++ b/elliptic-curve/src/public_key.rs
@@ -32,7 +32,7 @@ use pkcs8::EncodePublicKey;
 #[cfg(any(feature = "jwk", feature = "pem"))]
 use alloc::string::{String, ToString};
 
-#[cfg(all(feature = "pkcs8", feature = "serde"))]
+#[cfg(feature = "serde")]
 use serdect::serde::{de, ser, Deserialize, Serialize};
 
 #[cfg(all(feature = "sec1", feature = "pkcs8"))]
@@ -413,7 +413,7 @@ where
     }
 }
 
-#[cfg(all(feature = "pkcs8", feature = "serde"))]
+#[cfg(feature = "serde")]
 impl<C> Serialize for PublicKey<C>
 where
     C: AssociatedOid + CurveArithmetic,
@@ -429,7 +429,7 @@ where
     }
 }
 
-#[cfg(all(feature = "pkcs8", feature = "serde"))]
+#[cfg(feature = "serde")]
 impl<'de, C> Deserialize<'de> for PublicKey<C>
 where
     C: AssociatedOid + CurveArithmetic,


### PR DESCRIPTION
Previously the `Serialize`/`Deserialize` impls for `PublicKey` were gated on both the `pkcs8` and `serde` features being enabled, which is potentially confusing.

`PublicKey` uses `pkcs8` to serialize the public key as SPKI, which includes OIDs which identify it as an elliptic curve public key and also another OID which identifies the curve.

Now that features are namespaced, it's easy to activate `pkcs8` from the `serde` feature to make this a bit easier.