### PR TITLE
signature: add `SignatureEncoding::encoded_len`

### DIFF
--- a/signature/src/encoding.rs
+++ b/signature/src/encoding.rs
@@ -23,4 +23,9 @@ pub trait SignatureEncoding:
     fn to_vec(&self) -> Vec<u8> {
         self.to_bytes().as_ref().to_vec()
     }
+
+    /// Get the length of this signature when encoded.
+    fn encoded_len(&self) -> usize {
+        self.to_bytes().as_ref().len()
+    }
 }


### PR DESCRIPTION
Adds a new provided method to the `SignatureEncoding` trait for computing the length of the signature when it's serialized.