### PR TITLE
fix: `missing_debug_implementations`

### DIFF
--- a/aead/src/lib.rs
+++ b/aead/src/lib.rs
@@ -20,7 +20,12 @@
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg"
 )]
 #![forbid(unsafe_code)]
-#![warn(clippy::unwrap_used, missing_docs, rust_2018_idioms)]
+#![warn(
+    clippy::unwrap_used,
+    missing_debug_implementations,
+    missing_docs,
+    rust_2018_idioms
+)]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;
@@ -481,6 +486,7 @@ impl<Alg: AeadInPlace> AeadMutInPlace for Alg {
 /// `encrypt`/`decrypt` and it will automatically be coerced to this type.
 #[cfg(feature = "alloc")]
 #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+#[derive(Debug)]
 pub struct Payload<'msg, 'aad> {
     /// Message to be encrypted/decrypted
     pub msg: &'msg [u8],

--- a/aead/src/stream.rs
+++ b/aead/src/stream.rs
@@ -201,6 +201,7 @@ macro_rules! impl_stream_object {
         #[doc = "[Online Authenticated-Encryption and its Nonce-Reuse Misuse-Resistance][1]."]
         #[doc = ""]
         #[doc = "[1]: https://eprint.iacr.org/2015/189.pdf"]
+        #[derive(Debug)]
         pub struct $name<A, S>
         where
             A: AeadInPlace,
@@ -365,6 +366,7 @@ impl_stream_object!(
 /// the last 5-bytes of the AEAD nonce.
 ///
 /// [1]: https://eprint.iacr.org/2015/189.pdf
+#[derive(Debug)]
 pub struct StreamBE32<A>
 where
     A: AeadInPlace,
@@ -454,6 +456,7 @@ where
 /// when interpreted as a 32-bit integer.
 ///
 /// The 31-bit + 1-bit value is stored as the last 4 bytes of the AEAD nonce.
+#[derive(Debug)]
 pub struct StreamLE31<A>
 where
     A: AeadInPlace,

--- a/cipher/src/block.rs
+++ b/cipher/src/block.rs
@@ -134,9 +134,9 @@ pub trait BlockEncrypt: BlockSizeUser + Sized {
     #[cfg(feature = "block-padding")]
     #[cfg_attr(docsrs, doc(cfg(feature = "block-padding")))]
     #[inline]
-    fn encrypt_padded_inout<'inp, 'out, P: Padding<Self::BlockSize>>(
+    fn encrypt_padded_inout<'out, P: Padding<Self::BlockSize>>(
         &self,
-        data: InOutBufReserved<'inp, 'out, u8>,
+        data: InOutBufReserved<'_, 'out, u8>,
     ) -> Result<&'out [u8], PadError> {
         let mut buf = data.into_padded_blocks::<P, Self::BlockSize>()?;
         self.encrypt_blocks_inout(buf.get_blocks());
@@ -250,9 +250,9 @@ pub trait BlockDecrypt: BlockSizeUser {
     #[cfg(feature = "block-padding")]
     #[cfg_attr(docsrs, doc(cfg(feature = "block-padding")))]
     #[inline]
-    fn decrypt_padded_inout<'inp, 'out, P: Padding<Self::BlockSize>>(
+    fn decrypt_padded_inout<'out, P: Padding<Self::BlockSize>>(
         &self,
-        data: InOutBuf<'inp, 'out, u8>,
+        data: InOutBuf<'_, 'out, u8>,
     ) -> Result<&'out [u8], UnpadError> {
         let (mut blocks, tail) = data.into_chunks();
         if !tail.is_empty() {
@@ -379,9 +379,9 @@ pub trait BlockEncryptMut: BlockSizeUser + Sized {
     #[cfg(feature = "block-padding")]
     #[cfg_attr(docsrs, doc(cfg(feature = "block-padding")))]
     #[inline]
-    fn encrypt_padded_inout_mut<'inp, 'out, P: Padding<Self::BlockSize>>(
+    fn encrypt_padded_inout_mut<'out, P: Padding<Self::BlockSize>>(
         mut self,
-        data: InOutBufReserved<'inp, 'out, u8>,
+        data: InOutBufReserved<'_, 'out, u8>,
     ) -> Result<&'out [u8], PadError> {
         let mut buf = data.into_padded_blocks::<P, Self::BlockSize>()?;
         self.encrypt_blocks_inout_mut(buf.get_blocks());
@@ -499,9 +499,9 @@ pub trait BlockDecryptMut: BlockSizeUser + Sized {
     #[cfg(feature = "block-padding")]
     #[cfg_attr(docsrs, doc(cfg(feature = "block-padding")))]
     #[inline]
-    fn decrypt_padded_inout_mut<'inp, 'out, P: Padding<Self::BlockSize>>(
+    fn decrypt_padded_inout_mut<'out, P: Padding<Self::BlockSize>>(
         mut self,
-        data: InOutBuf<'inp, 'out, u8>,
+        data: InOutBuf<'_, 'out, u8>,
     ) -> Result<&'out [u8], UnpadError> {
         let (mut blocks, tail) = data.into_chunks();
         if !tail.is_empty() {

--- a/cipher/src/lib.rs
+++ b/cipher/src/lib.rs
@@ -11,7 +11,7 @@
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg"
 )]
-#![warn(missing_docs, rust_2018_idioms)]
+#![warn(missing_debug_implementations, missing_docs, rust_2018_idioms)]
 
 pub use crypto_common;
 pub use inout;

--- a/cipher/src/stream_wrapper.rs
+++ b/cipher/src/stream_wrapper.rs
@@ -13,7 +13,7 @@ use zeroize::{Zeroize, ZeroizeOnDrop};
 /// Wrapper around [`StreamCipherCore`] implementations.
 ///
 /// It handles data buffering and implements the slice-based traits.
-#[derive(Clone, Default)]
+#[derive(Debug, Clone, Default)]
 pub struct StreamCipherCoreWrapper<T: BlockSizeUser>
 where
     T::BlockSize: IsLess<U256>,

--- a/crypto-common/src/lib.rs
+++ b/crypto-common/src/lib.rs
@@ -7,7 +7,7 @@
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg"
 )]
 #![forbid(unsafe_code)]
-#![warn(missing_docs, rust_2018_idioms)]
+#![warn(missing_debug_implementations, missing_docs, rust_2018_idioms)]
 
 #[cfg(feature = "std")]
 extern crate std;

--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -6,7 +6,7 @@
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg"
 )]
 #![forbid(unsafe_code)]
-#![warn(rust_2018_idioms)]
+#![warn(missing_debug_implementations, rust_2018_idioms)]
 
 pub use crypto_common as common;
 

--- a/digest/src/core_api/ct_variable.rs
+++ b/digest/src/core_api/ct_variable.rs
@@ -21,7 +21,7 @@ pub struct NoOid;
 
 /// Wrapper around [`VariableOutputCore`] which selects output size
 /// at compile time.
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct CtVariableCoreWrapper<T, OutSize, O = NoOid>
 where
     T: VariableOutputCore,

--- a/digest/src/lib.rs
+++ b/digest/src/lib.rs
@@ -29,7 +29,7 @@
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg"
 )]
-#![warn(missing_docs, rust_2018_idioms)]
+#![warn(missing_debug_implementations, missing_docs, rust_2018_idioms)]
 
 #[cfg(feature = "alloc")]
 #[macro_use]

--- a/digest/src/mac.rs
+++ b/digest/src/mac.rs
@@ -194,7 +194,7 @@ impl<T: Update + FixedOutput + MacMarker> Mac for T {
 /// runs in constant time.
 ///
 /// It is useful for implementing Message Authentication Codes (MACs).
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 #[cfg_attr(docsrs, doc(cfg(feature = "mac")))]
 pub struct CtOutput<T: OutputSizeUser> {
     bytes: Output<T>,

--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -19,6 +19,7 @@
     clippy::panic,
     clippy::panic_in_result_fn,
     clippy::unwrap_used,
+    missing_debug_implementations,
     missing_docs,
     rust_2018_idioms,
     unused_lifetimes,

--- a/kem/src/kem.rs
+++ b/kem/src/kem.rs
@@ -36,6 +36,7 @@ pub trait EncappedKey: AsRef<[u8]> + Debug + Sized {
 }
 
 /// The shared secret that results from key exchange.
+#[derive(Debug)]
 pub struct SharedSecret<EK: EncappedKey>(GenericArray<u8, EK::SharedSecretSize>);
 
 // Zero the secret on drop

--- a/kem/src/lib.rs
+++ b/kem/src/lib.rs
@@ -7,7 +7,7 @@
     html_root_url = "https://docs.rs/kem"
 )]
 #![forbid(unsafe_code)]
-#![warn(missing_docs, unused_qualifications)]
+#![warn(missing_debug_implementations, missing_docs, unused_qualifications)]
 
 #[cfg(feature = "std")]
 extern crate std;

--- a/password-hash/src/lib.rs
+++ b/password-hash/src/lib.rs
@@ -6,7 +6,12 @@
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg"
 )]
 #![forbid(unsafe_code)]
-#![warn(missing_docs, rust_2018_idioms, unused_lifetimes)]
+#![warn(
+    missing_debug_implementations,
+    missing_docs,
+    rust_2018_idioms,
+    unused_lifetimes
+)]
 
 //!
 //! # Usage

--- a/password-hash/src/params.rs
+++ b/password-hash/src/params.rs
@@ -239,6 +239,7 @@ impl fmt::Debug for ParamsString {
 }
 
 /// Iterator over algorithm parameters stored in a [`ParamsString`] struct.
+#[derive(Debug)]
 pub struct Iter<'a> {
     inner: Option<str::Split<'a, char>>,
 }

--- a/signature/src/lib.rs
+++ b/signature/src/lib.rs
@@ -9,6 +9,7 @@
 #![warn(
     clippy::mod_module_files,
     clippy::unwrap_used,
+    missing_debug_implementations,
     missing_docs,
     rust_2018_idioms,
     unused_lifetimes,

--- a/universal-hash/src/lib.rs
+++ b/universal-hash/src/lib.rs
@@ -24,7 +24,7 @@
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![deny(unsafe_code)]
-#![warn(missing_docs, rust_2018_idioms)]
+#![warn(missing_debug_implementations, missing_docs, rust_2018_idioms)]
 
 #[cfg(feature = "std")]
 extern crate std;


### PR DESCRIPTION
Sets `missing_debug_implementations` to warn and adds missing `std::fmt::Debug` implementations.

When tracing/logging/debugging a program it is common to debug print inputs and outputs of function, to do this generally dependencies need to offer `std::fmt::Debug` implementations.

I won't repeat what is written under [`missing_debug_implementations`](https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html#missing-debug-implementations) which gives some more explanation.