### PR TITLE
signature_derive v2.0.1

### DIFF
--- a/signature/derive/CHANGELOG.md
+++ b/signature/derive/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.0.1 (2023-04-17)
+### Changed
+- Bump `syn` to v2 ([#1299])
+
+[#1299]: https://github.com/RustCrypto/traits/pull/1299
+
 ## 2.0.0 (2023-01-15)
 ### Changed
 - `Signature` trait has been removed, so don't emit it in custom derive ([#1141])

--- a/signature/derive/Cargo.toml
+++ b/signature/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "signature_derive"
-version       = "2.0.0"
+version       = "2.0.1"
 authors       = ["RustCrypto Developers"]
 license       = "Apache-2.0 OR MIT"
 description   = "Custom derive support for the 'signature' crate"


### PR DESCRIPTION
### Changed
- Bump `syn` to v2 ([#1299])

[#1299]: https://github.com/RustCrypto/traits/pull/1299