### PR TITLE
elliptic-curve: dependency cleanups

### DIFF
--- a/elliptic-curve/Cargo.lock
+++ b/elliptic-curve/Cargo.lock
@@ -4,12 +4,6 @@ version = 3
 
 [[package]]
 name = "base16ct"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
-
-[[package]]
-name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
@@ -110,7 +104,7 @@ dependencies = [
 name = "elliptic-curve"
 version = "0.13.0-rc.0"
 dependencies = [
- "base16ct 0.1.1",
+ "base16ct",
  "base64ct",
  "crypto-bigint",
  "digest",
@@ -272,7 +266,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48518a2b5775ba8ca5b46596aae011caa431e6ce7e4a67ead66d92f08884220e"
 dependencies = [
- "base16ct 0.2.0",
+ "base16ct",
  "der",
  "generic-array",
  "pkcs8",
@@ -304,7 +298,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a84f14a19e9a014bb9f4512488d9829a68e04ecabffb0f9904cd1ace94598177"
 dependencies = [
- "base16ct 0.2.0",
+ "base16ct",
  "serde",
 ]
 

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2021"
 rust-version = "1.65"
 
 [dependencies]
-base16ct = "0.1.1"
+base16ct = "0.2"
 crypto-bigint = { version = "0.5", default-features = false, features = ["rand_core", "generic-array", "zeroize"] }
 generic-array = { version = "0.14.6", default-features = false, features = ["zeroize"] }
 rand_core = { version = "0.6.4", default-features = false }
@@ -24,13 +24,13 @@ subtle = { version = "2", default-features = false }
 zeroize = { version = "1.5", default-features = false }
 
 # optional dependencies
-base64ct = { version = "1", optional = true, default-features = false }
+base64ct = { version = "1", optional = true, default-features = false, features = ["alloc"] }
 digest = { version = "0.10", optional = true }
 ff = { version = "0.13", optional = true, default-features = false }
 group = { version = "0.13", optional = true, default-features = false }
 hkdf = { version = "0.12", optional = true, default-features = false }
 hex-literal = { version = "0.3", optional = true }
-pem-rfc7468 = { version = "0.7", optional = true }
+pem-rfc7468 = { version = "0.7", optional = true, features = ["alloc"] }
 pkcs8 = { version = "0.10", optional = true, default-features = false }
 sec1 = { version = "0.7.1", optional = true, features = ["subtle", "zeroize"] }
 serdect = { version = "0.2", optional = true, default-features = false, features = ["alloc"] }
@@ -61,12 +61,12 @@ arithmetic = ["group"]
 bits = ["arithmetic", "ff/bits"]
 dev = ["arithmetic", "dep:hex-literal", "pem", "pkcs8"]
 hash2curve = ["arithmetic", "digest"]
-ecdh = ["arithmetic", "digest", "hkdf"]
+ecdh = ["arithmetic", "digest", "dep:hkdf"]
 group = ["dep:group", "ff"]
 hazmat = []
-jwk = ["alloc", "base64ct/alloc", "serde", "serde_json", "zeroize/alloc"]
+jwk = ["dep:base64ct", "dep:serde_json", "alloc", "serde", "zeroize/alloc"]
 pkcs8 = ["dep:pkcs8", "sec1"]
-pem = ["alloc", "arithmetic", "pem-rfc7468/alloc", "pkcs8", "sec1/pem"]
+pem = ["dep:pem-rfc7468", "alloc", "arithmetic", "pkcs8", "sec1/pem"]
 serde = ["dep:serdect", "alloc", "pkcs8", "sec1/serde"]
 voprf = ["digest"]
 


### PR DESCRIPTION
- Bump `base16ct` to v0.2
- Put more dependencies behind namespaced features