### PR TITLE
elliptic-curve v0.13.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -723,7 +723,7 @@ checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
 dependencies = [
  "cpufeatures",
  "opaque-debug",
- "universal-hash 0.5.0",
+ "universal-hash 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -735,7 +735,7 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "opaque-debug",
- "universal-hash 0.5.0",
+ "universal-hash 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1011,9 +1011,7 @@ checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
 
 [[package]]
 name = "universal-hash"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d3160b73c9a19f7e2939a2fdad446c57c1bbbbf4d919d3213ff1267a580d8b5"
+version = "0.5.1"
 dependencies = [
  "crypto-common 0.1.6",
  "subtle",
@@ -1022,6 +1020,8 @@ dependencies = [
 [[package]]
 name = "universal-hash"
 version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
  "crypto-common 0.1.6",
  "subtle",

--- a/elliptic-curve/CHANGELOG.md
+++ b/elliptic-curve/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.13.5 (2023-05-19)
+### Changed
+- Faster `PublicKey::from_encoded_point` ([#1310])
+
+### Fixed
+- `alloc`+`arithmetic` features w/o `sec1` feature ([#1301])
+
+[#1301]: https://github.com/RustCrypto/traits/pull/1301
+[#1310]: https://github.com/RustCrypto/traits/pull/1310
+
 ## 0.13.4 (2023-04-08)
 ### Changed
 - Bump `hex-literal` to v0.4 ([#1295])

--- a/elliptic-curve/Cargo.lock
+++ b/elliptic-curve/Cargo.lock
@@ -102,7 +102,7 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.13.4"
+version = "0.13.5"
 dependencies = [
  "base16ct",
  "base64ct",

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elliptic-curve"
-version = "0.13.4"
+version = "0.13.5"
 description = """
 General purpose Elliptic Curve Cryptography (ECC) support, including types
 and traits for representing various elliptic curve forms, scalars, points,


### PR DESCRIPTION
### Changed
- Faster `PublicKey::from_encoded_point` ([#1310])

### Fixed
- `alloc`+`arithmetic` features w/o `sec1` feature ([#1301])

[#1301]: https://github.com/RustCrypto/traits/pull/1301
[#1310]: https://github.com/RustCrypto/traits/pull/1310