### PR TITLE
local crypto-common breaks digest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,7 +304,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6faaa83e7700e0832cbbf84854d4c356270526907d9b14fab927fc7a9b5befb8"
 dependencies = [
  "generic-array",
- "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -385,7 +384,7 @@ dependencies = [
  "blobby",
  "block-buffer 0.11.0-pre",
  "const-oid 0.9.5",
- "crypto-common 0.2.0-pre (registry+https://github.com/rust-lang/crates.io-index)",
+ "crypto-common 0.2.0-pre",
  "subtle",
 ]
 

--- a/digest/Cargo.toml
+++ b/digest/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["digest", "crypto", "hash"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-crypto-common = "0.2.0-pre"
+crypto-common = { version = "0.2.0-pre", path = "../crypto-common" }
 
 # optional dependencies
 block-buffer = { version = "0.11.0-pre", optional = true }


### PR DESCRIPTION
When I tried merging master branch into #1078 I had to update the digest
crate's dependency to point to the local crypto-common path as in this PR and
ended up with the following build errors:

```
   Compiling digest v0.11.0-pre (/home/wayne/projects/RustCrypto/traits/digest)
error[E0277]: the trait bound `<Self as BlockSizeUser>::BlockSize: Cmp<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UTerm, B1>, B0>, B0>, B0>, B0>, B0>, B0>, B0>, B0>>` is not satisfied
  --> digest/src/core_api.rs:43:52
   |
43 |     fn finalize_fixed_core(&mut self, buffer: &mut Buffer<Self>, out: &mut Output<Self>);
   |                                                    ^^^^^^^^^^^^ the trait `Cmp<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UTerm, B1>, B0>, B0>, B0>, B0>, B0>, B0>, B0>, B0>>` is not implemented for `<Self as BlockSizeUser>::BlockSize`
   |
   = note: required for `<Self as BlockSizeUser>::BlockSize` to implement `IsLess<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UTerm, B1>, B0>, B0>, B0>, B0>, B0>, B0>, B0>, B0>>`
   = note: required for `<Self as BlockSizeUser>::BlockSize` to implement `crypto_common::sealed::BlockSizes`
   = note: required for `<Self as BlockSizeUser>::BlockSize` to implement `crypto_common::BlockSizes`
note: required by a bound in `BlockBuffer`
  --> /home/wayne/.cargo/registry/src/index.crates.io-6f17d22bba15001f/block-buffer-0.11.0-pre/src/lib.rs:61:28
   |
61 | pub struct BlockBuffer<BS: BlockSizes, K: BufferKind> {
   |                            ^^^^^^^^^^ required by this bound in `BlockBuffer`
help: consider further restricting the associated type
   |
43 |     fn finalize_fixed_core(&mut self, buffer: &mut Buffer<Self>, out: &mut Output<Self>) where <Self as BlockSizeUser>::BlockSize: Cmp<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UTerm, B1>, B0>, B0>, B0>, B0>, B0>, B0>, B0>, B0>>;
   |                                                                                          ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

error[E0277]: the trait bound `<Self as BlockSizeUser>::BlockSize: Cmp<UInt<UTerm, B1>>` is not satisfied
  --> digest/src/core_api.rs:43:52
   |
43 |     fn finalize_fixed_core(&mut self, buffer: &mut Buffer<Self>, out: &mut Output<Self>);
   |                                                    ^^^^^^^^^^^^ the trait `Cmp<UInt<UTerm, B1>>` is not implemented for `<Self as BlockSizeUser>::BlockSize`
   |
   = note: required for `<Self as BlockSizeUser>::BlockSize` to implement `IsGreater<UInt<UTerm, B1>>`
   = note: required for `<Self as BlockSizeUser>::BlockSize` to implement `crypto_common::sealed::BlockSizes`
   = note: required for `<Self as BlockSizeUser>::BlockSize` to implement `crypto_common::BlockSizes`
note: required by a bound in `BlockBuffer`
  --> /home/wayne/.cargo/registry/src/index.crates.io-6f17d22bba15001f/block-buffer-0.11.0-pre/src/lib.rs:61:28
   |
61 | pub struct BlockBuffer<BS: BlockSizes, K: BufferKind> {
   |                            ^^^^^^^^^^ required by this bound in `BlockBuffer`
help: consider further restricting the associated type
   |
43 |     fn finalize_fixed_core(&mut self, buffer: &mut Buffer<Self>, out: &mut Output<Self>) where <Self as BlockSizeUser>::BlockSize: Cmp<UInt<UTerm, B1>>;
   |                                                                                          ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

error[E0277]: the trait bound `<Self as BlockSizeUser>::BlockSize: Cmp<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UTerm, B1>, B0>, B0>, B0>, B0>, B0>, B0>, B0>, B0>>` is not satisfied
  --> digest/src/core_api.rs:53:50
   |
53 |     fn finalize_xof_core(&mut self, buffer: &mut Buffer<Self>) -> Self::ReaderCore;
   |                                                  ^^^^^^^^^^^^ the trait `Cmp<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UTerm, B1>, B0>, B0>, B0>, B0>, B0>, B0>, B0>, B0>>` is not implemented for `<Self as BlockSizeUser>::BlockSize`
   |
   = note: required for `<Self as BlockSizeUser>::BlockSize` to implement `IsLess<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UTerm, B1>, B0>, B0>, B0>, B0>, B0>, B0>, B0>, B0>>`
   = note: required for `<Self as BlockSizeUser>::BlockSize` to implement `crypto_common::sealed::BlockSizes`
   = note: required for `<Self as BlockSizeUser>::BlockSize` to implement `crypto_common::BlockSizes`
note: required by a bound in `BlockBuffer`
  --> /home/wayne/.cargo/registry/src/index.crates.io-6f17d22bba15001f/block-buffer-0.11.0-pre/src/lib.rs:61:28
   |
61 | pub struct BlockBuffer<BS: BlockSizes, K: BufferKind> {
   |                            ^^^^^^^^^^ required by this bound in `BlockBuffer`
help: consider further restricting the associated type
   |
53 |     fn finalize_xof_core(&mut self, buffer: &mut Buffer<Self>) -> Self::ReaderCore where <Self as BlockSizeUser>::BlockSize: Cmp<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UTerm, B1>, B0>, B0>, B0>, B0>, B0>, B0>, B0>, B0>>;
   |                                                                                    ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

error[E0277]: the trait bound `<Self as BlockSizeUser>::BlockSize: Cmp<UInt<UTerm, B1>>` is not satisfied
  --> digest/src/core_api.rs:53:50
   |
53 |     fn finalize_xof_core(&mut self, buffer: &mut Buffer<Self>) -> Self::ReaderCore;
   |                                                  ^^^^^^^^^^^^ the trait `Cmp<UInt<UTerm, B1>>` is not implemented for `<Self as BlockSizeUser>::BlockSize`
   |
   = note: required for `<Self as BlockSizeUser>::BlockSize` to implement `IsGreater<UInt<UTerm, B1>>`
   = note: required for `<Self as BlockSizeUser>::BlockSize` to implement `crypto_common::sealed::BlockSizes`
   = note: required for `<Self as BlockSizeUser>::BlockSize` to implement `crypto_common::BlockSizes`
note: required by a bound in `BlockBuffer`
  --> /home/wayne/.cargo/registry/src/index.crates.io-6f17d22bba15001f/block-buffer-0.11.0-pre/src/lib.rs:61:28
   |
61 | pub struct BlockBuffer<BS: BlockSizes, K: BufferKind> {
   |                            ^^^^^^^^^^ required by this bound in `BlockBuffer`
help: consider further restricting the associated type
   |
53 |     fn finalize_xof_core(&mut self, buffer: &mut Buffer<Self>) -> Self::ReaderCore where <Self as BlockSizeUser>::BlockSize: Cmp<UInt<UTerm, B1>>;
   |                                                                                    ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

error[E0277]: the trait bound `<Self as BlockSizeUser>::BlockSize: Cmp<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UTerm, B1>, B0>, B0>, B0>, B0>, B0>, B0>, B0>, B0>>` is not satisfied
  --> digest/src/core_api.rs:93:55
   |
93 |     fn finalize_variable_core(&mut self, buffer: &mut Buffer<Self>, out: &mut Output<Self>);
   |                                                       ^^^^^^^^^^^^ the trait `Cmp<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UTerm, B1>, B0>, B0>, B0>, B0>, B0>, B0>, B0>, B0>>` is not implemented for `<Self as BlockSizeUser>::BlockSize`
   |
   = note: required for `<Self as BlockSizeUser>::BlockSize` to implement `IsLess<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UTerm, B1>, B0>, B0>, B0>, B0>, B0>, B0>, B0>, B0>>`
   = note: required for `<Self as BlockSizeUser>::BlockSize` to implement `crypto_common::sealed::BlockSizes`
   = note: required for `<Self as BlockSizeUser>::BlockSize` to implement `crypto_common::BlockSizes`
note: required by a bound in `BlockBuffer`
  --> /home/wayne/.cargo/registry/src/index.crates.io-6f17d22bba15001f/block-buffer-0.11.0-pre/src/lib.rs:61:28
   |
61 | pub struct BlockBuffer<BS: BlockSizes, K: BufferKind> {
   |                            ^^^^^^^^^^ required by this bound in `BlockBuffer`
help: consider further restricting the associated type
   |
93 |     fn finalize_variable_core(&mut self, buffer: &mut Buffer<Self>, out: &mut Output<Self>) where <Self as BlockSizeUser>::BlockSize: Cmp<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UTerm, B1>, B0>, B0>, B0>, B0>, B0>, B0>, B0>, B0>>;
   |                                                                                             ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

error[E0277]: the trait bound `<Self as BlockSizeUser>::BlockSize: Cmp<UInt<UTerm, B1>>` is not satisfied
  --> digest/src/core_api.rs:93:55
   |
93 |     fn finalize_variable_core(&mut self, buffer: &mut Buffer<Self>, out: &mut Output<Self>);
   |                                                       ^^^^^^^^^^^^ the trait `Cmp<UInt<UTerm, B1>>` is not implemented for `<Self as BlockSizeUser>::BlockSize`
   |
   = note: required for `<Self as BlockSizeUser>::BlockSize` to implement `IsGreater<UInt<UTerm, B1>>`
   = note: required for `<Self as BlockSizeUser>::BlockSize` to implement `crypto_common::sealed::BlockSizes`
   = note: required for `<Self as BlockSizeUser>::BlockSize` to implement `crypto_common::BlockSizes`
note: required by a bound in `BlockBuffer`
  --> /home/wayne/.cargo/registry/src/index.crates.io-6f17d22bba15001f/block-buffer-0.11.0-pre/src/lib.rs:61:28
   |
61 | pub struct BlockBuffer<BS: BlockSizes, K: BufferKind> {
   |                            ^^^^^^^^^^ required by this bound in `BlockBuffer`
help: consider further restricting the associated type
   |
93 |     fn finalize_variable_core(&mut self, buffer: &mut Buffer<Self>, out: &mut Output<Self>) where <Self as BlockSizeUser>::BlockSize: Cmp<UInt<UTerm, B1>>;
   |                                                                                             ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

error[E0277]: the trait bound `<T as BlockSizeUser>::BlockSize: Cmp<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UTerm, B1>, B0>, B0>, B0>, B0>, B0>, B0>, B0>, B0>>` is not satisfied
   --> digest/src/core_api/ct_variable.rs:100:22
    |
100 |         buffer: &mut Buffer<Self>,
    |                      ^^^^^^^^^^^^ the trait `Cmp<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UTerm, B1>, B0>, B0>, B0>, B0>, B0>, B0>, B0>, B0>>` is not implemented for `<T as BlockSizeUser>::BlockSize`
    |
    = note: required for `<T as BlockSizeUser>::BlockSize` to implement `IsLess<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UTerm, B1>, B0>, B0>, B0>, B0>, B0>, B0>, B0>, B0>>`
    = note: required for `<T as BlockSizeUser>::BlockSize` to implement `crypto_common::sealed::BlockSizes`
    = note: required for `<T as BlockSizeUser>::BlockSize` to implement `crypto_common::BlockSizes`
note: required by a bound in `BlockBuffer`
   --> /home/wayne/.cargo/registry/src/index.crates.io-6f17d22bba15001f/block-buffer-0.11.0-pre/src/lib.rs:61:28
    |
61  | pub struct BlockBuffer<BS: BlockSizes, K: BufferKind> {
    |                            ^^^^^^^^^^ required by this bound in `BlockBuffer`
help: consider further restricting the associated type
    |
102 |     ) where <T as BlockSizeUser>::BlockSize: Cmp<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UTerm, B1>, B0>, B0>, B0>, B0>, B0>, B0>, B0>, B0>> {
    |       +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

error[E0277]: the trait bound `<T as BlockSizeUser>::BlockSize: Cmp<UInt<UTerm, B1>>` is not satisfied
   --> digest/src/core_api/ct_variable.rs:100:22
    |
100 |         buffer: &mut Buffer<Self>,
    |                      ^^^^^^^^^^^^ the trait `Cmp<UInt<UTerm, B1>>` is not implemented for `<T as BlockSizeUser>::BlockSize`
    |
    = note: required for `<T as BlockSizeUser>::BlockSize` to implement `IsGreater<UInt<UTerm, B1>>`
    = note: required for `<T as BlockSizeUser>::BlockSize` to implement `crypto_common::sealed::BlockSizes`
    = note: required for `<T as BlockSizeUser>::BlockSize` to implement `crypto_common::BlockSizes`
note: required by a bound in `BlockBuffer`
   --> /home/wayne/.cargo/registry/src/index.crates.io-6f17d22bba15001f/block-buffer-0.11.0-pre/src/lib.rs:61:28
    |
61  | pub struct BlockBuffer<BS: BlockSizes, K: BufferKind> {
    |                            ^^^^^^^^^^ required by this bound in `BlockBuffer`
help: consider further restricting the associated type
    |
102 |     ) where <T as BlockSizeUser>::BlockSize: Cmp<UInt<UTerm, B1>> {
    |       +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

error[E0277]: the trait bound `<T as BlockSizeUser>::BlockSize: Cmp<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UTerm, B1>, B0>, B0>, B0>, B0>, B0>, B0>, B0>, B0>>` is not satisfied
  --> digest/src/core_api/rt_variable.rs:18:13
   |
18 |     buffer: BlockBuffer<T::BlockSize, T::BufferKind>,
   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Cmp<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UTerm, B1>, B0>, B0>, B0>, B0>, B0>, B0>, B0>, B0>>` is not implemented for `<T as BlockSizeUser>::BlockSize`
   |
   = note: required for `<T as BlockSizeUser>::BlockSize` to implement `IsLess<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UTerm, B1>, B0>, B0>, B0>, B0>, B0>, B0>, B0>, B0>>`
   = note: required for `<T as BlockSizeUser>::BlockSize` to implement `crypto_common::sealed::BlockSizes`
   = note: required for `<T as BlockSizeUser>::BlockSize` to implement `crypto_common::BlockSizes`
note: required by a bound in `BlockBuffer`
  --> /home/wayne/.cargo/registry/src/index.crates.io-6f17d22bba15001f/block-buffer-0.11.0-pre/src/lib.rs:61:28
   |
61 | pub struct BlockBuffer<BS: BlockSizes, K: BufferKind> {
   |                            ^^^^^^^^^^ required by this bound in `BlockBuffer`
help: consider extending the `where` clause, but there might be an alternative better way to express this requirement
   |
15 |     T: VariableOutputCore, <T as BlockSizeUser>::BlockSize: Cmp<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UTerm, B1>, B0>, B0>, B0>, B0>, B0>, B0>, B0>, B0>>
   |                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

error[E0277]: the trait bound `<T as BlockSizeUser>::BlockSize: Cmp<UInt<UTerm, B1>>` is not satisfied
  --> digest/src/core_api/rt_variable.rs:18:13
   |
18 |     buffer: BlockBuffer<T::BlockSize, T::BufferKind>,
   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Cmp<UInt<UTerm, B1>>` is not implemented for `<T as BlockSizeUser>::BlockSize`
   |
   = note: required for `<T as BlockSizeUser>::BlockSize` to implement `IsGreater<UInt<UTerm, B1>>`
   = note: required for `<T as BlockSizeUser>::BlockSize` to implement `crypto_common::sealed::BlockSizes`
   = note: required for `<T as BlockSizeUser>::BlockSize` to implement `crypto_common::BlockSizes`
note: required by a bound in `BlockBuffer`
  --> /home/wayne/.cargo/registry/src/index.crates.io-6f17d22bba15001f/block-buffer-0.11.0-pre/src/lib.rs:61:28
   |
61 | pub struct BlockBuffer<BS: BlockSizes, K: BufferKind> {
   |                            ^^^^^^^^^^ required by this bound in `BlockBuffer`
help: consider extending the `where` clause, but there might be an alternative better way to express this requirement
   |
15 |     T: VariableOutputCore, <T as BlockSizeUser>::BlockSize: Cmp<UInt<UTerm, B1>>
   |                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

error[E0277]: the trait bound `<T as BlockSizeUser>::BlockSize: Cmp<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UTerm, B1>, B0>, B0>, B0>, B0>, B0>, B0>, B0>, B0>>` is not satisfied
  --> digest/src/core_api/wrapper.rs:26:13
   |
26 |     buffer: BlockBuffer<T::BlockSize, T::BufferKind>,
   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Cmp<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UTerm, B1>, B0>, B0>, B0>, B0>, B0>, B0>, B0>, B0>>` is not implemented for `<T as BlockSizeUser>::BlockSize`
   |
   = note: required for `<T as BlockSizeUser>::BlockSize` to implement `IsLess<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UTerm, B1>, B0>, B0>, B0>, B0>, B0>, B0>, B0>, B0>>`
   = note: required for `<T as BlockSizeUser>::BlockSize` to implement `crypto_common::sealed::BlockSizes`
   = note: required for `<T as BlockSizeUser>::BlockSize` to implement `crypto_common::BlockSizes`
note: required by a bound in `BlockBuffer`
  --> /home/wayne/.cargo/registry/src/index.crates.io-6f17d22bba15001f/block-buffer-0.11.0-pre/src/lib.rs:61:28
   |
61 | pub struct BlockBuffer<BS: BlockSizes, K: BufferKind> {
   |                            ^^^^^^^^^^ required by this bound in `BlockBuffer`
help: consider extending the `where` clause, but there might be an alternative better way to express this requirement
   |
23 |     T: BufferKindUser, <T as BlockSizeUser>::BlockSize: Cmp<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UTerm, B1>, B0>, B0>, B0>, B0>, B0>, B0>, B0>, B0>>
   |                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

error[E0277]: the trait bound `<T as BlockSizeUser>::BlockSize: Cmp<UInt<UTerm, B1>>` is not satisfied
  --> digest/src/core_api/wrapper.rs:26:13
   |
26 |     buffer: BlockBuffer<T::BlockSize, T::BufferKind>,
   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Cmp<UInt<UTerm, B1>>` is not implemented for `<T as BlockSizeUser>::BlockSize`
   |
   = note: required for `<T as BlockSizeUser>::BlockSize` to implement `IsGreater<UInt<UTerm, B1>>`
   = note: required for `<T as BlockSizeUser>::BlockSize` to implement `crypto_common::sealed::BlockSizes`
   = note: required for `<T as BlockSizeUser>::BlockSize` to implement `crypto_common::BlockSizes`
note: required by a bound in `BlockBuffer`
  --> /home/wayne/.cargo/registry/src/index.crates.io-6f17d22bba15001f/block-buffer-0.11.0-pre/src/lib.rs:61:28
   |
61 | pub struct BlockBuffer<BS: BlockSizes, K: BufferKind> {
   |                            ^^^^^^^^^^ required by this bound in `BlockBuffer`
help: consider extending the `where` clause, but there might be an alternative better way to express this requirement
   |
23 |     T: BufferKindUser, <T as BlockSizeUser>::BlockSize: Cmp<UInt<UTerm, B1>>
   |                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

error[E0277]: the trait bound `<T as BlockSizeUser>::BlockSize: Cmp<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UTerm, B1>, B0>, B0>, B0>, B0>, B0>, B0>, B0>, B0>>` is not satisfied
  --> digest/src/core_api/wrapper.rs:56:35
   |
56 |     pub fn decompose(self) -> (T, Buffer<T>) {
   |                                   ^^^^^^^^^ the trait `Cmp<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UTerm, B1>, B0>, B0>, B0>, B0>, B0>, B0>, B0>, B0>>` is not implemented for `<T as BlockSizeUser>::BlockSize`
   |
   = note: required for `<T as BlockSizeUser>::BlockSize` to implement `IsLess<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UTerm, B1>, B0>, B0>, B0>, B0>, B0>, B0>, B0>, B0>>`
   = note: required for `<T as BlockSizeUser>::BlockSize` to implement `crypto_common::sealed::BlockSizes`
   = note: required for `<T as BlockSizeUser>::BlockSize` to implement `crypto_common::BlockSizes`
note: required by a bound in `BlockBuffer`
  --> /home/wayne/.cargo/registry/src/index.crates.io-6f17d22bba15001f/block-buffer-0.11.0-pre/src/lib.rs:61:28
   |
61 | pub struct BlockBuffer<BS: BlockSizes, K: BufferKind> {
   |                            ^^^^^^^^^^ required by this bound in `BlockBuffer`
help: consider further restricting the associated type
   |
56 |     pub fn decompose(self) -> (T, Buffer<T>) where <T as BlockSizeUser>::BlockSize: Cmp<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UTerm, B1>, B0>, B0>, B0>, B0>, B0>, B0>, B0>, B0>> {
   |                                              +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

error[E0277]: the trait bound `<T as BlockSizeUser>::BlockSize: Cmp<UInt<UTerm, B1>>` is not satisfied
  --> digest/src/core_api/wrapper.rs:56:35
   |
56 |     pub fn decompose(self) -> (T, Buffer<T>) {
   |                                   ^^^^^^^^^ the trait `Cmp<UInt<UTerm, B1>>` is not implemented for `<T as BlockSizeUser>::BlockSize`
   |
   = note: required for `<T as BlockSizeUser>::BlockSize` to implement `IsGreater<UInt<UTerm, B1>>`
   = note: required for `<T as BlockSizeUser>::BlockSize` to implement `crypto_common::sealed::BlockSizes`
   = note: required for `<T as BlockSizeUser>::BlockSize` to implement `crypto_common::BlockSizes`
note: required by a bound in `BlockBuffer`
  --> /home/wayne/.cargo/registry/src/index.crates.io-6f17d22bba15001f/block-buffer-0.11.0-pre/src/lib.rs:61:28
   |
61 | pub struct BlockBuffer<BS: BlockSizes, K: BufferKind> {
   |                            ^^^^^^^^^^ required by this bound in `BlockBuffer`
help: consider further restricting the associated type
   |
56 |     pub fn decompose(self) -> (T, Buffer<T>) where <T as BlockSizeUser>::BlockSize: Cmp<UInt<UTerm, B1>> {
   |                                              +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

error[E0277]: the trait bound `<T as BlockSizeUser>::BlockSize: Cmp<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UTerm, B1>, B0>, B0>, B0>, B0>, B0>, B0>, B0>, B0>>` is not satisfied
  --> digest/src/core_api/xof_reader.rs:15:24
   |
15 |     pub(super) buffer: ReadBuffer<T::BlockSize>,
   |                        ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Cmp<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UTerm, B1>, B0>, B0>, B0>, B0>, B0>, B0>, B0>, B0>>` is not implemented for `<T as BlockSizeUser>::BlockSize`
   |
   = note: required for `<T as BlockSizeUser>::BlockSize` to implement `IsLess<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UTerm, B1>, B0>, B0>, B0>, B0>, B0>, B0>, B0>, B0>>`
   = note: required for `<T as BlockSizeUser>::BlockSize` to implement `crypto_common::sealed::BlockSizes`
   = note: required for `<T as BlockSizeUser>::BlockSize` to implement `crypto_common::BlockSizes`
note: required by a bound in `ReadBuffer`
  --> /home/wayne/.cargo/registry/src/index.crates.io-6f17d22bba15001f/block-buffer-0.11.0-pre/src/read.rs:6:27
   |
6  | pub struct ReadBuffer<BS: BlockSizes> {
   |                           ^^^^^^^^^^ required by this bound in `ReadBuffer`
help: consider extending the `where` clause, but there might be an alternative better way to express this requirement
   |
12 |     T: XofReaderCore, <T as BlockSizeUser>::BlockSize: Cmp<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UTerm, B1>, B0>, B0>, B0>, B0>, B0>, B0>, B0>, B0>>
   |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

error[E0277]: the trait bound `<T as BlockSizeUser>::BlockSize: Cmp<UInt<UTerm, B1>>` is not satisfied
  --> digest/src/core_api/xof_reader.rs:15:24
   |
15 |     pub(super) buffer: ReadBuffer<T::BlockSize>,
   |                        ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Cmp<UInt<UTerm, B1>>` is not implemented for `<T as BlockSizeUser>::BlockSize`
   |
   = note: required for `<T as BlockSizeUser>::BlockSize` to implement `IsGreater<UInt<UTerm, B1>>`
   = note: required for `<T as BlockSizeUser>::BlockSize` to implement `crypto_common::sealed::BlockSizes`
   = note: required for `<T as BlockSizeUser>::BlockSize` to implement `crypto_common::BlockSizes`
note: required by a bound in `ReadBuffer`
  --> /home/wayne/.cargo/registry/src/index.crates.io-6f17d22bba15001f/block-buffer-0.11.0-pre/src/read.rs:6:27
   |
6  | pub struct ReadBuffer<BS: BlockSizes> {
   |                           ^^^^^^^^^^ required by this bound in `ReadBuffer`
help: consider extending the `where` clause, but there might be an alternative better way to express this requirement
   |
12 |     T: XofReaderCore, <T as BlockSizeUser>::BlockSize: Cmp<UInt<UTerm, B1>>
   |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

error[E0277]: the trait bound `<T as BlockSizeUser>::BlockSize: Cmp<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UTerm, B1>, B0>, B0>, B0>, B0>, B0>, B0>, B0>, B0>>` is not satisfied
   --> digest/src/core_api/xof_reader.rs:9:10
    |
9   | #[derive(Clone, Default)]
    |          ^^^^^ the trait `Cmp<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UTerm, B1>, B0>, B0>, B0>, B0>, B0>, B0>, B0>, B0>>` is not implemented for `<T as BlockSizeUser>::BlockSize`
    |
    = note: required for `<T as BlockSizeUser>::BlockSize` to implement `IsLess<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UTerm, B1>, B0>, B0>, B0>, B0>, B0>, B0>, B0>, B0>>`
    = note: required for `<T as BlockSizeUser>::BlockSize` to implement `crypto_common::sealed::BlockSizes`
    = note: required for `<T as BlockSizeUser>::BlockSize` to implement `crypto_common::BlockSizes`
    = note: required for `ReadBuffer<<T as BlockSizeUser>::BlockSize>` to implement `crypto_common::BlockSizeUser`
note: required because it appears within the type `XofReaderCoreWrapper<T>`
   --> digest/src/core_api/xof_reader.rs:10:12
    |
10  | pub struct XofReaderCoreWrapper<T>
    |            ^^^^^^^^^^^^^^^^^^^^
note: required by a bound in `Clone`
   --> /home/wayne/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/clone.rs:107:18
    |
107 | pub trait Clone: Sized {
    |                  ^^^^^ required by this bound in `Clone`
    = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
help: consider further restricting the associated type
    |
9   | #[derive(Clone, <T as BlockSizeUser>::BlockSize: Cmp<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UTerm, B1>, B0>, B0>, B0>, B0>, B0>, B0>, B0>, B0>>, Default)]
    |               +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

error[E0277]: the trait bound `<T as BlockSizeUser>::BlockSize: Cmp<UInt<UTerm, B1>>` is not satisfied
   --> digest/src/core_api/xof_reader.rs:9:10
    |
9   | #[derive(Clone, Default)]
    |          ^^^^^ the trait `Cmp<UInt<UTerm, B1>>` is not implemented for `<T as BlockSizeUser>::BlockSize`
    |
    = note: required for `<T as BlockSizeUser>::BlockSize` to implement `IsGreater<UInt<UTerm, B1>>`
    = note: required for `<T as BlockSizeUser>::BlockSize` to implement `crypto_common::sealed::BlockSizes`
    = note: required for `<T as BlockSizeUser>::BlockSize` to implement `crypto_common::BlockSizes`
    = note: required for `ReadBuffer<<T as BlockSizeUser>::BlockSize>` to implement `crypto_common::BlockSizeUser`
note: required because it appears within the type `XofReaderCoreWrapper<T>`
   --> digest/src/core_api/xof_reader.rs:10:12
    |
10  | pub struct XofReaderCoreWrapper<T>
    |            ^^^^^^^^^^^^^^^^^^^^
note: required by a bound in `Clone`
   --> /home/wayne/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/clone.rs:107:18
    |
107 | pub trait Clone: Sized {
    |                  ^^^^^ required by this bound in `Clone`
    = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
help: consider further restricting the associated type
    |
9   | #[derive(Clone, <T as BlockSizeUser>::BlockSize: Cmp<UInt<UTerm, B1>>, Default)]
    |               +++++++++++++++++++++++++++++++++++++++++++++++++++++++

error[E0277]: the trait bound `<T as BlockSizeUser>::BlockSize: Cmp<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UTerm, B1>, B0>, B0>, B0>, B0>, B0>, B0>, B0>, B0>>` is not satisfied
   --> digest/src/core_api/xof_reader.rs:9:17
    |
9   | #[derive(Clone, Default)]
    |                 ^^^^^^^ the trait `Cmp<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UTerm, B1>, B0>, B0>, B0>, B0>, B0>, B0>, B0>, B0>>` is not implemented for `<T as BlockSizeUser>::BlockSize`
    |
    = note: required for `<T as BlockSizeUser>::BlockSize` to implement `IsLess<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UTerm, B1>, B0>, B0>, B0>, B0>, B0>, B0>, B0>, B0>>`
    = note: required for `<T as BlockSizeUser>::BlockSize` to implement `crypto_common::sealed::BlockSizes`
    = note: required for `<T as BlockSizeUser>::BlockSize` to implement `crypto_common::BlockSizes`
    = note: required for `ReadBuffer<<T as BlockSizeUser>::BlockSize>` to implement `crypto_common::BlockSizeUser`
note: required because it appears within the type `XofReaderCoreWrapper<T>`
   --> digest/src/core_api/xof_reader.rs:10:12
    |
10  | pub struct XofReaderCoreWrapper<T>
    |            ^^^^^^^^^^^^^^^^^^^^
note: required by a bound in `Default`
   --> /home/wayne/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/default.rs:102:20
    |
102 | pub trait Default: Sized {
    |                    ^^^^^ required by this bound in `Default`
    = note: this error originates in the derive macro `Default` (in Nightly builds, run with -Z macro-backtrace for more info)
help: consider further restricting the associated type
    |
9   | #[derive(Clone, Default, <T as BlockSizeUser>::BlockSize: Cmp<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UInt<UTerm, B1>, B0>, B0>, B0>, B0>, B0>, B0>, B0>, B0>>)]
    |                        +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

error[E0277]: the trait bound `<T as BlockSizeUser>::BlockSize: Cmp<UInt<UTerm, B1>>` is not satisfied
   --> digest/src/core_api/xof_reader.rs:9:17
    |
9   | #[derive(Clone, Default)]
    |                 ^^^^^^^ the trait `Cmp<UInt<UTerm, B1>>` is not implemented for `<T as BlockSizeUser>::BlockSize`
    |
    = note: required for `<T as BlockSizeUser>::BlockSize` to implement `IsGreater<UInt<UTerm, B1>>`
    = note: required for `<T as BlockSizeUser>::BlockSize` to implement `crypto_common::sealed::BlockSizes`
    = note: required for `<T as BlockSizeUser>::BlockSize` to implement `crypto_common::BlockSizes`
    = note: required for `ReadBuffer<<T as BlockSizeUser>::BlockSize>` to implement `crypto_common::BlockSizeUser`
note: required because it appears within the type `XofReaderCoreWrapper<T>`
   --> digest/src/core_api/xof_reader.rs:10:12
    |
10  | pub struct XofReaderCoreWrapper<T>
    |            ^^^^^^^^^^^^^^^^^^^^
note: required by a bound in `Default`
   --> /home/wayne/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/default.rs:102:20
    |
102 | pub trait Default: Sized {
    |                    ^^^^^ required by this bound in `Default`
    = note: this error originates in the derive macro `Default` (in Nightly builds, run with -Z macro-backtrace for more info)
help: consider further restricting the associated type
    |
9   | #[derive(Clone, Default, <T as BlockSizeUser>::BlockSize: Cmp<UInt<UTerm, B1>>)]
    |                        +++++++++++++++++++++++++++++++++++++++++++++++++++++++

For more information about this error, try `rustc --explain E0277`.
error: could not compile `digest` (lib) due to 20 previous errors
```

I'm mostly opening this PR just to demonstrate the problem, I'm not sure how to
fix this (but happy to take any guidance). I suspect the maintainers may
already know about this and have WIP to address it.
