### PR TITLE
Fix minor documentation error in AeadCore::TagSize

### DIFF
--- a/aead/src/lib.rs
+++ b/aead/src/lib.rs
@@ -104,7 +104,7 @@ pub trait AeadCore {
     /// The length of a nonce.
     type NonceSize: ArrayLength<u8>;
 
-    /// The maximum length of the nonce.
+    /// The maximum length of the tag.
     type TagSize: ArrayLength<u8>;
 
     /// The upper bound amount of additional space required to support a


### PR DESCRIPTION
The documentation originally described TagSize as "the maximum length of the nonce" when it is, in fact, the maximum length of the tag.