### PR TITLE
cipher+digest: migrate to hybrid array; MSRV 1.65

### DIFF
--- a/.github/workflows/cipher.yml
+++ b/.github/workflows/cipher.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.56.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -57,7 +57,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.56.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/digest.yml
+++ b/.github/workflows/digest.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.57.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -34,21 +34,20 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
           targets: ${{ matrix.target }}
-      # Isolate this crate from workspace which is otherwise MSRV 1.56 due to 2021 edition crates
-      - run: rm ../Cargo.toml
       - run: cargo build --target ${{ matrix.target }}
 
-  minimal-versions:
-    uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
-    with:
-        working-directory: ${{ github.workflow }}
+  # TODO(tarcieri): re-enable after next `crypto-common` release
+  #minimal-versions:
+  #  uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
+  #  with:
+  #      working-directory: ${{ github.workflow }}
 
   test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         rust:
-          - 1.57.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,7 +31,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac1f845298e95f983ff1944b728ae08b8cebab80d684f0a832ed0fc74dfa27e2"
 dependencies = [
  "cfg-if",
- "cipher 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cipher 0.4.4",
  "cpufeatures",
 ]
 
@@ -43,7 +43,7 @@ checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
 dependencies = [
  "aead 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "aes",
- "cipher 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cipher 0.4.4",
  "ctr",
  "ghash",
  "subtle",
@@ -137,20 +137,17 @@ dependencies = [
 [[package]]
 name = "block-buffer"
 version = "0.11.0-pre"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b6a33d658e9ef24ba0c4566d3d023d7978ca2ea3efb65e4eacd4586695892b"
+source = "git+https://github.com/RustCrypto/utils.git#b755f1a29b074d8b0a6fc5fda5744312a11632c7"
 dependencies = [
- "crypto-common 0.2.0-pre (registry+https://github.com/rust-lang/crates.io-index)",
- "generic-array",
+ "crypto-common 0.2.0-pre",
 ]
 
 [[package]]
 name = "block-padding"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+version = "0.4.0-pre"
+source = "git+https://github.com/RustCrypto/utils.git#b755f1a29b074d8b0a6fc5fda5744312a11632c7"
 dependencies = [
- "generic-array",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -188,7 +185,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
 dependencies = [
  "cfg-if",
- "cipher 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cipher 0.4.4",
  "cpufeatures",
 ]
 
@@ -200,18 +197,8 @@ checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
 dependencies = [
  "aead 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "chacha20",
- "cipher 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cipher 0.4.4",
  "poly1305",
- "zeroize",
-]
-
-[[package]]
-name = "cipher"
-version = "0.4.4"
-dependencies = [
- "blobby",
- "crypto-common 0.1.6",
- "inout",
  "zeroize",
 ]
 
@@ -222,7 +209,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common 0.1.6",
- "inout",
+ "inout 0.1.3",
+ "zeroize",
+]
+
+[[package]]
+name = "cipher"
+version = "0.5.0-pre"
+dependencies = [
+ "blobby",
+ "crypto-common 0.2.0-pre",
+ "inout 0.2.0-pre",
  "zeroize",
 ]
 
@@ -297,17 +294,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crypto-common"
-version = "0.2.0-pre"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6faaa83e7700e0832cbbf84854d4c356270526907d9b14fab927fc7a9b5befb8"
-dependencies = [
- "generic-array",
- "rand_core 0.6.4",
- "typenum",
-]
-
-[[package]]
 name = "crypto-mac"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -323,7 +309,7 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
 dependencies = [
- "cipher 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cipher 0.4.4",
 ]
 
 [[package]]
@@ -384,7 +370,7 @@ dependencies = [
  "blobby",
  "block-buffer 0.11.0-pre",
  "const-oid 0.9.5",
- "crypto-common 0.2.0-pre (registry+https://github.com/rust-lang/crates.io-index)",
+ "crypto-common 0.2.0-pre",
  "subtle",
 ]
 
@@ -612,8 +598,7 @@ dependencies = [
 [[package]]
 name = "hybrid-array"
 version = "0.2.0-pre.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "431615b6a66a159a76ac38f4b0bcbd5999433d08425d79e152438e3ab9f1013c"
+source = "git+https://github.com/RustCrypto/utils.git#b755f1a29b074d8b0a6fc5fda5744312a11632c7"
 dependencies = [
  "typenum",
 ]
@@ -624,8 +609,16 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
 dependencies = [
- "block-padding",
  "generic-array",
+]
+
+[[package]]
+name = "inout"
+version = "0.2.0-pre"
+source = "git+https://github.com/RustCrypto/utils.git#b755f1a29b074d8b0a6fc5fda5744312a11632c7"
+dependencies = [
+ "block-padding",
+ "hybrid-array",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,9 @@ exclude = [
     "crypto",
     "elliptic-curve"
 ]
+
+[patch.crates-io]
+block-buffer = { git = "https://github.com/RustCrypto/utils.git" }
+crypto-common = { path = "crypto-common" }
+hybrid-array = { git = "https://github.com/RustCrypto/utils.git" }
+inout = { git = "https://github.com/RustCrypto/utils.git" }

--- a/cipher/Cargo.toml
+++ b/cipher/Cargo.toml
@@ -1,20 +1,20 @@
 [package]
 name = "cipher"
 description = "Traits for describing block ciphers and stream ciphers"
-version = "0.4.4"
+version = "0.5.0-pre"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.65"
 documentation = "https://docs.rs/cipher"
 repository = "https://github.com/RustCrypto/traits"
 keywords = ["crypto", "block-cipher", "stream-cipher", "trait"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-crypto-common = "0.1.6"
-inout = "0.1"
+crypto-common = "=0.2.0-pre"
+inout = "=0.2.0-pre"
 
 # optional dependencies
 blobby = { version = "0.3", optional = true }

--- a/cipher/README.md
+++ b/cipher/README.md
@@ -16,7 +16,7 @@ implementations which use these traits.
 
 ## Minimum Supported Rust Version
 
-Rust **1.56** or higher.
+Rust **1.65** or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be
 done with a minor version bump.
@@ -48,7 +48,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/cipher/badge.svg
 [docs-link]: https://docs.rs/cipher/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.41+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.65+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260050-traits
 [build-image]: https://github.com/RustCrypto/traits/workflows/cipher/badge.svg?branch=master&event=push

--- a/cipher/src/block.rs
+++ b/cipher/src/block.rs
@@ -13,6 +13,7 @@
 use crate::{ParBlocks, ParBlocksSizeUser};
 #[cfg(all(feature = "block-padding", feature = "alloc"))]
 use alloc::{vec, vec::Vec};
+use crypto_common::BlockSizes;
 #[cfg(feature = "block-padding")]
 use inout::{
     block_padding::{Padding, UnpadError},
@@ -20,7 +21,7 @@ use inout::{
 };
 use inout::{InOut, InOutBuf, NotEqualError};
 
-pub use crypto_common::{generic_array::ArrayLength, typenum::Unsigned, Block, BlockSizeUser};
+pub use crypto_common::{array::ArraySize, typenum::Unsigned, Block, BlockSizeUser};
 
 /// Marker trait for block ciphers.
 pub trait BlockCipher: BlockSizeUser {}
@@ -593,15 +594,15 @@ impl<Alg: BlockDecrypt> BlockDecrypt for &Alg {
 }
 
 /// Closure used in methods which operate over separate blocks.
-struct BlockCtx<'inp, 'out, BS: ArrayLength<u8>> {
+struct BlockCtx<'inp, 'out, BS: BlockSizes> {
     block: InOut<'inp, 'out, Block<Self>>,
 }
 
-impl<'inp, 'out, BS: ArrayLength<u8>> BlockSizeUser for BlockCtx<'inp, 'out, BS> {
+impl<'inp, 'out, BS: BlockSizes> BlockSizeUser for BlockCtx<'inp, 'out, BS> {
     type BlockSize = BS;
 }
 
-impl<'inp, 'out, BS: ArrayLength<u8>> BlockClosure for BlockCtx<'inp, 'out, BS> {
+impl<'inp, 'out, BS: BlockSizes> BlockClosure for BlockCtx<'inp, 'out, BS> {
     #[inline(always)]
     fn call<B: BlockBackend<BlockSize = BS>>(self, backend: &mut B) {
         backend.proc_block(self.block);
@@ -609,15 +610,15 @@ impl<'inp, 'out, BS: ArrayLength<u8>> BlockClosure for BlockCtx<'inp, 'out, BS> 
 }
 
 /// Closure used in methods which operate over slice of blocks.
-struct BlocksCtx<'inp, 'out, BS: ArrayLength<u8>> {
+struct BlocksCtx<'inp, 'out, BS: BlockSizes> {
     blocks: InOutBuf<'inp, 'out, Block<Self>>,
 }
 
-impl<'inp, 'out, BS: ArrayLength<u8>> BlockSizeUser for BlocksCtx<'inp, 'out, BS> {
+impl<'inp, 'out, BS: BlockSizes> BlockSizeUser for BlocksCtx<'inp, 'out, BS> {
     type BlockSize = BS;
 }
 
-impl<'inp, 'out, BS: ArrayLength<u8>> BlockClosure for BlocksCtx<'inp, 'out, BS> {
+impl<'inp, 'out, BS: BlockSizes> BlockClosure for BlocksCtx<'inp, 'out, BS> {
     #[inline(always)]
     fn call<B: BlockBackend<BlockSize = BS>>(self, backend: &mut B) {
         if B::ParBlocksSize::USIZE > 1 {

--- a/cipher/src/dev/block.rs
+++ b/cipher/src/dev/block.rs
@@ -10,14 +10,14 @@ macro_rules! block_cipher_test {
         #[test]
         fn $name() {
             use cipher::{
-                blobby::Blob3Iterator, generic_array::GenericArray, typenum::Unsigned,
-                BlockDecryptMut, BlockEncryptMut, BlockSizeUser, KeyInit,
+                array::Array, blobby::Blob3Iterator, typenum::Unsigned, BlockDecryptMut,
+                BlockEncryptMut, BlockSizeUser, KeyInit,
             };
 
             fn run_test(key: &[u8], pt: &[u8], ct: &[u8]) -> bool {
                 let mut state = <$cipher as KeyInit>::new_from_slice(key).unwrap();
 
-                let mut block = GenericArray::clone_from_slice(pt);
+                let mut block = Array::clone_from_slice(pt);
                 state.encrypt_block_mut(&mut block);
                 if ct != block.as_slice() {
                     return false;
@@ -105,8 +105,8 @@ macro_rules! block_mode_enc_test {
         #[test]
         fn $name() {
             use cipher::{
-                blobby::Blob4Iterator, generic_array::GenericArray, inout::InOutBuf,
-                typenum::Unsigned, BlockEncryptMut, BlockSizeUser, KeyIvInit,
+                array::Array, blobby::Blob4Iterator, inout::InOutBuf, typenum::Unsigned,
+                BlockEncryptMut, BlockSizeUser, KeyIvInit,
             };
 
             fn run_test(key: &[u8], iv: &[u8], pt: &[u8], ct: &[u8]) -> bool {
@@ -164,8 +164,8 @@ macro_rules! block_mode_dec_test {
         #[test]
         fn $name() {
             use cipher::{
-                blobby::Blob4Iterator, generic_array::GenericArray, inout::InOutBuf,
-                typenum::Unsigned, BlockDecryptMut, BlockSizeUser, KeyIvInit,
+                array::Array, blobby::Blob4Iterator, inout::InOutBuf, typenum::Unsigned,
+                BlockDecryptMut, BlockSizeUser, KeyIvInit,
             };
 
             fn run_test(key: &[u8], iv: &[u8], pt: &[u8], ct: &[u8]) -> bool {

--- a/cipher/src/dev/stream.rs
+++ b/cipher/src/dev/stream.rs
@@ -7,7 +7,7 @@ macro_rules! stream_cipher_test {
     ($name:ident, $test_name:expr, $cipher:ty $(,)?) => {
         #[test]
         fn $name() {
-            use cipher::generic_array::GenericArray;
+            use cipher::array::Array;
             use cipher::{blobby::Blob4Iterator, KeyIvInit, StreamCipher};
 
             let data = include_bytes!(concat!("data/", $test_name, ".blb"));
@@ -43,7 +43,7 @@ macro_rules! stream_cipher_seek_test {
     ($name:ident, $cipher:ty) => {
         #[test]
         fn $name() {
-            use cipher::generic_array::GenericArray;
+            use cipher::array::Array;
             use cipher::{KeyIvInit, StreamCipher, StreamCipherSeek};
 
             fn get_cipher() -> $cipher {

--- a/cipher/src/lib.rs
+++ b/cipher/src/lib.rs
@@ -48,7 +48,7 @@ mod stream_wrapper;
 
 pub use crate::{block::*, errors::*, stream::*, stream_core::*, stream_wrapper::*};
 pub use crypto_common::{
-    generic_array,
+    array,
     typenum::{self, consts},
     AlgorithmName, Block, InnerIvInit, InvalidLength, Iv, IvSizeUser, Key, KeyInit, KeyIvInit,
     KeySizeUser, ParBlocks, ParBlocksSizeUser,

--- a/cipher/src/stream_core.rs
+++ b/cipher/src/stream_core.rs
@@ -1,8 +1,8 @@
 use crate::{ParBlocks, ParBlocksSizeUser, StreamCipherError};
 use crypto_common::{
-    generic_array::{ArrayLength, GenericArray},
+    array::{Array, ArraySize},
     typenum::Unsigned,
-    Block, BlockSizeUser,
+    Block, BlockSizeUser, BlockSizes,
 };
 use inout::{InOut, InOutBuf};
 
@@ -195,7 +195,7 @@ impl_counter! { u32 u64 u128 }
 /// In case if `N` is less or equal to 1, buffer of arrays has length
 /// of zero and tail is equal to `self`.
 #[inline]
-fn into_chunks<T, N: ArrayLength<T>>(buf: &mut [T]) -> (&mut [GenericArray<T, N>], &mut [T]) {
+fn into_chunks<T, N: ArraySize>(buf: &mut [T]) -> (&mut [Array<T, N>], &mut [T]) {
     use core::slice;
     if N::USIZE <= 1 {
         return (&mut [], buf);
@@ -205,32 +205,32 @@ fn into_chunks<T, N: ArrayLength<T>>(buf: &mut [T]) -> (&mut [GenericArray<T, N>
     let tail_len = buf.len() - tail_pos;
     unsafe {
         let ptr = buf.as_mut_ptr();
-        let chunks = slice::from_raw_parts_mut(ptr as *mut GenericArray<T, N>, chunks_len);
+        let chunks = slice::from_raw_parts_mut(ptr as *mut Array<T, N>, chunks_len);
         let tail = slice::from_raw_parts_mut(ptr.add(tail_pos), tail_len);
         (chunks, tail)
     }
 }
 
-struct WriteBlockCtx<'a, BS: ArrayLength<u8>> {
+struct WriteBlockCtx<'a, BS: BlockSizes> {
     block: &'a mut Block<Self>,
 }
-impl<'a, BS: ArrayLength<u8>> BlockSizeUser for WriteBlockCtx<'a, BS> {
+impl<'a, BS: BlockSizes> BlockSizeUser for WriteBlockCtx<'a, BS> {
     type BlockSize = BS;
 }
-impl<'a, BS: ArrayLength<u8>> StreamClosure for WriteBlockCtx<'a, BS> {
+impl<'a, BS: BlockSizes> StreamClosure for WriteBlockCtx<'a, BS> {
     #[inline(always)]
     fn call<B: StreamBackend<BlockSize = BS>>(self, backend: &mut B) {
         backend.gen_ks_block(self.block);
     }
 }
 
-struct WriteBlocksCtx<'a, BS: ArrayLength<u8>> {
+struct WriteBlocksCtx<'a, BS: BlockSizes> {
     blocks: &'a mut [Block<Self>],
 }
-impl<'a, BS: ArrayLength<u8>> BlockSizeUser for WriteBlocksCtx<'a, BS> {
+impl<'a, BS: BlockSizes> BlockSizeUser for WriteBlocksCtx<'a, BS> {
     type BlockSize = BS;
 }
-impl<'a, BS: ArrayLength<u8>> StreamClosure for WriteBlocksCtx<'a, BS> {
+impl<'a, BS: BlockSizes> StreamClosure for WriteBlocksCtx<'a, BS> {
     #[inline(always)]
     fn call<B: StreamBackend<BlockSize = BS>>(self, backend: &mut B) {
         if B::ParBlocksSize::USIZE > 1 {
@@ -247,15 +247,15 @@ impl<'a, BS: ArrayLength<u8>> StreamClosure for WriteBlocksCtx<'a, BS> {
     }
 }
 
-struct ApplyBlockCtx<'inp, 'out, BS: ArrayLength<u8>> {
+struct ApplyBlockCtx<'inp, 'out, BS: BlockSizes> {
     block: InOut<'inp, 'out, Block<Self>>,
 }
 
-impl<'inp, 'out, BS: ArrayLength<u8>> BlockSizeUser for ApplyBlockCtx<'inp, 'out, BS> {
+impl<'inp, 'out, BS: BlockSizes> BlockSizeUser for ApplyBlockCtx<'inp, 'out, BS> {
     type BlockSize = BS;
 }
 
-impl<'inp, 'out, BS: ArrayLength<u8>> StreamClosure for ApplyBlockCtx<'inp, 'out, BS> {
+impl<'inp, 'out, BS: BlockSizes> StreamClosure for ApplyBlockCtx<'inp, 'out, BS> {
     #[inline(always)]
     fn call<B: StreamBackend<BlockSize = BS>>(mut self, backend: &mut B) {
         let mut t = Default::default();
@@ -264,15 +264,15 @@ impl<'inp, 'out, BS: ArrayLength<u8>> StreamClosure for ApplyBlockCtx<'inp, 'out
     }
 }
 
-struct ApplyBlocksCtx<'inp, 'out, BS: ArrayLength<u8>> {
+struct ApplyBlocksCtx<'inp, 'out, BS: BlockSizes> {
     blocks: InOutBuf<'inp, 'out, Block<Self>>,
 }
 
-impl<'inp, 'out, BS: ArrayLength<u8>> BlockSizeUser for ApplyBlocksCtx<'inp, 'out, BS> {
+impl<'inp, 'out, BS: BlockSizes> BlockSizeUser for ApplyBlocksCtx<'inp, 'out, BS> {
     type BlockSize = BS;
 }
 
-impl<'inp, 'out, BS: ArrayLength<u8>> StreamClosure for ApplyBlocksCtx<'inp, 'out, BS> {
+impl<'inp, 'out, BS: BlockSizes> StreamClosure for ApplyBlocksCtx<'inp, 'out, BS> {
     #[inline(always)]
     #[allow(clippy::needless_range_loop)]
     fn call<B: StreamBackend<BlockSize = BS>>(self, backend: &mut B) {
@@ -284,7 +284,7 @@ impl<'inp, 'out, BS: ArrayLength<u8>> StreamClosure for ApplyBlocksCtx<'inp, 'ou
                 chunk.xor_in2out(&tmp);
             }
             let n = tail.len();
-            let mut buf = GenericArray::<_, B::ParBlocksSize>::default();
+            let mut buf = Array::<_, B::ParBlocksSize>::default();
             let ks = &mut buf[..n];
             backend.gen_tail_blocks(ks);
             for i in 0..n {

--- a/digest/Cargo.toml
+++ b/digest/Cargo.toml
@@ -6,17 +6,17 @@ authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 edition = "2021"
-rust-version = "1.57"
+rust-version = "1.65"
 documentation = "https://docs.rs/digest"
 repository = "https://github.com/RustCrypto/traits"
 keywords = ["digest", "crypto", "hash"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-crypto-common = "0.2.0-pre"
+crypto-common = "=0.2.0-pre"
 
 # optional dependencies
-block-buffer = { version = "0.11.0-pre", optional = true }
+block-buffer = { version = "=0.11.0-pre", optional = true }
 subtle = { version = "2.4", default-features = false, optional = true }
 blobby = { version = "0.3", optional = true }
 const-oid = { version = "0.9", optional = true }

--- a/digest/README.md
+++ b/digest/README.md
@@ -16,7 +16,7 @@ See [RustCrypto/hashes][1] for implementations which use this trait.
 
 ## Minimum Supported Rust Version
 
-Rust **1.57** or higher.
+Rust **1.65** or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be
 done with a minor version bump.
@@ -56,7 +56,7 @@ let hash = hasher.finalize();
 println!("Result: {:x}", hash);
 ```
 
-In this example `hash` has type [`GenericArray<u8, U64>`][2], which is a generic
+In this example `hash` has type [`Array<u8, U64>`][2], which is a generic
 alternative to `[u8; 64]`.
 
 Alternatively you can use chained approach, which is equivalent to the previous
@@ -147,7 +147,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/digest/badge.svg
 [docs-link]: https://docs.rs/digest/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.57+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.65+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260041-hashes
 [build-image]: https://github.com/RustCrypto/traits/workflows/digest/badge.svg?branch=master&event=push
@@ -157,7 +157,7 @@ dual licensed as above, without any additional terms or conditions.
 
 [0]: https://en.wikipedia.org/wiki/Cryptographic_hash_function
 [1]: https://github.com/RustCrypto/hashes
-[2]: https://docs.rs/generic-array
+[2]: https://docs.rs/hybrid-array
 [3]: https://doc.rust-lang.org/std/io/trait.Read.html
 [4]: https://doc.rust-lang.org/std/io/trait.Write.html
 [5]: https://en.wikipedia.org/wiki/Hash-based_message_authentication_code

--- a/digest/src/core_api/ct_variable.rs
+++ b/digest/src/core_api/ct_variable.rs
@@ -9,7 +9,7 @@ use crate::MacMarker;
 use const_oid::{AssociatedOid, ObjectIdentifier};
 use core::{fmt, marker::PhantomData};
 use crypto_common::{
-    generic_array::{ArrayLength, GenericArray},
+    array::{Array, ArraySize},
     typenum::{IsLessOrEqual, LeEq, NonZero},
     Block, BlockSizeUser, OutputSizeUser,
 };
@@ -25,7 +25,7 @@ pub struct NoOid;
 pub struct CtVariableCoreWrapper<T, OutSize, O = NoOid>
 where
     T: VariableOutputCore,
-    OutSize: ArrayLength<u8> + IsLessOrEqual<T::OutputSize>,
+    OutSize: ArraySize + IsLessOrEqual<T::OutputSize>,
     LeEq<OutSize, T::OutputSize>: NonZero,
 {
     inner: T,
@@ -35,7 +35,7 @@ where
 impl<T, OutSize, O> HashMarker for CtVariableCoreWrapper<T, OutSize, O>
 where
     T: VariableOutputCore + HashMarker,
-    OutSize: ArrayLength<u8> + IsLessOrEqual<T::OutputSize>,
+    OutSize: ArraySize + IsLessOrEqual<T::OutputSize>,
     LeEq<OutSize, T::OutputSize>: NonZero,
 {
 }
@@ -44,7 +44,7 @@ where
 impl<T, OutSize, O> MacMarker for CtVariableCoreWrapper<T, OutSize, O>
 where
     T: VariableOutputCore + MacMarker,
-    OutSize: ArrayLength<u8> + IsLessOrEqual<T::OutputSize>,
+    OutSize: ArraySize + IsLessOrEqual<T::OutputSize>,
     LeEq<OutSize, T::OutputSize>: NonZero,
 {
 }
@@ -52,7 +52,7 @@ where
 impl<T, OutSize, O> BlockSizeUser for CtVariableCoreWrapper<T, OutSize, O>
 where
     T: VariableOutputCore,
-    OutSize: ArrayLength<u8> + IsLessOrEqual<T::OutputSize>,
+    OutSize: ArraySize + IsLessOrEqual<T::OutputSize>,
     LeEq<OutSize, T::OutputSize>: NonZero,
 {
     type BlockSize = T::BlockSize;
@@ -61,7 +61,7 @@ where
 impl<T, OutSize, O> UpdateCore for CtVariableCoreWrapper<T, OutSize, O>
 where
     T: VariableOutputCore,
-    OutSize: ArrayLength<u8> + IsLessOrEqual<T::OutputSize>,
+    OutSize: ArraySize + IsLessOrEqual<T::OutputSize>,
     LeEq<OutSize, T::OutputSize>: NonZero,
 {
     #[inline]
@@ -73,7 +73,7 @@ where
 impl<T, OutSize, O> OutputSizeUser for CtVariableCoreWrapper<T, OutSize, O>
 where
     T: VariableOutputCore,
-    OutSize: ArrayLength<u8> + IsLessOrEqual<T::OutputSize> + 'static,
+    OutSize: ArraySize + IsLessOrEqual<T::OutputSize> + 'static,
     LeEq<OutSize, T::OutputSize>: NonZero,
 {
     type OutputSize = OutSize;
@@ -82,7 +82,7 @@ where
 impl<T, OutSize, O> BufferKindUser for CtVariableCoreWrapper<T, OutSize, O>
 where
     T: VariableOutputCore,
-    OutSize: ArrayLength<u8> + IsLessOrEqual<T::OutputSize>,
+    OutSize: ArraySize + IsLessOrEqual<T::OutputSize>,
     LeEq<OutSize, T::OutputSize>: NonZero,
 {
     type BufferKind = T::BufferKind;
@@ -91,14 +91,14 @@ where
 impl<T, OutSize, O> FixedOutputCore for CtVariableCoreWrapper<T, OutSize, O>
 where
     T: VariableOutputCore,
-    OutSize: ArrayLength<u8> + IsLessOrEqual<T::OutputSize> + 'static,
+    OutSize: ArraySize + IsLessOrEqual<T::OutputSize> + 'static,
     LeEq<OutSize, T::OutputSize>: NonZero,
 {
     #[inline]
     fn finalize_fixed_core(
         &mut self,
         buffer: &mut Buffer<Self>,
-        out: &mut GenericArray<u8, Self::OutputSize>,
+        out: &mut Array<u8, Self::OutputSize>,
     ) {
         let mut full_res = Default::default();
         self.inner.finalize_variable_core(buffer, &mut full_res);
@@ -114,7 +114,7 @@ where
 impl<T, OutSize, O> Default for CtVariableCoreWrapper<T, OutSize, O>
 where
     T: VariableOutputCore,
-    OutSize: ArrayLength<u8> + IsLessOrEqual<T::OutputSize>,
+    OutSize: ArraySize + IsLessOrEqual<T::OutputSize>,
     LeEq<OutSize, T::OutputSize>: NonZero,
 {
     #[inline]
@@ -129,7 +129,7 @@ where
 impl<T, OutSize, O> Reset for CtVariableCoreWrapper<T, OutSize, O>
 where
     T: VariableOutputCore,
-    OutSize: ArrayLength<u8> + IsLessOrEqual<T::OutputSize>,
+    OutSize: ArraySize + IsLessOrEqual<T::OutputSize>,
     LeEq<OutSize, T::OutputSize>: NonZero,
 {
     #[inline]
@@ -141,7 +141,7 @@ where
 impl<T, OutSize, O> AlgorithmName for CtVariableCoreWrapper<T, OutSize, O>
 where
     T: VariableOutputCore + AlgorithmName,
-    OutSize: ArrayLength<u8> + IsLessOrEqual<T::OutputSize>,
+    OutSize: ArraySize + IsLessOrEqual<T::OutputSize>,
     LeEq<OutSize, T::OutputSize>: NonZero,
 {
     fn write_alg_name(f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -157,7 +157,7 @@ impl<T, OutSize, O> AssociatedOid for CtVariableCoreWrapper<T, OutSize, O>
 where
     T: VariableOutputCore,
     O: AssociatedOid,
-    OutSize: ArrayLength<u8> + IsLessOrEqual<T::OutputSize>,
+    OutSize: ArraySize + IsLessOrEqual<T::OutputSize>,
     LeEq<OutSize, T::OutputSize>: NonZero,
 {
     const OID: ObjectIdentifier = O::OID;

--- a/digest/src/core_api/ct_variable.rs
+++ b/digest/src/core_api/ct_variable.rs
@@ -73,7 +73,7 @@ where
 impl<T, OutSize, O> OutputSizeUser for CtVariableCoreWrapper<T, OutSize, O>
 where
     T: VariableOutputCore,
-    OutSize: ArraySize + IsLessOrEqual<T::OutputSize> + 'static,
+    OutSize: ArraySize + IsLessOrEqual<T::OutputSize>,
     LeEq<OutSize, T::OutputSize>: NonZero,
 {
     type OutputSize = OutSize;
@@ -91,7 +91,7 @@ where
 impl<T, OutSize, O> FixedOutputCore for CtVariableCoreWrapper<T, OutSize, O>
 where
     T: VariableOutputCore,
-    OutSize: ArraySize + IsLessOrEqual<T::OutputSize> + 'static,
+    OutSize: ArraySize + IsLessOrEqual<T::OutputSize>,
     LeEq<OutSize, T::OutputSize>: NonZero,
 {
     #[inline]

--- a/digest/src/digest.rs
+++ b/digest/src/digest.rs
@@ -196,9 +196,9 @@ impl<D: Update + FixedOutputReset + Reset + Clone + 'static> DynDigest for D {
     }
 
     fn finalize_into(self, buf: &mut [u8]) -> Result<(), InvalidBufferSize> {
-        let buf = <&mut Output<Self>>::try_from(buf).map_err(|_| InvalidBufferSize)?;
-        FixedOutput::finalize_into(self, buf);
-        Ok(())
+        buf.try_into()
+            .map_err(|_| InvalidBufferSize)
+            .map(|buf| FixedOutput::finalize_into(self, buf))
     }
 
     fn finalize_into_reset(&mut self, buf: &mut [u8]) -> Result<(), InvalidBufferSize> {

--- a/digest/src/digest.rs
+++ b/digest/src/digest.rs
@@ -196,21 +196,15 @@ impl<D: Update + FixedOutputReset + Reset + Clone + 'static> DynDigest for D {
     }
 
     fn finalize_into(self, buf: &mut [u8]) -> Result<(), InvalidBufferSize> {
-        if buf.len() == self.output_size() {
-            FixedOutput::finalize_into(self, Output::<Self>::from_mut_slice(buf));
-            Ok(())
-        } else {
-            Err(InvalidBufferSize)
-        }
+        let buf = <&mut Output<Self>>::try_from(buf).map_err(|_| InvalidBufferSize)?;
+        FixedOutput::finalize_into(self, buf);
+        Ok(())
     }
 
     fn finalize_into_reset(&mut self, buf: &mut [u8]) -> Result<(), InvalidBufferSize> {
-        if buf.len() == self.output_size() {
-            FixedOutputReset::finalize_into_reset(self, Output::<Self>::from_mut_slice(buf));
-            Ok(())
-        } else {
-            Err(InvalidBufferSize)
-        }
+        let buf = <&mut Output<Self>>::try_from(buf).map_err(|_| InvalidBufferSize)?;
+        FixedOutputReset::finalize_into_reset(self, buf);
+        Ok(())
     }
 
     fn reset(&mut self) {

--- a/digest/src/lib.rs
+++ b/digest/src/lib.rs
@@ -65,7 +65,7 @@ pub use const_oid;
 pub use crypto_common;
 
 pub use crate::digest::{Digest, DynDigest, HashMarker};
-pub use crypto_common::{generic_array, typenum, typenum::consts, Output, OutputSizeUser, Reset};
+pub use crypto_common::{array, typenum, typenum::consts, Output, OutputSizeUser, Reset};
 #[cfg(feature = "mac")]
 pub use crypto_common::{InnerInit, InvalidLength, Key, KeyInit};
 #[cfg(feature = "mac")]


### PR DESCRIPTION
Continuation of #1319.    

Replaces `generic-array` with `hybrid-array`, which is built on a combination of `typenum` and const generics, providing a degree of interoperability between the two systems.

`hybrid-array` is designed to be a largely drop-in replacement, and the number of changes required to switch are relatively minimal aside from some idiosyncrasies.