### PR TITLE
cipher: remove needless lifetimes

### DIFF
--- a/cipher/src/block.rs
+++ b/cipher/src/block.rs
@@ -135,9 +135,9 @@ pub trait BlockEncrypt: BlockSizeUser + Sized {
     #[cfg(feature = "block-padding")]
     #[cfg_attr(docsrs, doc(cfg(feature = "block-padding")))]
     #[inline]
-    fn encrypt_padded_inout<'inp, 'out, P: Padding<Self::BlockSize>>(
+    fn encrypt_padded_inout<'out, P: Padding<Self::BlockSize>>(
         &self,
-        data: InOutBufReserved<'inp, 'out, u8>,
+        data: InOutBufReserved<'_, 'out, u8>,
     ) -> Result<&'out [u8], PadError> {
         let mut buf = data.into_padded_blocks::<P, Self::BlockSize>()?;
         self.encrypt_blocks_inout(buf.get_blocks());
@@ -251,9 +251,9 @@ pub trait BlockDecrypt: BlockSizeUser {
     #[cfg(feature = "block-padding")]
     #[cfg_attr(docsrs, doc(cfg(feature = "block-padding")))]
     #[inline]
-    fn decrypt_padded_inout<'inp, 'out, P: Padding<Self::BlockSize>>(
+    fn decrypt_padded_inout<'out, P: Padding<Self::BlockSize>>(
         &self,
-        data: InOutBuf<'inp, 'out, u8>,
+        data: InOutBuf<'_, 'out, u8>,
     ) -> Result<&'out [u8], UnpadError> {
         let (mut blocks, tail) = data.into_chunks();
         if !tail.is_empty() {
@@ -380,9 +380,9 @@ pub trait BlockEncryptMut: BlockSizeUser + Sized {
     #[cfg(feature = "block-padding")]
     #[cfg_attr(docsrs, doc(cfg(feature = "block-padding")))]
     #[inline]
-    fn encrypt_padded_inout_mut<'inp, 'out, P: Padding<Self::BlockSize>>(
+    fn encrypt_padded_inout_mut<'out, P: Padding<Self::BlockSize>>(
         mut self,
-        data: InOutBufReserved<'inp, 'out, u8>,
+        data: InOutBufReserved<'_, 'out, u8>,
     ) -> Result<&'out [u8], PadError> {
         let mut buf = data.into_padded_blocks::<P, Self::BlockSize>()?;
         self.encrypt_blocks_inout_mut(buf.get_blocks());
@@ -500,9 +500,9 @@ pub trait BlockDecryptMut: BlockSizeUser + Sized {
     #[cfg(feature = "block-padding")]
     #[cfg_attr(docsrs, doc(cfg(feature = "block-padding")))]
     #[inline]
-    fn decrypt_padded_inout_mut<'inp, 'out, P: Padding<Self::BlockSize>>(
+    fn decrypt_padded_inout_mut<'out, P: Padding<Self::BlockSize>>(
         mut self,
-        data: InOutBuf<'inp, 'out, u8>,
+        data: InOutBuf<'_, 'out, u8>,
     ) -> Result<&'out [u8], UnpadError> {
         let (mut blocks, tail) = data.into_chunks();
         if !tail.is_empty() {

--- a/cipher/src/lib.rs
+++ b/cipher/src/lib.rs
@@ -11,8 +11,7 @@
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg"
 )]
-#![warn(missing_docs, rust_2018_idioms)]
-#![allow(clippy::needless_lifetimes)]
+#![warn(missing_docs, rust_2018_idioms, unused_lifetimes)]
 
 pub use crypto_common;
 pub use inout;


### PR DESCRIPTION
One of the lifetimes is unused, but we couldn't remove it before because it would be a breaking change.

Closes #1336