### PR TITLE
elliptic-curve v0.13.1

### DIFF
--- a/elliptic-curve/CHANGELOG.md
+++ b/elliptic-curve/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.13.1 (2023-03-01)
+### Added
+- `SecretKey::from_slice` short input support ([#1256])
+
+[#1256]: https://github.com/RustCrypto/traits/pull/1256
+
 ## 0.13.0 (2023-02-28)
 ### Added
 - `PublicKey::to_sec1_bytes` ([#1102])

--- a/elliptic-curve/Cargo.lock
+++ b/elliptic-curve/Cargo.lock
@@ -102,7 +102,7 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "base16ct",
  "base64ct",

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elliptic-curve"
-version = "0.13.0"
+version = "0.13.1"
 description = """
 General purpose Elliptic Curve Cryptography (ECC) support, including types
 and traits for representing various elliptic curve forms, scalars, points,


### PR DESCRIPTION
### Added
- `SecretKey::from_slice` short input support ([#1256])

[#1256]: https://github.com/RustCrypto/traits/pull/1256