### PR TITLE
universal-hash v0.5.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -723,7 +723,7 @@ checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
 dependencies = [
  "cpufeatures",
  "opaque-debug",
- "universal-hash 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "universal-hash 0.5.0",
 ]
 
 [[package]]
@@ -735,7 +735,7 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "opaque-debug",
- "universal-hash 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "universal-hash 0.5.0",
 ]
 
 [[package]]
@@ -1012,6 +1012,8 @@ checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
 [[package]]
 name = "universal-hash"
 version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d3160b73c9a19f7e2939a2fdad446c57c1bbbbf4d919d3213ff1267a580d8b5"
 dependencies = [
  "crypto-common 0.1.6",
  "subtle",
@@ -1019,9 +1021,7 @@ dependencies = [
 
 [[package]]
 name = "universal-hash"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d3160b73c9a19f7e2939a2fdad446c57c1bbbbf4d919d3213ff1267a580d8b5"
+version = "0.5.1"
 dependencies = [
  "crypto-common 0.1.6",
  "subtle",

--- a/universal-hash/CHANGELOG.md
+++ b/universal-hash/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.5.0 (2021-07-30)
+## 0.5.1 (2023-05-19)
+### Changed
+- Loosen `subtle` version requirement to `^2.4` ([#1260])
+
+[#1260]: https://github.com/RustCrypto/traits/pull/1260
+
+## 0.5.0 (2022-07-30)
 ### Added
 - `UhfBackend` trait ([#1051], [#1059])
 - `UhfClosure` trait ([#1051])

--- a/universal-hash/Cargo.toml
+++ b/universal-hash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "universal-hash"
-version = "0.5.0"
+version = "0.5.1"
 description = "Traits which describe the functionality of universal hash functions (UHFs)"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
### Changed
- Loosen `subtle` version requirement to `^2.4` ([#1260])

[#1260]: https://github.com/RustCrypto/traits/pull/1260