### PR TITLE
Replace unmaintained actions-rs/* actions in CI workflows

### DIFF
--- a/.github/workflows/aead.yml
+++ b/.github/workflows/aead.yml
@@ -30,12 +30,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: RustCrypto/actions/cargo-cache@master
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: ${{ matrix.rust }}
-          target: ${{ matrix.target }}
-          override: true
+          targets: ${{ matrix.target }}
       - run: cargo check --all-features
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features alloc
@@ -59,11 +57,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: RustCrypto/actions/cargo-cache@master
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
-          override: true
-          profile: minimal
       - run: cargo test --release --no-default-features
       - run: cargo test --release
       - run: cargo test --release --all-features

--- a/.github/workflows/async-signature.yml
+++ b/.github/workflows/async-signature.yml
@@ -27,11 +27,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: RustCrypto/actions/cargo-cache@master
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
-          override: true
-          profile: minimal
       - run: cargo check --all-features
       - run: cargo test --release
       - run: cargo test --all-features --release
@@ -41,11 +39,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: RustCrypto/actions/cargo-cache@master
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly
-          override: true
-          profile: minimal
       - uses: RustCrypto/actions/cargo-hack-install@master
       - run: rm ../../Cargo.toml
       - run: cargo update -Z minimal-versions

--- a/.github/workflows/cipher.yml
+++ b/.github/workflows/cipher.yml
@@ -30,12 +30,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: RustCrypto/actions/cargo-cache@master
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
-          target: ${{ matrix.target }}
-          override: true
-          profile: minimal
+          targets: ${{ matrix.target }}
       - run: cargo build --target ${{ matrix.target }}
       - run: cargo build --target ${{ matrix.target }} --features rand_core
       - run: cargo build --target ${{ matrix.target }} --features block-padding
@@ -47,11 +45,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: RustCrypto/actions/cargo-cache@master
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly
-          override: true
-          profile: minimal
       - uses: RustCrypto/actions/cargo-hack-install@master
       - run: cargo update -Z minimal-versions
       - run: cargo hack test --release --feature-powerset
@@ -66,9 +62,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: RustCrypto/actions/cargo-cache@master
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: ${{ matrix.rust }}
       - run: cargo check --all-features
       - run: cargo test

--- a/.github/workflows/crypto-common.yml
+++ b/.github/workflows/crypto-common.yml
@@ -30,12 +30,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: RustCrypto/actions/cargo-cache@master
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
-          target: ${{ matrix.target }}
-          override: true
-          profile: minimal
+          targets: ${{ matrix.target }}
       - run: cargo build --target ${{ matrix.target }}
 
   minimal-versions:
@@ -53,11 +51,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: RustCrypto/actions/cargo-cache@master
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
-          override: true
-          profile: minimal
       - run: cargo check --all-features
       - run: cargo test
       - run: cargo test --features std

--- a/.github/workflows/crypto.yml
+++ b/.github/workflows/crypto.yml
@@ -30,12 +30,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: RustCrypto/actions/cargo-cache@master
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
-          target: ${{ matrix.target }}
-          override: true
-          profile: minimal
+          targets: ${{ matrix.target }}
       - run: cargo build --no-default-features --release --target ${{ matrix.target }}
       - run: cargo build --no-default-features --release --target ${{ matrix.target }}
                --features aead,cipher,digest,elliptic-curve,signature,universal-hash
@@ -45,11 +43,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: RustCrypto/actions/cargo-cache@master
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly
-          override: true
-          profile: minimal
       - uses: RustCrypto/actions/cargo-hack-install@master
       - run: cargo update -Z minimal-versions
       - run: cargo hack test --release --feature-powerset
@@ -64,11 +60,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: RustCrypto/actions/cargo-cache@master
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
-          override: true
-          profile: minimal
       - run: cargo check --all-features
       - run: cargo test --no-default-features --release
       - run: cargo test --release
@@ -79,10 +73,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: RustCrypto/actions/cargo-cache@master
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: 1.60.0
           components: clippy
-          override: true
-          profile: minimal
       - run: cargo clippy --all --all-features -- -D warnings

--- a/.github/workflows/digest.yml
+++ b/.github/workflows/digest.yml
@@ -30,12 +30,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: RustCrypto/actions/cargo-cache@master
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
-          target: ${{ matrix.target }}
-          override: true
-          profile: minimal
+          targets: ${{ matrix.target }}
       # Isolate this crate from workspace which is otherwise MSRV 1.56 due to 2021 edition crates
       - run: rm ../Cargo.toml
       - run: cargo build --target ${{ matrix.target }}
@@ -55,11 +53,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: RustCrypto/actions/cargo-cache@master
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
-          override: true
-          profile: minimal
       - run: cargo check --all-features
       - run: cargo test --no-default-features
       - run: cargo test

--- a/.github/workflows/elliptic-curve.yml
+++ b/.github/workflows/elliptic-curve.yml
@@ -32,12 +32,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: RustCrypto/actions/cargo-cache@master
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: ${{ matrix.rust }}
-          target: ${{ matrix.target }}
-          override: true
+          targets: ${{ matrix.target }}
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features alloc
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features arithmetic
@@ -65,11 +63,9 @@ jobs:
   #   steps:
   #     - uses: actions/checkout@v3
   #     - uses: RustCrypto/actions/cargo-cache@master
-  #     - uses: actions-rs/toolchain@v1
+  #     - uses: dtolnay/rust-toolchain@master
   #       with:
   #         toolchain: nightly
-  #         override: true
-  #         profile: minimal
   #     - uses: RustCrypto/actions/cargo-hack-install@master
   #     - run: cargo update -Z minimal-versions
   #     - run: cargo hack test --release --feature-powerset
@@ -85,11 +81,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: RustCrypto/actions/cargo-cache@master
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
-          override: true
-          profile: minimal
       - run: cargo check --all-features
       - run: cargo test --no-default-features
       - run: cargo test
@@ -99,9 +93,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
-          override: true
-          profile: minimal
       - run: cargo doc --all-features

--- a/.github/workflows/kem.yml
+++ b/.github/workflows/kem.yml
@@ -30,12 +30,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: RustCrypto/actions/cargo-cache@master
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
-          target: ${{ matrix.target }}
-          override: true
-          profile: minimal
+          targets: ${{ matrix.target }}
       - run: cargo build --no-default-features --release --target ${{ matrix.target }}
 
   # TODO: use the reusable workflow after this crate will be part of the
@@ -45,11 +43,9 @@ jobs:
   #   steps:
   #     - uses: actions/checkout@v3
   #     - uses: RustCrypto/actions/cargo-cache@master
-  #     - uses: actions-rs/toolchain@v1
+  #     - uses: dtolnay/rust-toolchain@master
   #       with:
   #         toolchain: nightly
-  #         override: true
-  #         profile: minimal
   #     - uses: RustCrypto/actions/cargo-hack-install@master
   #     - run: cargo update -Z minimal-versions
   #     - run: cargo hack test --release --feature-powerset
@@ -64,11 +60,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: RustCrypto/actions/cargo-cache@master
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
-          override: true
-          profile: minimal
       - run: cargo check --all-features
       - run: cargo test --no-default-features --release
       - run: cargo test --release

--- a/.github/workflows/password-hash.yml
+++ b/.github/workflows/password-hash.yml
@@ -30,12 +30,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: RustCrypto/actions/cargo-cache@master
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
-          target: ${{ matrix.target }}
-          override: true
-          profile: minimal
+          targets: ${{ matrix.target }}
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features alloc
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features rand_core
@@ -47,11 +45,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: RustCrypto/actions/cargo-cache@master
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly
-          override: true
-          profile: minimal
       - uses: RustCrypto/actions/cargo-hack-install@master
       - run: cargo update -Z minimal-versions
       - run: cargo hack test --release --feature-powerset
@@ -66,11 +62,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: RustCrypto/actions/cargo-cache@master
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
-          override: true
-          profile: minimal
       - run: cargo check --all-features
       - run: cargo test --release --no-default-features
       - run: cargo test --release

--- a/.github/workflows/signature.yml
+++ b/.github/workflows/signature.yml
@@ -31,12 +31,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: RustCrypto/actions/cargo-cache@master
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
-          target: ${{ matrix.target }}
-          override: true
-          profile: minimal
+          targets: ${{ matrix.target }}
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features derive
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features digest
@@ -58,11 +56,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: RustCrypto/actions/cargo-cache@master
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
-          override: true
-          profile: minimal
       - run: cargo check --all-features
       - run: cargo test --no-default-features --release
       - run: cargo test --release
@@ -78,11 +74,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: RustCrypto/actions/cargo-cache@master
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
-          override: true
-          profile: minimal
       - run: cargo test --release
         working-directory: signature/derive
 
@@ -90,9 +84,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
-          override: true
-          profile: minimal
       - run: cargo doc --all-features

--- a/.github/workflows/universal-hash.yml
+++ b/.github/workflows/universal-hash.yml
@@ -30,12 +30,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: RustCrypto/actions/cargo-cache@master
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
-          target: ${{ matrix.target }}
-          override: true
-          profile: minimal
+          targets: ${{ matrix.target }}
       # Isolate this crate from workspace which is otherwise MSRV 1.56 due to 2021 edition crates
       - run: rm ../Cargo.toml
       - run: cargo build --no-default-features --release --target ${{ matrix.target }}
@@ -55,11 +53,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: RustCrypto/actions/cargo-cache@master
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
-          override: true
-          profile: minimal
       # Isolate this crate from workspace which is otherwise MSRV 1.56 due to 2021 edition crates
       - run: rm ../Cargo.toml
       - run: cargo check --all-features

--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -24,25 +24,18 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: RustCrypto/actions/cargo-cache@master
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: 1.60.0
           components: clippy
-          override: true
-          profile: minimal
       - run: cargo clippy --all --all-features -- -D warnings
 
   rustfmt:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
           components: rustfmt
-          profile: minimal
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+      - run: cargo fmt --all -- --check


### PR DESCRIPTION
Basically all of the `actions-rs/*` actions are unmaintained. See <https://github.com/actions-rs/toolchain/issues/216> for more information. Due to their age they generate several warnings in CI runs, for example in https://github.com/RustCrypto/traits/actions/runs/4369716863:

> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions-rs/toolchain@v1, actions-rs/cargo@v1. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

To get rid of some of those warnings the occurrences of `actions-rs/toolchain` are replaced by [`dtolnay/rust-toolchain`](https://github.com/dtolnay/rust-toolchain), and the occurrences of `actions-rs/cargo` are replaced by direct invocations of `cargo`.