### PR TITLE
password-hash v0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -702,7 +702,7 @@ dependencies = [
 
 [[package]]
 name = "password-hash"
-version = "0.5.0-rc.0"
+version = "0.5.0"
 dependencies = [
  "base64ct",
  "rand_core 0.6.4",

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -22,7 +22,7 @@ aead = { version = "0.5", optional = true, path = "../aead" }
 cipher = { version = "0.4", optional = true }
 digest = { version = "0.10", optional = true, features = ["mac"] }
 elliptic-curve = { version = "0.12", optional = true } # path = "../elliptic-curve"
-password-hash = { version = "=0.5.0-rc.0", optional = true, path = "../password-hash" }
+password-hash = { version = "0.5", optional = true, path = "../password-hash" }
 signature = { version = "2", optional = true, default-features = false, path = "../signature" }
 universal-hash = { version = "0.5", optional = true, path = "../universal-hash" }
 

--- a/password-hash/CHANGELOG.md
+++ b/password-hash/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.5.0 (2023-03-04)
+### Added
+- `Error::OutputSize` ([#1026])
+- `std::error::Error::source` for `Error` ([#1264])
+- `getrandom` feature ([#1267])
+
+### Changed
+- Use `Salt` type with `PasswordHasher` ([#1187])
+- Rename `Salt::new` => `Salt::from_b64` ([#1266])
+- Rename `Salt::b64_decode` => `Salt::decode_b64` ([#1266])
+- Rename `SaltString::new` => `SaltString::from_b64` ([#1266])
+- Rename `SaltString::b64_decode` => `SaltString::decode_b64` ([#1266])
+- Rename `SaltString::b64_encode` => `SaltString::encode_b64` ([#1266])
+
+### Fixed
+- Allow `Salt` to be exactly the same amount as `MAX_LENGTH` value ([#1246])
+
+[#1026]: https://github.com/RustCrypto/traits/pull/1026
+[#1187]: https://github.com/RustCrypto/traits/pull/1187
+[#1246]: https://github.com/RustCrypto/traits/pull/1246
+[#1264]: https://github.com/RustCrypto/traits/pull/1264
+[#1266]: https://github.com/RustCrypto/traits/pull/1266
+[#1267]: https://github.com/RustCrypto/traits/pull/1267
+
 ## 0.4.2 (2022-06-27)
 ### Fixed
 - docs.rs metadata ([#1031])

--- a/password-hash/Cargo.toml
+++ b/password-hash/Cargo.toml
@@ -5,7 +5,7 @@ Traits which describe the functionality of password hashing algorithms,
 as well as a `no_std`-friendly implementation of the PHC string format
 (a well-defined subset of the Modular Crypt Format a.k.a. MCF)
 """
-version = "0.5.0-rc.0"
+version = "0.5.0"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/password-hash/LICENSE-MIT
+++ b/password-hash/LICENSE-MIT
@@ -1,4 +1,4 @@
-Copyright (c) 2020 RustCrypto Developers
+Copyright (c) 2020-2023 RustCrypto Developers
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated


### PR DESCRIPTION
### Added
- `Error::OutputSize` ([#1026])
- `std::error::Error::source` for `Error` ([#1264])
- `getrandom` feature ([#1267])

### Changed
- Use `Salt` type with `PasswordHasher` ([#1187])
- Rename `Salt::new` => `Salt::from_b64` ([#1266])
- Rename `Salt::b64_decode` => `Salt::decode_b64` ([#1266])
- Rename `SaltString::new` => `SaltString::from_b64` ([#1266])
- Rename `SaltString::b64_decode` => `SaltString::decode_b64` ([#1266])
- Rename `SaltString::b64_encode` => `SaltString::encode_b64` ([#1266])

### Fixed
- Allow `Salt` to be exactly the same amount as `MAX_LENGTH` value ([#1246])

[#1026]: https://github.com/RustCrypto/traits/pull/1026
[#1187]: https://github.com/RustCrypto/traits/pull/1187
[#1246]: https://github.com/RustCrypto/traits/pull/1246
[#1264]: https://github.com/RustCrypto/traits/pull/1264
[#1266]: https://github.com/RustCrypto/traits/pull/1266
[#1267]: https://github.com/RustCrypto/traits/pull/1267