### PR TITLE
elliptic-curve: minimum supported `serde_json` is v1.0.47

### DIFF
--- a/.github/workflows/elliptic-curve.yml
+++ b/.github/workflows/elliptic-curve.yml
@@ -67,7 +67,7 @@ jobs:
           toolchain: nightly
       - uses: RustCrypto/actions/cargo-hack-install@master
       - run: cargo update -Z minimal-versions
-      - run: cargo build --release --features ecdh,hash2curve,pem,std,voprf # TODO(tarcieri): test all features
+      - run: cargo build --release --features ecdh,hash2curve,jwk,pem,std,voprf # TODO(tarcieri): test all features
 
   test:
     runs-on: ubuntu-latest

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -34,7 +34,7 @@ pem-rfc7468 = { version = "0.7", optional = true, features = ["alloc"] }
 pkcs8 = { version = "0.10.2", optional = true, default-features = false }
 sec1 = { version = "0.7.1", optional = true, features = ["subtle", "zeroize"] }
 serdect = { version = "0.2", optional = true, default-features = false, features = ["alloc"] }
-serde_json = { version = "1", optional = true, default-features = false, features = ["alloc"] }
+serde_json = { version = "1.0.47", optional = true, default-features = false, features = ["alloc"] }
 
 [dev-dependencies]
 hex-literal = "0.4"


### PR DESCRIPTION
...when resolving with `-Z minimal-versions`

This appears to be due to earlier versions of `serde_json` itself misspecifying its required `serde` version.