### PR TITLE
signature v2.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,7 +60,7 @@ name = "async-signature"
 version = "0.3.0"
 dependencies = [
  "async-trait",
- "signature 2.0.0",
+ "signature 2.1.0",
 ]
 
 [[package]]
@@ -262,7 +262,7 @@ dependencies = [
  "digest 0.10.6",
  "elliptic-curve 0.12.3",
  "password-hash",
- "signature 2.0.0",
+ "signature 2.1.0",
  "universal-hash 0.5.0",
 ]
 
@@ -964,7 +964,7 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "digest 0.10.6",
  "hex-literal",

--- a/signature/CHANGELOG.md
+++ b/signature/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.1.0 (2023-04-01)
+### Added
+- `SignatureEncoding::encoded_len` ([#1283])
+
+[#1283]: https://github.com/RustCrypto/traits/pull/1283
+
 ## 2.0.0 (2023-01-15)
 ### Added
 - `SignatureEncoding` trait as a replacement for `Signature` trait and the

--- a/signature/Cargo.toml
+++ b/signature/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name          = "signature"
 description   = "Traits for cryptographic signature algorithms (e.g. ECDSA, Ed25519)"
-version       = "2.0.0"
+version       = "2.1.0"
 authors       = ["RustCrypto Developers"]
 license       = "Apache-2.0 OR MIT"
 documentation = "https://docs.rs/signature"
 repository    = "https://github.com/RustCrypto/traits/tree/master/signature"
 readme        = "README.md"
-edition       = "2021"
-rust-version  = "1.56"
 keywords      = ["crypto", "ecdsa", "ed25519", "signature", "signing"]
 categories    = ["cryptography", "no-std"]
+edition       = "2021"
+rust-version  = "1.56"
 
 [dependencies]
 derive = { package = "signature_derive", version = "2", optional = true, path = "derive" }

--- a/signature/async/Cargo.toml
+++ b/signature/async/Cargo.toml
@@ -14,7 +14,7 @@ rust-version  = "1.56"
 
 [dependencies]
 async-trait = "0.1.9"
-signature = { version = "2.0, <2.1", path = ".." }
+signature = { version = "2.0, <2.2", path = ".." }
 
 [features]
 digest = ["signature/digest"]


### PR DESCRIPTION
### Added
- `SignatureEncoding::encoded_len` ([#1283])

[#1283]: https://github.com/RustCrypto/traits/pull/1283