### PR TITLE
crypto v0.5.0

### DIFF
--- a/crypto/CHANGELOG.md
+++ b/crypto/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.5.0 (2023-04-17)
+### Changed
+- Bump `signature` to v2 ([#1211])
+- Bump `password-hash` to v0.5 ([#1271])
+- Bump `elliptic-curve` to v0.13; MSRV 1.65 ([#1302])
+
+[#1211]: https://github.com/RustCrypto/traits/pull/1211
+[#1271]: https://github.com/RustCrypto/traits/pull/1271
+[#1302]: https://github.com/RustCrypto/traits/pull/1302
+
 ## 0.4.0 (2022-08-09)
 ### Added
 - Re-export `crypto-common` as `common` ([#1076])

--- a/crypto/Cargo.lock
+++ b/crypto/Cargo.lock
@@ -64,7 +64,7 @@ checksum = "520fbf3c07483f94e3e3ca9d0cfd913d7718ef2483d2cfd91c0d9e91474ab913"
 
 [[package]]
 name = "crypto"
-version = "0.5.0-pre"
+version = "0.5.0"
 dependencies = [
  "aead",
  "cipher",

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -1,9 +1,7 @@
 [package]
 name = "crypto"
-version = "0.5.0-pre" # Also update html_root_url in lib.rs when bumping this
-description = """
-Resources for building cryptosystems in Rust using the RustCrypto project's ecosystem.
-"""
+version = "0.5.0"
+description = "Facade crate for all of the RustCrypto traits (e.g. `aead`, `cipher`, `digest`)"
 authors = ["The RustCrypto Project Developers"]
 license = "Apache-2.0 OR MIT"
 documentation = "https://docs.rs/crypto"
@@ -41,3 +39,4 @@ rand_core = ["crypto-common/rand_core"]
 
 [package.metadata.docs.rs]
 all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crypto/README.md
+++ b/crypto/README.md
@@ -12,6 +12,44 @@ access compatible versions of all traits from the Rust Crypto project.
 
 [Documentation][docs-link]
 
+## About
+
+Facade crate for [RustCrypto Traits][1], providing a single place to
+access compatible versions of all traits from the Rust Crypto project.
+
+# About
+
+The [RustCrypto Project][2] publishes and maintains independently versioned
+crates containing traits for many different kinds of cryptographic
+algorithms.
+
+However, these algorithms are often interdependent (e.g. many depend on digest
+algorithms), which requires figuring out which versions of the trait crates
+are compatible with each other.
+
+This crate will automatically pull in compatible versions of these crates,
+with each one gated under a cargo feature, providing a single place to both
+import and upgrade these crates while ensuring they remain compatible.
+
+# Traits
+
+The following traits are available as re-exports of RustCrypto crates through
+this crate's facade. To access a particular re-export you (or a crate you
+depend on) must enable the associated Cargo feature named below.
+
+| Re-export | Cargo feature | Description |
+|-----------|---------------|-------------|
+| [`aead`](https://docs.rs/aead) | `aead` | Authenticated Encryption with Associated Data (i.e. high-level symmetric encryption) |
+| [`cipher`](https://docs.rs/cipher) | `cipher` | Block and stream ciphers (i.e. low-level symmetric encryption) |
+| [`digest`](https://docs.rs/digest) | `digest` | Cryptographic hash functions |
+| [`elliptic_curve`](https://docs.rs/elliptic-curve) | `elliptic-curve` | Elliptic curve cryptography |
+| [`password_hash`](https://docs.rs/password-hash) | `password-hash` | Password hashing functions |
+| [`signature`](https://docs.rs/signature) | `signature` | Digital signatures (i.e. public key-based message authentication) |
+| [`universal_hash`](https://docs.rs/universal-hash) | `universal‑hash` | Universal Hash Functions (used to build MACs) |
+
+[1]: https://github.com/RustCrypto/traits
+[2]: https://github.com/RustCrypto
+
 ## Minimum Supported Rust Version
 
 Rust **1.65** or higher.

--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -1,47 +1,12 @@
 #![no_std]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![doc = include_str!("../README.md")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
-    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
-    html_root_url = "https://docs.rs/crypto/0.4.0-pre"
+    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg"
 )]
 #![forbid(unsafe_code)]
 #![warn(rust_2018_idioms)]
-
-//! Facade crate for [RustCrypto Traits][1], providing a single place to
-//! access compatible versions of all traits from the Rust Crypto project.
-//!
-//! # About
-//!
-//! The [RustCrypto Project][2] publishes and maintains independently versioned
-//! crates containing traits for many different kinds of cryptographic
-//! algorithms.
-//!
-//! However, these algorithms are often interdependent (e.g. many depend on digest
-//! algorithms), which requires figuring out which versions of the trait crates
-//! are compatible with each other.
-//!
-//! This crate will automatically pull in compatible versions of these crates,
-//! with each one gated under a cargo feature, providing a single place to both
-//! import and upgrade these crates while ensuring they remain compatible.
-//!
-//! # Traits
-//!
-//! The following traits are available as re-exports of RustCrypto crates through
-//! this crate's facade. To access a particular re-export you (or a crate you
-//! depend on) must enable the associated Cargo feature named below.
-//!
-//! | Re-export | Cargo feature | Description |
-//! |-----------|---------------|-------------|
-//! | [`aead`](https://docs.rs/aead) | `aead` | Authenticated Encryption with Associated Data (i.e. high-level symmetric encryption) |
-//! | [`cipher`](https://docs.rs/cipher) | `cipher` | Block and stream ciphers (i.e. low-level symmetric encryption) |
-//! | [`digest`](https://docs.rs/digest) | `digest` | Cryptographic hash functions |
-//! | [`elliptic_curve`](https://docs.rs/elliptic-curve) | `elliptic-curve` | Elliptic curve cryptography |
-//! | [`password_hash`](https://docs.rs/password-hash) | `password-hash` | Password hashing functions |
-//! | [`signature`](https://docs.rs/signature) | `signature` | Digital signatures (i.e. public key-based message authentication) |
-//! | [`universal_hash`](https://docs.rs/universal-hash) | `universal‑hash` | Universal Hash Functions (used to build MACs) |
-//!
-//! [1]: https://github.com/RustCrypto/traits
-//! [2]: https://github.com/RustCrypto
 
 pub use crypto_common as common;
 


### PR DESCRIPTION
### Changed
- Bump `signature` to v2 ([#1211])
- Bump `password-hash` to v0.5 ([#1271])
- Bump `elliptic-curve` to v0.13; MSRV 1.65 ([#1302])

[#1211]: https://github.com/RustCrypto/traits/pull/1211
[#1271]: https://github.com/RustCrypto/traits/pull/1271
[#1302]: https://github.com/RustCrypto/traits/pull/1302