### PR TITLE
cipher: test `minimal-versions` on stable in CI

### DIFF
--- a/.github/workflows/cipher.yml
+++ b/.github/workflows/cipher.yml
@@ -3,6 +3,7 @@ name: cipher
 on:
   pull_request:
     paths:
+      - ".github/workflows/cipher.yml"
       - "cipher/**"
       - "Cargo.*"
   push:
@@ -39,17 +40,16 @@ jobs:
       - run: cargo build --target ${{ matrix.target }} --features block-padding
 
   # TODO: use the reusable workflow after this crate will be part of the
-  # toot workspace
+  # root workspace
   minimal-versions:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: RustCrypto/actions/cargo-cache@master
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: nightly
+      - uses: dtolnay/rust-toolchain@nightly
       - uses: RustCrypto/actions/cargo-hack-install@master
       - run: cargo update -Z minimal-versions
+      - uses: dtolnay/rust-toolchain@stable
       - run: cargo hack test --release --feature-powerset
 
   test:


### PR DESCRIPTION
I suspect a nightly regression is responsible for this build failure:

https://github.com/RustCrypto/traits/actions/runs/6648272740/job/18065054230?pr=1319