### PR TITLE
elliptic-curve: fix FieldBytesEncoding ranges

### DIFF
--- a/elliptic-curve/src/field.rs
+++ b/elliptic-curve/src/field.rs
@@ -32,7 +32,8 @@ where
     fn decode_field_bytes(field_bytes: &FieldBytes<C>) -> Self {
         debug_assert!(field_bytes.len() <= Self::ByteSize::USIZE);
         let mut byte_array = ByteArray::<Self>::default();
-        byte_array[..field_bytes.len()].copy_from_slice(field_bytes);
+        let offset = Self::ByteSize::USIZE - field_bytes.len();
+        byte_array[offset..].copy_from_slice(field_bytes);
         Self::from_be_byte_array(byte_array)
     }
 
@@ -43,8 +44,8 @@ where
         let mut field_bytes = FieldBytes::<C>::default();
         debug_assert!(field_bytes.len() <= Self::ByteSize::USIZE);
 
-        let len = field_bytes.len();
-        field_bytes.copy_from_slice(&self.to_be_byte_array()[..len]);
+        let offset = Self::ByteSize::USIZE - field_bytes.len();
+        field_bytes.copy_from_slice(&self.to_be_byte_array()[offset..]);
         field_bytes
     }
 }


### PR DESCRIPTION
This should fix methods like SecretKey::from_slice for curves where the number of bytes in their internal representation is larger than it's modulus (e.g. NIST P224)