### PR TITLE
elliptic-curve: minimum supported `tap` for `bits` is v1.0.1

### DIFF
--- a/.github/workflows/elliptic-curve.yml
+++ b/.github/workflows/elliptic-curve.yml
@@ -67,7 +67,7 @@ jobs:
           toolchain: nightly
       - uses: RustCrypto/actions/cargo-hack-install@master
       - run: cargo update -Z minimal-versions
-      - run: cargo build --release --features ecdh,hash2curve,jwk,pem,std,voprf # TODO(tarcieri): test all features
+      - run: cargo +stable build --release --all-features
 
   test:
     runs-on: ubuntu-latest

--- a/elliptic-curve/Cargo.lock
+++ b/elliptic-curve/Cargo.lock
@@ -122,6 +122,7 @@ dependencies = [
  "sha2",
  "sha3",
  "subtle",
+ "tap",
  "zeroize",
 ]
 

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -35,6 +35,7 @@ pkcs8 = { version = "0.10.2", optional = true, default-features = false }
 sec1 = { version = "0.7.1", optional = true, features = ["subtle", "zeroize"] }
 serdect = { version = "0.2", optional = true, default-features = false, features = ["alloc"] }
 serde_json = { version = "1.0.47", optional = true, default-features = false, features = ["alloc"] }
+tap = { version = "1.0.1", optional = true, default-features = false } # hack for minimal-versions support for `bits`
 
 [dev-dependencies]
 hex-literal = "0.4"
@@ -59,7 +60,7 @@ std = [
 ]
 
 arithmetic = ["group"]
-bits = ["arithmetic", "ff/bits"]
+bits = ["arithmetic", "ff/bits", "dep:tap"]
 dev = ["arithmetic", "dep:hex-literal", "pem", "pkcs8"]
 hash2curve = ["arithmetic", "digest"]
 ecdh = ["arithmetic", "digest", "dep:hkdf"]


### PR DESCRIPTION
...when resolving with `-Z minimal-versions`

`tap` is a transitive dependency of `bitvec` by way of `wyz` v0.5, which misspecifies the required `tap` version. This is addressed in newer v0.6 releases of `wyz`, which `bitvec` does not yet use.

So, as a workaround, this adds an explicit `dep:tap` dependency on v1.0.1 for the `bits` feature.

This was the last remaining `minimal-versions` incompatibility in this crate, allowing all features to now be tested in the `minimal-versions` check in CI.