### PR TITLE
digest v0.10.7

### DIFF
--- a/digest/CHANGELOG.md
+++ b/digest/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.10.7 (2023-05-19)
+### Changed
+- Loosen `subtle` version requirement ([#1260])
+
+[#1260]: https://github.com/RustCrypto/traits/pull/1260
+
 ## 0.10.6 (2022-11-17)
 ### Added
 - `Mac::verify_reset` and `Mac::verify_slice_reset` methods ([#1154])

--- a/digest/Cargo.toml
+++ b/digest/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "digest"
 description = "Traits for cryptographic hash functions and message authentication codes"
-version = "0.10.6"
+version = "0.10.7"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/digest/Cargo.toml
+++ b/digest/Cargo.toml
@@ -16,7 +16,7 @@ crypto-common = { version = "0.1.3", path = "../crypto-common" }
 
 # optional dependencies
 block-buffer = { version = "0.10", optional = true }
-subtle = { version = "=2.4", default-features = false, optional = true }
+subtle = { version = "2.4", default-features = false, optional = true }
 blobby = { version = "0.3", optional = true }
 const-oid = { version = "0.9", optional = true }
 

--- a/universal-hash/Cargo.toml
+++ b/universal-hash/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["cryptography", "no-std"]
 
 [dependencies]
 crypto-common = { version = "0.1.6", path = "../crypto-common" }
-subtle = { version = "=2.4", default-features = false }
+subtle = { version = "2.4", default-features = false }
 
 [features]
 std = ["crypto-common/std"]


### PR DESCRIPTION
NOTE: this release is a backport, since `master` is currently targeting `digest` v0.11.0-pre. As such, it won't be merged.

### Changed
- Loosen `subtle` version requirement ([#1260])

[#1260]: https://github.com/RustCrypto/traits/pull/1260