### PR TITLE
password-hash: provide std::error::Error::source() for Error

### DIFF
--- a/password-hash/src/errors.rs
+++ b/password-hash/src/errors.rs
@@ -100,7 +100,25 @@ impl fmt::Display for Error {
 }
 
 #[cfg(feature = "std")]
-impl std::error::Error for Error {}
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Algorithm => None,
+            Self::B64Encoding(err) => Some(err),
+            Self::Crypto => None,
+            Self::OutputSize { .. } => None,
+            Self::ParamNameDuplicated => None,
+            Self::ParamNameInvalid => None,
+            Self::ParamValueInvalid(err) => Some(err),
+            Self::ParamsMaxExceeded => None,
+            Self::Password => None,
+            Self::PhcStringField => None,
+            Self::PhcStringTrailingData => None,
+            Self::SaltInvalid(err) => Some(err),
+            Self::Version => None,
+        }
+    }
+}
 
 impl From<B64Error> for Error {
     fn from(err: B64Error) -> Error {

--- a/password-hash/src/errors.rs
+++ b/password-hash/src/errors.rs
@@ -157,3 +157,6 @@ impl fmt::Display for InvalidValue {
         }
     }
 }
+
+#[cfg(feature = "std")]
+impl std::error::Error for InvalidValue {}


### PR DESCRIPTION
There's not much in the way of description here, I hope the change is self-explanatory.