### PR TITLE
elliptic-curve: `SecretKey::from_slice` short input support

### DIFF
--- a/elliptic-curve/tests/secret_key.rs
+++ b/elliptic-curve/tests/secret_key.rs
@@ -5,6 +5,24 @@
 use elliptic_curve::dev::SecretKey;
 
 #[test]
-fn undersize_secret_key() {
+fn from_slice_undersize() {
     assert!(SecretKey::from_slice(&[]).is_err());
+}
+
+#[test]
+fn from_slice_expected_size() {
+    let bytes = [1u8; 32];
+    assert!(SecretKey::from_slice(&bytes).is_ok());
+}
+
+#[test]
+fn from_slice_allowed_short() {
+    let bytes = [1u8; 28];
+    assert!(SecretKey::from_slice(&bytes).is_ok());
+}
+
+#[test]
+fn from_slice_too_short() {
+    let bytes = [1u8; 27];
+    assert!(SecretKey::from_slice(&bytes).is_err());
 }


### PR DESCRIPTION
Tolerates inputs which are slightly shorter than expected (up to 4-bytes) to handle inputs from formats which strip leading zeroes from serialized scalars.

Closes https://github.com/RustCrypto/elliptic-curves/issues/769