### PR TITLE
signature: add traits to obtain verifier objects

### DIFF
--- a/signature/src/signer.rs
+++ b/signature/src/signer.rs
@@ -1,12 +1,32 @@
 //! Traits for generating digital signatures
 
 use crate::error::Error;
+use crate::verifier::Verifier;
 
 #[cfg(feature = "digest")]
-use crate::digest::Digest;
+use crate::{digest::Digest, verifier::DigestVerifier};
 
 #[cfg(feature = "rand_core")]
 use crate::rand_core::CryptoRngCore;
+
+/// This object can be used to obtain a verifier for the signature type `S`.
+pub trait HasVerifier<S> {
+    /// The corresponding verifier type.
+    type Verifier: Verifier<S>;
+
+    /// Returns a verifier object.
+    fn verifier(&self) -> Self::Verifier;
+}
+
+/// This object can be used to obtain a digest verifier for the signature type `S`.
+#[cfg(feature = "digest")]
+pub trait HasDigestVerifier<D: Digest, S> {
+    /// The corresponding digest verifier type.
+    type DigestVerifier: DigestVerifier<D, S>;
+
+    /// Returns a digest verifier object.
+    fn digest_verifier(&self) -> Self::DigestVerifier;
+}
 
 /// Sign the provided message bytestring using `Self` (e.g. a cryptographic key
 /// or connection to an HSM), returning a digital signature.


### PR DESCRIPTION
I occasionally encounter situations where I need to get a verifier from a signer, and have to pass both to a method since there's currently no generic mechanism to do that. `ecdsa::SigningKey` has a [`verifying_key()`](https://docs.rs/ecdsa/0.16.8/ecdsa/struct.SigningKey.html#method.verifying_key) method, but it's not in any trait, so if my code is generic over Signer/Verifier traits, I can't use it.

Would it make sense to add a trait for that connection? Are there any situations where a signer object does not allow one to obtain the corresponding verifier? If not, we can even bound `Singer<S>: HasVerifier<S>`.