### PR TITLE
elliptic-curve v0.13.2

### DIFF
--- a/elliptic-curve/CHANGELOG.md
+++ b/elliptic-curve/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.13.2 (2023-03-08)
+### Added
+- Weakly activate `pkcs8?/std` ([#1263])
+- More `PublicKey` <-> SEC1 conversions ([#1272])
+
+[#1263]: https://github.com/RustCrypto/traits/pull/1263
+[#1272]: https://github.com/RustCrypto/traits/pull/1272
+
 ## 0.13.1 (2023-03-01)
 ### Added
 - `SecretKey::from_slice` short input support ([#1256])

--- a/elliptic-curve/Cargo.lock
+++ b/elliptic-curve/Cargo.lock
@@ -102,7 +102,7 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "base16ct",
  "base64ct",

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elliptic-curve"
-version = "0.13.1"
+version = "0.13.2"
 description = """
 General purpose Elliptic Curve Cryptography (ECC) support, including types
 and traits for representing various elliptic curve forms, scalars, points,


### PR DESCRIPTION
### Added
- Weakly activate `pkcs8?/std` ([#1263])
- More `PublicKey` <-> SEC1 conversions ([#1272])

[#1263]: https://github.com/RustCrypto/traits/pull/1263
[#1272]: https://github.com/RustCrypto/traits/pull/1272