### PR TITLE
elliptic-curve: bump `crypto-bigint` and format crates; MSRV 1.65

### DIFF
--- a/.github/workflows/elliptic-curve.yml
+++ b/.github/workflows/elliptic-curve.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.61.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -79,7 +79,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.61.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
           - nightly
     steps:

--- a/elliptic-curve/Cargo.lock
+++ b/elliptic-curve/Cargo.lock
@@ -9,10 +9,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
 
 [[package]]
-name = "base64ct"
-version = "1.5.3"
+name = "base16ct"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b645a089122eccb6111b4f81cbc1a49f5900ac4666bb93ac027feaecf15607bf"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
+name = "base64ct"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "bitvec"
@@ -43,9 +49,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "const-oid"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cec318a675afcb6a1ea1d4340e2d377e56e47c266f28043ceccbf4412ddfdd3b"
+checksum = "520fbf3c07483f94e3e3ca9d0cfd913d7718ef2483d2cfd91c0d9e91474ab913"
 
 [[package]]
 name = "cpufeatures"
@@ -58,9 +64,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-bigint"
-version = "0.5.0-pre.3"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c37ac947d5ac4ad24acbfe3ae18154b71eb91a360319c2f82e8c9d54d8de71c9"
+checksum = "071c0f5945634bc9ba7a452f492377dd6b1993665ddb58f28704119b32f07a9a"
 dependencies = [
  "generic-array",
  "rand_core",
@@ -80,9 +86,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
+checksum = "bc302fd9b18d66834a6f092d10ea85489c0ca8ad6b7304092135fab171d853cd"
 dependencies = [
  "const-oid",
  "pem-rfc7468",
@@ -104,7 +110,7 @@ dependencies = [
 name = "elliptic-curve"
 version = "0.13.0-pre.5"
 dependencies = [
- "base16ct",
+ "base16ct 0.1.1",
  "base64ct",
  "crypto-bigint",
  "digest",
@@ -150,6 +156,7 @@ checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -221,18 +228,18 @@ checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
 name = "pem-rfc7468"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d159833a9105500e0398934e205e0773f0b27529557134ecfc51c27646adac"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
 dependencies = [
  "base64ct",
 ]
 
 [[package]]
 name = "pkcs8"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
+checksum = "e34154ec92c136238e7c210443538e64350962b8e2788cadcf5f781a6da70c36"
 dependencies = [
  "der",
  "spki",
@@ -261,11 +268,11 @@ checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
 
 [[package]]
 name = "sec1"
-version = "0.3.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
+checksum = "48518a2b5775ba8ca5b46596aae011caa431e6ce7e4a67ead66d92f08884220e"
 dependencies = [
- "base16ct",
+ "base16ct 0.2.0",
  "der",
  "generic-array",
  "pkcs8",
@@ -282,9 +289,9 @@ checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
 
 [[package]]
 name = "serde_json"
-version = "1.0.91"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877c235533714907a8c2464236f5c4b2a17262ef1bd71f38f35ea592c8da6883"
+checksum = "cad406b69c91885b5107daf2c29572f6c8cdb3c66826821e286c533490c0bc76"
 dependencies = [
  "itoa",
  "ryu",
@@ -293,11 +300,11 @@ dependencies = [
 
 [[package]]
 name = "serdect"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "038fce1bf4d74b9b30ea7dcd59df75ba8ec669a5dcb3cc64fbfcef7334ced32c"
+checksum = "a84f14a19e9a014bb9f4512488d9829a68e04ecabffb0f9904cd1ace94598177"
 dependencies = [
- "base16ct",
+ "base16ct 0.2.0",
  "serde",
 ]
 
@@ -324,9 +331,9 @@ dependencies = [
 
 [[package]]
 name = "spki"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
+checksum = "c0445c905640145c7ea8c1993555957f65e7c46d0535b91ba501bc9bfc85522f"
 dependencies = [
  "base64ct",
  "der",

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -13,12 +13,12 @@ readme = "README.md"
 categories = ["cryptography", "no-std"]
 keywords = ["crypto", "ecc", "elliptic", "weierstrass"]
 edition = "2021"
-rust-version = "1.61"
+rust-version = "1.65"
 
 [dependencies]
 base16ct = "0.1.1"
-crypto-bigint = { version = "=0.5.0-pre.3", default-features = false, features = ["rand_core", "generic-array", "zeroize"] }
-generic-array = { version = "0.14", default-features = false }
+crypto-bigint = { version = "0.5", default-features = false, features = ["rand_core", "generic-array", "zeroize"] }
+generic-array = { version = "0.14.6", default-features = false, features = ["zeroize"] }
 rand_core = { version = "0.6.4", default-features = false }
 subtle = { version = "2", default-features = false }
 zeroize = { version = "1.5", default-features = false }
@@ -30,10 +30,10 @@ ff = { version = "0.13", optional = true, default-features = false }
 group = { version = "0.13", optional = true, default-features = false }
 hkdf = { version = "0.12", optional = true, default-features = false }
 hex-literal = { version = "0.3", optional = true }
-pem-rfc7468 = { version = "0.6", optional = true }
-pkcs8 = { version = "0.9", optional = true, default-features = false }
-sec1 = { version = "0.3", optional = true, features = ["subtle", "zeroize"] }
-serdect = { version = "0.1", optional = true, default-features = false, features = ["alloc"] }
+pem-rfc7468 = { version = "0.7", optional = true }
+pkcs8 = { version = "0.10", optional = true, default-features = false }
+sec1 = { version = "0.7.1", optional = true, features = ["subtle", "zeroize"] }
+serdect = { version = "0.2", optional = true, default-features = false, features = ["alloc"] }
 serde_json = { version = "1", optional = true, default-features = false, features = ["alloc"] }
 
 [dev-dependencies]
@@ -59,7 +59,7 @@ std = [
 
 arithmetic = ["group"]
 bits = ["arithmetic", "ff/bits"]
-dev = ["arithmetic", "hex-literal", "pem", "pkcs8"]
+dev = ["arithmetic", "dep:hex-literal", "pem", "pkcs8"]
 hash2curve = ["arithmetic", "digest"]
 ecdh = ["arithmetic", "digest", "hkdf"]
 group = ["dep:group", "ff"]

--- a/elliptic-curve/README.md
+++ b/elliptic-curve/README.md
@@ -15,7 +15,7 @@ and public/secret keys composed thereof.
 
 ## Minimum Supported Rust Version
 
-Requires Rust **1.61** or higher.
+Requires Rust **1.65** or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be
 done with a minor version bump.
@@ -49,6 +49,6 @@ dual licensed as above, without any additional terms or conditions.
 [build-image]: https://github.com/RustCrypto/traits/actions/workflows/elliptic-curve.yml/badge.svg
 [build-link]: https://github.com/RustCrypto/traits/actions/workflows/elliptic-curve.yml
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.61+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.65+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260040-elliptic-curves

--- a/elliptic-curve/src/secret_key.rs
+++ b/elliptic-curve/src/secret_key.rs
@@ -190,8 +190,7 @@ where
         AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
         FieldBytesSize<C>: ModulusSize,
     {
-        // TODO(tarcieri): wrap `secret_key_bytes` in `Zeroizing`
-        let mut private_key_bytes = self.to_bytes();
+        let private_key_bytes = Zeroizing::new(self.to_bytes());
         let public_key_bytes = self.public_key().to_encoded_point(false);
 
         let ec_private_key = Zeroizing::new(
@@ -200,11 +199,8 @@ where
                 parameters: None,
                 public_key: Some(public_key_bytes.as_bytes()),
             }
-            .to_vec()?,
+            .to_der()?,
         );
-
-        // TODO(tarcieri): wrap `private_key_bytes` in `Zeroizing`
-        private_key_bytes.zeroize();
 
         Ok(ec_private_key)
     }

--- a/elliptic-curve/src/secret_key/pkcs8.rs
+++ b/elliptic-curve/src/secret_key/pkcs8.rs
@@ -2,7 +2,7 @@
 
 use super::SecretKey;
 use crate::{
-    pkcs8::{self, der::Decode, AssociatedOid, DecodePrivateKey},
+    pkcs8::{self, der::Decode, AssociatedOid},
     sec1::{ModulusSize, ValidatePublicKey},
     Curve, FieldBytesSize, ALGORITHM_OID,
 };
@@ -23,6 +23,7 @@ use {
 use {
     crate::{error::Error, Result},
     core::str::FromStr,
+    pkcs8::DecodePrivateKey,
 };
 
 impl<C> TryFrom<pkcs8::PrivateKeyInfo<'_>> for SecretKey<C>
@@ -42,13 +43,6 @@ where
     }
 }
 
-impl<C> DecodePrivateKey for SecretKey<C>
-where
-    C: Curve + AssociatedOid + ValidatePublicKey,
-    FieldBytesSize<C>: ModulusSize,
-{
-}
-
 #[cfg(all(feature = "alloc", feature = "arithmetic"))]
 impl<C> EncodePrivateKey for SecretKey<C>
 where
@@ -57,7 +51,7 @@ where
     FieldBytesSize<C>: ModulusSize,
 {
     fn to_pkcs8_der(&self) -> pkcs8::Result<der::SecretDocument> {
-        let algorithm_identifier = pkcs8::AlgorithmIdentifier {
+        let algorithm_identifier = pkcs8::AlgorithmIdentifierRef {
             oid: ALGORITHM_OID,
             parameters: Some((&C::OID).into()),
         };

--- a/elliptic-curve/tests/pkcs8.rs
+++ b/elliptic-curve/tests/pkcs8.rs
@@ -31,6 +31,7 @@ fn example_private_key() -> der::SecretDocument {
 
 #[test]
 fn decode_pkcs8_private_key_from_der() {
+    dbg!(example_private_key().as_bytes());
     let secret_key = SecretKey::from_pkcs8_der(example_private_key().as_bytes()).unwrap();
     assert_eq!(secret_key.to_bytes().as_slice(), &EXAMPLE_SCALAR);
 }


### PR DESCRIPTION
Bumps the following dependencies:

- `crypto-bigint` v0.5
- `pem-rfc7468` v0.7
- `pkcs8` v0.10
- `sec1` v0.7
- `serdect` v0.2