### PR TITLE
crypto-common: use `CryptoRngCore`

### DIFF
--- a/crypto-common/Cargo.toml
+++ b/crypto-common/Cargo.toml
@@ -17,7 +17,7 @@ generic-array = { version = "0.14.6", features = ["more_lengths"] }
 typenum = "1.14" # earlier versions of typenum don't satisfy the 'static bound on U* types
 
 # optional dependencies
-rand_core = { version = "0.6", optional = true }
+rand_core = { version = "0.6.4", optional = true }
 
 [features]
 std = []

--- a/crypto-common/src/lib.rs
+++ b/crypto-common/src/lib.rs
@@ -21,7 +21,7 @@ pub use generic_array::typenum;
 use core::fmt;
 use generic_array::{typenum::Unsigned, ArrayLength, GenericArray};
 #[cfg(feature = "rand_core")]
-use rand_core::{CryptoRng, RngCore};
+use rand_core::CryptoRngCore;
 
 /// Block on which [`BlockSizeUser`] implementors operate.
 pub type Block<B> = GenericArray<u8, <B as BlockSizeUser>::BlockSize>;
@@ -158,11 +158,11 @@ pub trait KeyInit: KeySizeUser + Sized {
         }
     }
 
-    /// Generate random key using the provided [`CryptoRng`].
+    /// Generate random key using the provided [`CryptoRngCore`].
     #[cfg(feature = "rand_core")]
     #[cfg_attr(docsrs, doc(cfg(feature = "rand_core")))]
     #[inline]
-    fn generate_key(mut rng: impl CryptoRng + RngCore) -> Key<Self> {
+    fn generate_key(mut rng: impl CryptoRngCore) -> Key<Self> {
         let mut key = Key::<Self>::default();
         rng.fill_bytes(&mut key);
         key
@@ -189,31 +189,31 @@ pub trait KeyIvInit: KeySizeUser + IvSizeUser + Sized {
         }
     }
 
-    /// Generate random key using the provided [`CryptoRng`].
+    /// Generate random key using the provided [`CryptoRngCore`].
     #[cfg(feature = "rand_core")]
     #[cfg_attr(docsrs, doc(cfg(feature = "rand_core")))]
     #[inline]
-    fn generate_key(mut rng: impl CryptoRng + RngCore) -> Key<Self> {
+    fn generate_key(mut rng: impl CryptoRngCore) -> Key<Self> {
         let mut key = Key::<Self>::default();
         rng.fill_bytes(&mut key);
         key
     }
 
-    /// Generate random IV using the provided [`CryptoRng`].
+    /// Generate random IV using the provided [`CryptoRngCore`].
     #[cfg(feature = "rand_core")]
     #[cfg_attr(docsrs, doc(cfg(feature = "rand_core")))]
     #[inline]
-    fn generate_iv(mut rng: impl CryptoRng + RngCore) -> Iv<Self> {
+    fn generate_iv(mut rng: impl CryptoRngCore) -> Iv<Self> {
         let mut iv = Iv::<Self>::default();
         rng.fill_bytes(&mut iv);
         iv
     }
 
-    /// Generate random key and nonce using the provided [`CryptoRng`].
+    /// Generate random key and nonce using the provided [`CryptoRngCore`].
     #[cfg(feature = "rand_core")]
     #[cfg_attr(docsrs, doc(cfg(feature = "rand_core")))]
     #[inline]
-    fn generate_key_iv(mut rng: impl CryptoRng + RngCore) -> (Key<Self>, Iv<Self>) {
+    fn generate_key_iv(mut rng: impl CryptoRngCore) -> (Key<Self>, Iv<Self>) {
         (Self::generate_key(&mut rng), Self::generate_iv(&mut rng))
     }
 }
@@ -244,11 +244,11 @@ pub trait InnerIvInit: InnerUser + IvSizeUser + Sized {
         }
     }
 
-    /// Generate random IV using the provided [`CryptoRng`].
+    /// Generate random IV using the provided [`CryptoRngCore`].
     #[cfg(feature = "rand_core")]
     #[cfg_attr(docsrs, doc(cfg(feature = "rand_core")))]
     #[inline]
-    fn generate_iv(mut rng: impl CryptoRng + RngCore) -> Iv<Self> {
+    fn generate_iv(mut rng: impl CryptoRngCore) -> Iv<Self> {
         let mut iv = Iv::<Self>::default();
         rng.fill_bytes(&mut iv);
         iv


### PR DESCRIPTION
Added in `rand_core` v0.6.4.

I think in the next `rand_core` release we'll be able to replace it with `CryptoRng` (by leveraging a supertrait bound) but for now this reduces the number of traits needed to just one.