### PR TITLE
password-hash: clarity improvements for `Salt*` APIs

### DIFF
--- a/password-hash/Cargo.toml
+++ b/password-hash/Cargo.toml
@@ -21,7 +21,7 @@ base64ct = "1"
 subtle = { version = "2", default-features = false }
 
 # optional dependencies
-rand_core = { version = "0.6", optional = true, default-features = false }
+rand_core = { version = "0.6.4", optional = true, default-features = false }
 
 [features]
 default = ["rand_core"]

--- a/password-hash/tests/encoding.rs
+++ b/password-hash/tests/encoding.rs
@@ -23,10 +23,10 @@ const EXAMPLE_OUTPUT_RAW: &[u8] =
 #[test]
 fn salt_roundtrip() {
     let mut buffer = [0u8; 64];
-    let salt = Salt::new(EXAMPLE_SALT_B64).unwrap();
+    let salt = Salt::from_b64(EXAMPLE_SALT_B64).unwrap();
     assert_eq!(salt.as_ref(), EXAMPLE_SALT_B64);
 
-    let salt_decoded = salt.b64_decode(&mut buffer).unwrap();
+    let salt_decoded = salt.decode_b64(&mut buffer).unwrap();
     assert_eq!(salt_decoded, EXAMPLE_SALT_RAW);
 }
 

--- a/password-hash/tests/hashing.rs
+++ b/password-hash/tests/hashing.rs
@@ -29,7 +29,7 @@ impl PasswordHasher for StubPasswordHasher {
             }
         }
 
-        for slice in &[b"pw", password, b",salt:", salt.as_bytes()] {
+        for slice in &[b"pw", password, b",salt:", salt.as_str().as_bytes()] {
             output.extend_from_slice(slice);
         }
 
@@ -68,7 +68,7 @@ impl<'a> TryFrom<StubParams> for ParamsString {
 #[test]
 fn verify_password_hash() {
     let valid_password = "test password";
-    let salt = Salt::new("test-salt").unwrap();
+    let salt = Salt::from_b64("test-salt").unwrap();
     let hash = PasswordHash::generate(StubPasswordHasher, valid_password, salt).unwrap();
 
     // Sanity tests for StubFunction impl above

--- a/password-hash/tests/password_hash.rs
+++ b/password-hash/tests/password_hash.rs
@@ -57,7 +57,7 @@ fn salt() {
         algorithm: EXAMPLE_ALGORITHM,
         version: None,
         params: ParamsString::new(),
-        salt: Some(Salt::new(EXAMPLE_SALT).unwrap()),
+        salt: Some(Salt::from_b64(EXAMPLE_SALT).unwrap()),
         hash: None,
     };
 
@@ -77,7 +77,7 @@ fn one_param_and_salt() {
         algorithm: EXAMPLE_ALGORITHM,
         version: None,
         params,
-        salt: Some(Salt::new(EXAMPLE_SALT).unwrap()),
+        salt: Some(Salt::from_b64(EXAMPLE_SALT).unwrap()),
         hash: None,
     };
 
@@ -94,7 +94,7 @@ fn params_and_salt() {
         algorithm: EXAMPLE_ALGORITHM,
         version: None,
         params: example_params(),
-        salt: Some(Salt::new(EXAMPLE_SALT).unwrap()),
+        salt: Some(Salt::from_b64(EXAMPLE_SALT).unwrap()),
         hash: None,
     };
 
@@ -111,7 +111,7 @@ fn salt_and_hash() {
         algorithm: EXAMPLE_ALGORITHM,
         version: None,
         params: ParamsString::default(),
-        salt: Some(Salt::new(EXAMPLE_SALT).unwrap()),
+        salt: Some(Salt::from_b64(EXAMPLE_SALT).unwrap()),
         hash: Some(EXAMPLE_HASH.try_into().unwrap()),
     };
 
@@ -131,7 +131,7 @@ fn all_fields() {
         algorithm: EXAMPLE_ALGORITHM,
         version: None,
         params: example_params(),
-        salt: Some(Salt::new(EXAMPLE_SALT).unwrap()),
+        salt: Some(Salt::from_b64(EXAMPLE_SALT).unwrap()),
         hash: Some(EXAMPLE_HASH.try_into().unwrap()),
     };
 


### PR DESCRIPTION
The `Salt` and `SaltString` types are wrappers for B64-encoded salt strings as used by the PHC string format.

These API changes make it clearer that the input string needs to be B64-encoded.

The old API is preserved but with deprecations to ease upgrades.

The following methods were renamed:

- `Salt::new` => `Salt::from_b64`
- `Salt::b64_decode` => `Salt::decode_b64` (for consistency)
- `SaltString::new` => `SaltString::from_b64`
- `SaltString::b64_decode` => `SaltString::decode_b64`
- `SaltString::b64_encode` => `SaltString::encode_b64`

The `Salt::as_bytes` and `SaltString::as_bytes` methods were removed, as they return the B64-encoded string as bytes, rather than decoding B64 to bytes, which is what a user might be expecting.