### PR TITLE
digest+universal-hash: loosen `subtle` version requirement

### DIFF
--- a/digest/Cargo.toml
+++ b/digest/Cargo.toml
@@ -17,7 +17,7 @@ crypto-common = "0.2.0-pre"
 
 # optional dependencies
 block-buffer = { version = "0.11.0-pre", optional = true }
-subtle = { version = "=2.4", default-features = false, optional = true }
+subtle = { version = "2.4", default-features = false, optional = true }
 blobby = { version = "0.3", optional = true }
 const-oid = { version = "0.9", optional = true }
 

--- a/universal-hash/Cargo.toml
+++ b/universal-hash/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["cryptography", "no-std"]
 
 [dependencies]
 crypto-common = "0.1.6"
-subtle = { version = "=2.4", default-features = false }
+subtle = { version = "2.4", default-features = false }
 
 [features]
 std = ["crypto-common/std"]


### PR DESCRIPTION
Relaxes the version requirement from `=2.4` to `^2.4`, which allows usage of the newly published `subtle` v2.5.0 release.