### PR TITLE
elliptic-curve: fix remaining `FieldBytesSize` handling

### DIFF
--- a/elliptic-curve/src/scalar/nonzero.rs
+++ b/elliptic-curve/src/scalar/nonzero.rs
@@ -13,7 +13,7 @@ use core::{
 };
 use crypto_bigint::{ArrayEncoding, Integer};
 use ff::{Field, PrimeField};
-use generic_array::GenericArray;
+use generic_array::{typenum::Unsigned, GenericArray};
 use rand_core::CryptoRngCore;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 use zeroize::Zeroize;
@@ -285,7 +285,7 @@ where
     type Error = Error;
 
     fn try_from(bytes: &[u8]) -> Result<Self, Error> {
-        if bytes.len() == C::Uint::BYTES {
+        if bytes.len() == C::FieldBytesSize::USIZE {
             Option::from(NonZeroScalar::from_repr(GenericArray::clone_from_slice(
                 bytes,
             )))

--- a/elliptic-curve/src/scalar/primitive.rs
+++ b/elliptic-curve/src/scalar/primitive.rs
@@ -13,7 +13,7 @@ use core::{
     ops::{Add, AddAssign, Neg, ShrAssign, Sub, SubAssign},
     str,
 };
-use generic_array::GenericArray;
+use generic_array::{typenum::Unsigned, GenericArray};
 use rand_core::CryptoRngCore;
 use subtle::{
     Choice, ConditionallySelectable, ConstantTimeEq, ConstantTimeGreater, ConstantTimeLess,
@@ -83,7 +83,7 @@ where
 
     /// Decode [`ScalarPrimitive`] from a big endian byte slice.
     pub fn from_slice(slice: &[u8]) -> Result<Self> {
-        if slice.len() == C::Uint::BYTES {
+        if slice.len() == C::FieldBytesSize::USIZE {
             Option::from(Self::from_bytes(GenericArray::from_slice(slice))).ok_or(Error)
         } else {
             Err(Error)


### PR DESCRIPTION
Fixes the two remaining usages of `C::Uint::BYTES` to use `C::FieldBytesSize::USIZE` instead.

These usages were:

- `NonZeroScalar::from_slice`
- `ScalarPrimitive::from_slice`