### PR TITLE
elliptic-curve: fix/test alloc+arithmetic features w/o sec1

### DIFF
--- a/.github/workflows/elliptic-curve.yml
+++ b/.github/workflows/elliptic-curve.yml
@@ -51,6 +51,7 @@ jobs:
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features sec1
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features serde
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features voprf
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features alloc,arithmetic
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features alloc,arithmetic,pkcs8
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features alloc,serde
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features arithmetic,serde

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -975,7 +975,7 @@ dependencies = [
 
 [[package]]
 name = "signature_derive"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/elliptic-curve/src/public_key.rs
+++ b/elliptic-curve/src/public_key.rs
@@ -6,9 +6,6 @@ use crate::{
 use core::fmt::Debug;
 use group::{Curve, Group};
 
-#[cfg(feature = "alloc")]
-use alloc::boxed::Box;
-
 #[cfg(feature = "jwk")]
 use crate::{JwkEcKey, JwkParameters};
 
@@ -31,6 +28,9 @@ use {
 
 #[cfg(all(feature = "alloc", feature = "pkcs8"))]
 use pkcs8::EncodePublicKey;
+
+#[cfg(all(feature = "alloc", feature = "sec1"))]
+use alloc::boxed::Box;
 
 #[cfg(any(feature = "jwk", feature = "pem"))]
 use alloc::string::{String, ToString};
@@ -138,7 +138,7 @@ where
     /// (page 10).
     ///
     /// <http://www.secg.org/sec1-v2.pdf>
-    #[cfg(feature = "alloc")]
+    #[cfg(all(feature = "alloc", feature = "sec1"))]
     pub fn to_sec1_bytes(&self) -> Box<[u8]>
     where
         C: PointCompression,

--- a/elliptic-curve/src/secret_key.rs
+++ b/elliptic-curve/src/secret_key.rs
@@ -14,16 +14,6 @@ use generic_array::typenum::Unsigned;
 use subtle::{Choice, ConstantTimeEq};
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
-#[cfg(all(feature = "alloc", feature = "arithmetic"))]
-use {
-    crate::{
-        sec1::{FromEncodedPoint, ToEncodedPoint},
-        AffinePoint,
-    },
-    alloc::vec::Vec,
-    zeroize::Zeroizing,
-};
-
 #[cfg(feature = "arithmetic")]
 use crate::{rand_core::CryptoRngCore, CurveArithmetic, NonZeroScalar, PublicKey};
 
@@ -34,7 +24,15 @@ use crate::jwk::{JwkEcKey, JwkParameters};
 use sec1::der;
 
 #[cfg(all(feature = "alloc", feature = "arithmetic", feature = "sec1"))]
-use sec1::der::Encode;
+use {
+    crate::{
+        sec1::{FromEncodedPoint, ToEncodedPoint},
+        AffinePoint,
+    },
+    alloc::vec::Vec,
+    sec1::der::Encode,
+    zeroize::Zeroizing,
+};
 
 #[cfg(all(feature = "arithmetic", any(feature = "jwk", feature = "pem")))]
 use alloc::string::String;


### PR DESCRIPTION
The combination of `alloc`+`arithmetic` would previously cause compile errors because some `sec1`-related code was not properly gated.

This fixes the feature gating.