### PR TITLE
elliptic-curve v0.13.4

### DIFF
--- a/elliptic-curve/CHANGELOG.md
+++ b/elliptic-curve/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.13.4 (2023-04-08)
+### Changed
+- Bump `hex-literal` to v0.4 ([#1295])
+
+### Fixed
+- `NonZeroScalar::from_slice` ([#1296])
+- `ScalarPrimitive::from_slice` ([#1296])
+
+[#1295]: https://github.com/RustCrypto/traits/pull/1295
+[#1296]: https://github.com/RustCrypto/traits/pull/1296
+
 ## 0.13.3 (2023-04-04)
 ### Added
 - Impl `AssociatedAlgorithmIdentifier` for `SecretKey` and `PublicKey` ([#1286])

--- a/elliptic-curve/Cargo.lock
+++ b/elliptic-curve/Cargo.lock
@@ -102,7 +102,7 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "base16ct",
  "base64ct",

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elliptic-curve"
-version = "0.13.3"
+version = "0.13.4"
 description = """
 General purpose Elliptic Curve Cryptography (ECC) support, including types
 and traits for representing various elliptic curve forms, scalars, points,


### PR DESCRIPTION
### Changed
- Bump `hex-literal` to v0.4 ([#1295])

### Fixed
- `NonZeroScalar::from_slice` ([#1296])
- `ScalarPrimitive::from_slice` ([#1296])

[#1295]: https://github.com/RustCrypto/traits/pull/1295
[#1296]: https://github.com/RustCrypto/traits/pull/1296
