### PR TITLE
password-hash: Fix invalid operator in the SaltString struct constructor

### DIFF
--- a/password-hash/src/salt.rs
+++ b/password-hash/src/salt.rs
@@ -198,7 +198,7 @@ impl SaltString {
 
         let length = s.as_bytes().len();
 
-        if length < Salt::MAX_LENGTH {
+        if length <= Salt::MAX_LENGTH {
             let mut bytes = [0u8; Salt::MAX_LENGTH];
             bytes[..length].copy_from_slice(s.as_bytes());
             Ok(SaltString {


### PR DESCRIPTION
I am not 100% sure, but I think the length of provided string `s` should be lower or equal to the `MAX_LENGTH`.

When implementing some algorithm that required 64 bytes long salt I couldn't make a new `SaltString` structure due to this issue  and simple change from `<` to the `<=` operator fixed it. What is more, function `Salt::new` allows for the `s` string to be exactly 64 bytes (`MAX_LENGTH`) long. 

I did not find any opened or closed issues related to this matter, so that's why I am not sure if it is a bug or a feature.