### PR TITLE
elliptic-curve v0.13.6

### DIFF
--- a/elliptic-curve/CHANGELOG.md
+++ b/elliptic-curve/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.13.6 (2023-10-02)
+### Fixed
+- Minimum supported `hkdf` version is v0.12.1 ([#1353])
+- Minimum supported `serde_json` version for `jwk` feature is v1.0.47 ([#1354])
+- Minimum supported `tap` version for `bits` feature is v1.0.1 ([#1355])
+
+[#1353]: https://github.com/RustCrypto/traits/pull/1353
+[#1354]: https://github.com/RustCrypto/traits/pull/1354
+[#1355]: https://github.com/RustCrypto/traits/pull/1355
+
 ## 0.13.5 (2023-05-19)
 ### Changed
 - Faster `PublicKey::from_encoded_point` ([#1310])

--- a/elliptic-curve/Cargo.lock
+++ b/elliptic-curve/Cargo.lock
@@ -102,7 +102,7 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.13.5"
+version = "0.13.6"
 dependencies = [
  "base16ct",
  "base64ct",

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elliptic-curve"
-version = "0.13.5"
+version = "0.13.6"
 description = """
 General purpose Elliptic Curve Cryptography (ECC) support, including types
 and traits for representing various elliptic curve forms, scalars, points,


### PR DESCRIPTION
### Fixed
- Minimum supported `hkdf` version is v0.12.1 ([#1353])
- Minimum supported `serde_json` version for `jwk` feature is v1.0.47 ([#1354])
- Minimum supported `tap` version for `bits` feature is v1.0.1 ([#1355])

[#1353]: https://github.com/RustCrypto/traits/pull/1353
[#1354]: https://github.com/RustCrypto/traits/pull/1354
[#1355]: https://github.com/RustCrypto/traits/pull/1355