### PR TITLE
elliptic-curve: expand clippy lints

### DIFF
--- a/elliptic-curve/src/dev.rs
+++ b/elliptic-curve/src/dev.rs
@@ -335,6 +335,7 @@ impl Invert for Scalar {
 impl Reduce<U256> for Scalar {
     type Bytes = FieldBytes;
 
+    #[allow(clippy::integer_arithmetic)]
     fn reduce(w: U256) -> Self {
         let (r, underflow) = w.sbb(&MockCurve::ORDER, Limb::ZERO);
         let underflow = Choice::from((underflow.0 >> (Limb::BITS - 1)) as u8);
@@ -599,7 +600,7 @@ impl group::Group for ProjectivePoint {
     }
 
     fn is_identity(&self) -> Choice {
-        Choice::from((self == &Self::Identity) as u8)
+        Choice::from(u8::from(self == &Self::Identity))
     }
 
     #[must_use]

--- a/elliptic-curve/src/field.rs
+++ b/elliptic-curve/src/field.rs
@@ -32,7 +32,7 @@ where
     fn decode_field_bytes(field_bytes: &FieldBytes<C>) -> Self {
         debug_assert!(field_bytes.len() <= Self::ByteSize::USIZE);
         let mut byte_array = ByteArray::<Self>::default();
-        let offset = Self::ByteSize::USIZE - field_bytes.len();
+        let offset = Self::ByteSize::USIZE.saturating_sub(field_bytes.len());
         byte_array[offset..].copy_from_slice(field_bytes);
         Self::from_be_byte_array(byte_array)
     }
@@ -44,7 +44,7 @@ where
         let mut field_bytes = FieldBytes::<C>::default();
         debug_assert!(field_bytes.len() <= Self::ByteSize::USIZE);
 
-        let offset = Self::ByteSize::USIZE - field_bytes.len();
+        let offset = Self::ByteSize::USIZE.saturating_sub(field_bytes.len());
         field_bytes.copy_from_slice(&self.to_be_byte_array()[offset..]);
         field_bytes
     }

--- a/elliptic-curve/src/hash2curve/hash2field.rs
+++ b/elliptic-curve/src/hash2curve/hash2field.rs
@@ -6,7 +6,7 @@ mod expand_msg;
 
 pub use expand_msg::{xmd::*, xof::*, *};
 
-use crate::Result;
+use crate::{Error, Result};
 use generic_array::{typenum::Unsigned, ArrayLength, GenericArray};
 
 /// The trait for helping to convert to a field element.
@@ -37,7 +37,7 @@ where
     E: ExpandMsg<'a>,
     T: FromOkm + Default,
 {
-    let len_in_bytes = T::Length::to_usize() * out.len();
+    let len_in_bytes = T::Length::to_usize().checked_mul(out.len()).ok_or(Error)?;
     let mut tmp = GenericArray::<u8, <T as FromOkm>::Length>::default();
     let mut expander = E::expand_message(data, domain, len_in_bytes)?;
     for o in out.iter_mut() {

--- a/elliptic-curve/src/hash2curve/hash2field/expand_msg/xmd.rs
+++ b/elliptic-curve/src/hash2curve/hash2field/expand_msg/xmd.rs
@@ -1,5 +1,8 @@
 //! `expand_message_xmd` based on a hash function.
 
+// TODO(tarcieri): checked arithmetic
+#![allow(clippy::integer_arithmetic)]
+
 use core::marker::PhantomData;
 
 use super::{Domain, ExpandMsg, Expander};

--- a/elliptic-curve/src/hash2curve/isogeny.rs
+++ b/elliptic-curve/src/hash2curve/isogeny.rs
@@ -26,6 +26,7 @@ pub trait Isogeny: Field + AddAssign + Mul<Output = Self> {
     const COEFFICIENTS: IsogenyCoefficients<Self>;
 
     /// Map from the isogeny points to the main curve
+    #[allow(clippy::integer_arithmetic)]
     fn isogeny(x: Self, y: Self) -> (Self, Self) {
         let mut xs = GenericArray::<Self, Self::Degree>::default();
         xs[0] = Self::ONE;

--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -7,7 +7,17 @@
 )]
 #![forbid(unsafe_code)]
 #![warn(
+    clippy::cast_lossless,
+    clippy::cast_possible_truncation,
+    clippy::cast_possible_wrap,
+    clippy::cast_precision_loss,
+    clippy::cast_sign_loss,
+    clippy::checked_conversions,
+    clippy::implicit_saturating_sub,
+    clippy::integer_arithmetic,
     clippy::mod_module_files,
+    clippy::panic,
+    clippy::panic_in_result_fn,
     clippy::unwrap_used,
     missing_docs,
     rust_2018_idioms,


### PR DESCRIPTION
Adds the following clippy lints and fixes violations thereof:

- clippy::cast_lossless
- clippy::cast_possible_truncation
- clippy::cast_possible_wrap
- clippy::cast_precision_loss
- clippy::cast_sign_loss
- clippy::checked_conversions
- clippy::implicit_saturating_sub
- clippy::integer_arithmetic
- clippy::panic
- clippy::panic_in_result_fn