### PR TITLE
Migrate to `doc_auto_cfg`

### DIFF
--- a/aead/src/dev.rs
+++ b/aead/src/dev.rs
@@ -3,7 +3,6 @@ pub use blobby;
 
 /// Define AEAD test
 #[macro_export]
-#[cfg_attr(docsrs, doc(cfg(feature = "dev")))]
 macro_rules! new_test {
     ($name:ident, $test_name:expr, $cipher:ty $(,)?) => {
         #[test]

--- a/aead/src/lib.rs
+++ b/aead/src/lib.rs
@@ -14,7 +14,7 @@
 //! [RustCrypto/AEADs]: https://github.com/RustCrypto/AEADs
 
 #![no_std]
-#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg"
@@ -29,34 +29,27 @@ extern crate alloc;
 extern crate std;
 
 #[cfg(feature = "dev")]
-#[cfg_attr(docsrs, doc(cfg(feature = "dev")))]
 pub mod dev;
 
 #[cfg(feature = "stream")]
-#[cfg_attr(docsrs, doc(cfg(feature = "stream")))]
 pub mod stream;
 
 pub use crypto_common::{Key, KeyInit, KeySizeUser};
 pub use generic_array::{self, typenum::consts};
 
 #[cfg(feature = "arrayvec")]
-#[cfg_attr(docsrs, doc(cfg(feature = "arrayvec")))]
 pub use arrayvec;
 
 #[cfg(feature = "bytes")]
-#[cfg_attr(docsrs, doc(cfg(feature = "bytes")))]
 pub use bytes;
 
 #[cfg(feature = "getrandom")]
-#[cfg_attr(docsrs, doc(cfg(feature = "getrandom")))]
 pub use crypto_common::rand_core::OsRng;
 
 #[cfg(feature = "heapless")]
-#[cfg_attr(docsrs, doc(cfg(feature = "heapless")))]
 pub use heapless;
 
 #[cfg(feature = "rand_core")]
-#[cfg_attr(docsrs, doc(cfg(feature = "rand_core")))]
 pub use crypto_common::rand_core;
 
 use core::fmt;
@@ -147,7 +140,6 @@ pub trait AeadCore {
     ///
     /// [NIST SP 800-38D]: https://csrc.nist.gov/publications/detail/sp/800-38d/final
     #[cfg(feature = "rand_core")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "rand_core")))]
     fn generate_nonce(mut rng: impl CryptoRng + RngCore) -> Nonce<Self>
     where
         Nonce<Self>: Default,
@@ -163,7 +155,6 @@ pub trait AeadCore {
 /// This trait is intended for use with stateless AEAD algorithms. The
 /// [`AeadMut`] trait provides a stateful interface.
 #[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 pub trait Aead: AeadCore {
     /// Encrypt the given plaintext payload, and return the resulting
     /// ciphertext as a vector of bytes.
@@ -220,7 +211,6 @@ pub trait Aead: AeadCore {
 
 /// Stateful Authenticated Encryption with Associated Data algorithm.
 #[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 pub trait AeadMut: AeadCore {
     /// Encrypt the given plaintext slice, and return the resulting ciphertext
     /// as a vector of bytes.
@@ -480,7 +470,6 @@ impl<Alg: AeadInPlace> AeadMutInPlace for Alg {
 /// If you don't care about AAD, you can pass a `&[u8]` as the payload to
 /// `encrypt`/`decrypt` and it will automatically be coerced to this type.
 #[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 pub struct Payload<'msg, 'aad> {
     /// Message to be encrypted/decrypted
     pub msg: &'msg [u8],

--- a/aead/src/stream.rs
+++ b/aead/src/stream.rs
@@ -131,7 +131,6 @@ where
     /// Encrypt the given plaintext payload, and return the resulting
     /// ciphertext as a vector of bytes.
     #[cfg(feature = "alloc")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     fn encrypt<'msg, 'aad>(
         &self,
         position: Self::Counter,
@@ -148,7 +147,6 @@ where
     /// Decrypt the given ciphertext slice, and return the resulting plaintext
     /// as a vector of bytes.
     #[cfg(feature = "alloc")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     fn decrypt<'msg, 'aad>(
         &self,
         position: Self::Counter,
@@ -259,7 +257,6 @@ macro_rules! impl_stream_object {
             #[doc = "the next AEAD message in this STREAM, returning the"]
             #[doc = "result as a [`Vec`]."]
             #[cfg(feature = "alloc")]
-            #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
             pub fn $next_method<'msg, 'aad>(
                 &mut self,
                 payload: impl Into<Payload<'msg, 'aad>>,
@@ -308,7 +305,6 @@ macro_rules! impl_stream_object {
             #[doc = $obj_desc]
             #[doc = "object in order to prevent further use."]
             #[cfg(feature = "alloc")]
-            #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
             pub fn $last_method<'msg, 'aad>(
                 self,
                 payload: impl Into<Payload<'msg, 'aad>>,

--- a/cipher/src/block.rs
+++ b/cipher/src/block.rs
@@ -133,7 +133,6 @@ pub trait BlockEncrypt: BlockSizeUser + Sized {
     ///
     /// Returns [`PadError`] if length of output buffer is not sufficient.
     #[cfg(feature = "block-padding")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "block-padding")))]
     #[inline]
     fn encrypt_padded_inout<'out, P: Padding<Self::BlockSize>>(
         &self,
@@ -151,7 +150,6 @@ pub trait BlockEncrypt: BlockSizeUser + Sized {
     ///
     /// Returns [`PadError`] if length of output buffer is not sufficient.
     #[cfg(feature = "block-padding")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "block-padding")))]
     #[inline]
     fn encrypt_padded<'a, P: Padding<Self::BlockSize>>(
         &self,
@@ -166,7 +164,6 @@ pub trait BlockEncrypt: BlockSizeUser + Sized {
     ///
     /// Returns [`PadError`] if length of output buffer is not sufficient.
     #[cfg(feature = "block-padding")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "block-padding")))]
     #[inline]
     fn encrypt_padded_b2b<'a, P: Padding<Self::BlockSize>>(
         &self,
@@ -179,7 +176,6 @@ pub trait BlockEncrypt: BlockSizeUser + Sized {
 
     /// Pad input and encrypt into a newly allocated Vec. Returns resulting ciphertext Vec.
     #[cfg(all(feature = "block-padding", feature = "alloc"))]
-    #[cfg_attr(docsrs, doc(cfg(all(feature = "block-padding", feature = "alloc"))))]
     #[inline]
     fn encrypt_padded_vec<P: Padding<Self::BlockSize>>(&self, msg: &[u8]) -> Vec<u8> {
         let mut out = allocate_out_vec::<Self>(msg.len());
@@ -249,7 +245,6 @@ pub trait BlockDecrypt: BlockSizeUser {
     /// Returns [`UnpadError`] if padding is malformed or if input length is
     /// not multiple of `Self::BlockSize`.
     #[cfg(feature = "block-padding")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "block-padding")))]
     #[inline]
     fn decrypt_padded_inout<'out, P: Padding<Self::BlockSize>>(
         &self,
@@ -268,7 +263,6 @@ pub trait BlockDecrypt: BlockSizeUser {
     /// Returns [`UnpadError`] if padding is malformed or if input length is
     /// not multiple of `Self::BlockSize`.
     #[cfg(feature = "block-padding")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "block-padding")))]
     #[inline]
     fn decrypt_padded<'a, P: Padding<Self::BlockSize>>(
         &self,
@@ -283,7 +277,6 @@ pub trait BlockDecrypt: BlockSizeUser {
     /// Returns [`UnpadError`] if padding is malformed or if input length is
     /// not multiple of `Self::BlockSize`.
     #[cfg(feature = "block-padding")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "block-padding")))]
     #[inline]
     fn decrypt_padded_b2b<'a, P: Padding<Self::BlockSize>>(
         &self,
@@ -305,7 +298,6 @@ pub trait BlockDecrypt: BlockSizeUser {
     /// Returns [`UnpadError`] if padding is malformed or if input length is
     /// not multiple of `Self::BlockSize`.
     #[cfg(all(feature = "block-padding", feature = "alloc"))]
-    #[cfg_attr(docsrs, doc(cfg(all(feature = "block-padding", feature = "alloc"))))]
     #[inline]
     fn decrypt_padded_vec<P: Padding<Self::BlockSize>>(
         &self,
@@ -378,7 +370,6 @@ pub trait BlockEncryptMut: BlockSizeUser + Sized {
     ///
     /// Returns [`PadError`] if length of output buffer is not sufficient.
     #[cfg(feature = "block-padding")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "block-padding")))]
     #[inline]
     fn encrypt_padded_inout_mut<'out, P: Padding<Self::BlockSize>>(
         mut self,
@@ -396,7 +387,6 @@ pub trait BlockEncryptMut: BlockSizeUser + Sized {
     ///
     /// Returns [`PadError`] if length of output buffer is not sufficient.
     #[cfg(feature = "block-padding")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "block-padding")))]
     #[inline]
     fn encrypt_padded_mut<P: Padding<Self::BlockSize>>(
         self,
@@ -411,7 +401,6 @@ pub trait BlockEncryptMut: BlockSizeUser + Sized {
     ///
     /// Returns [`PadError`] if length of output buffer is not sufficient.
     #[cfg(feature = "block-padding")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "block-padding")))]
     #[inline]
     fn encrypt_padded_b2b_mut<'a, P: Padding<Self::BlockSize>>(
         self,
@@ -424,7 +413,6 @@ pub trait BlockEncryptMut: BlockSizeUser + Sized {
 
     /// Pad input and encrypt into a newly allocated Vec. Returns resulting ciphertext Vec.
     #[cfg(all(feature = "block-padding", feature = "alloc"))]
-    #[cfg_attr(docsrs, doc(cfg(all(feature = "block-padding", feature = "alloc"))))]
     #[inline]
     fn encrypt_padded_vec_mut<P: Padding<Self::BlockSize>>(self, msg: &[u8]) -> Vec<u8> {
         let mut out = allocate_out_vec::<Self>(msg.len());
@@ -498,7 +486,6 @@ pub trait BlockDecryptMut: BlockSizeUser + Sized {
     /// Returns [`UnpadError`] if padding is malformed or if input length is
     /// not multiple of `Self::BlockSize`.
     #[cfg(feature = "block-padding")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "block-padding")))]
     #[inline]
     fn decrypt_padded_inout_mut<'out, P: Padding<Self::BlockSize>>(
         mut self,
@@ -517,7 +504,6 @@ pub trait BlockDecryptMut: BlockSizeUser + Sized {
     /// Returns [`UnpadError`] if padding is malformed or if input length is
     /// not multiple of `Self::BlockSize`.
     #[cfg(feature = "block-padding")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "block-padding")))]
     #[inline]
     fn decrypt_padded_mut<P: Padding<Self::BlockSize>>(
         self,
@@ -532,7 +518,6 @@ pub trait BlockDecryptMut: BlockSizeUser + Sized {
     /// Returns [`UnpadError`] if padding is malformed or if input length is
     /// not multiple of `Self::BlockSize`.
     #[cfg(feature = "block-padding")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "block-padding")))]
     #[inline]
     fn decrypt_padded_b2b_mut<'a, P: Padding<Self::BlockSize>>(
         self,
@@ -554,7 +539,6 @@ pub trait BlockDecryptMut: BlockSizeUser + Sized {
     /// Returns [`UnpadError`] if padding is malformed or if input length is
     /// not multiple of `Self::BlockSize`.
     #[cfg(all(feature = "block-padding", feature = "alloc"))]
-    #[cfg_attr(docsrs, doc(cfg(all(feature = "block-padding", feature = "alloc"))))]
     #[inline]
     fn decrypt_padded_vec_mut<P: Padding<Self::BlockSize>>(
         self,

--- a/cipher/src/dev/block.rs
+++ b/cipher/src/dev/block.rs
@@ -4,7 +4,6 @@ pub use blobby;
 
 /// Define block cipher test
 #[macro_export]
-#[cfg_attr(docsrs, doc(cfg(feature = "dev")))]
 macro_rules! block_cipher_test {
     ($name:ident, $test_name:expr, $cipher:ty $(,)?) => {
         #[test]
@@ -99,7 +98,6 @@ macro_rules! block_cipher_test {
 
 /// Define block mode encryption test
 #[macro_export]
-#[cfg_attr(docsrs, doc(cfg(feature = "dev")))]
 macro_rules! block_mode_enc_test {
     ($name:ident, $test_name:expr, $cipher:ty $(,)?) => {
         #[test]
@@ -158,7 +156,6 @@ macro_rules! block_mode_enc_test {
 
 /// Define block mode decryption test
 #[macro_export]
-#[cfg_attr(docsrs, doc(cfg(feature = "dev")))]
 macro_rules! block_mode_dec_test {
     ($name:ident, $test_name:expr, $cipher:ty $(,)?) => {
         #[test]
@@ -217,7 +214,6 @@ macro_rules! block_mode_dec_test {
 
 /// Define `IvState` test
 #[macro_export]
-#[cfg_attr(docsrs, doc(cfg(feature = "dev")))]
 macro_rules! iv_state_test {
     ($name:ident, $cipher:ty, encrypt $(,)?) => {
         $crate::iv_state_test!($name, $cipher, encrypt_blocks_mut);
@@ -266,7 +262,6 @@ macro_rules! iv_state_test {
 
 /// Define block encryptor benchmark
 #[macro_export]
-#[cfg_attr(docsrs, doc(cfg(feature = "dev")))]
 macro_rules! block_encryptor_bench {
     (Key: $cipher:ty, $block_name:ident, $blocks_name:ident $(,)? ) => {
         $crate::block_encryptor_bench!(
@@ -328,7 +323,6 @@ macro_rules! block_encryptor_bench {
 
 /// Define block decryptor benchmark
 #[macro_export]
-#[cfg_attr(docsrs, doc(cfg(feature = "dev")))]
 macro_rules! block_decryptor_bench {
     (Key: $cipher:ty, $block_name:ident, $blocks_name:ident $(,)? ) => {
         $crate::block_decryptor_bench!(

--- a/cipher/src/dev/stream.rs
+++ b/cipher/src/dev/stream.rs
@@ -2,7 +2,6 @@
 
 /// Test core functionality of synchronous stream cipher
 #[macro_export]
-#[cfg_attr(docsrs, doc(cfg(feature = "dev")))]
 macro_rules! stream_cipher_test {
     ($name:ident, $test_name:expr, $cipher:ty $(,)?) => {
         #[test]
@@ -38,7 +37,6 @@ macro_rules! stream_cipher_test {
 
 /// Test stream synchronous stream cipher seeking capabilities
 #[macro_export]
-#[cfg_attr(docsrs, doc(cfg(feature = "dev")))]
 macro_rules! stream_cipher_seek_test {
     ($name:ident, $cipher:ty) => {
         #[test]
@@ -91,7 +89,6 @@ macro_rules! stream_cipher_seek_test {
 
 /// Create stream cipher benchmarks
 #[macro_export]
-#[cfg_attr(docsrs, doc(cfg(feature = "dev")))]
 macro_rules! stream_cipher_bench {
     (
         $cipher:ty;

--- a/cipher/src/errors.rs
+++ b/cipher/src/errors.rs
@@ -18,7 +18,6 @@ impl fmt::Display for StreamCipherError {
 }
 
 #[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl std::error::Error for StreamCipherError {}
 
 /// The error type returned when a cipher position can not be represented
@@ -39,5 +38,4 @@ impl From<OverflowError> for StreamCipherError {
 }
 
 #[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl std::error::Error for OverflowError {}

--- a/cipher/src/lib.rs
+++ b/cipher/src/lib.rs
@@ -6,7 +6,7 @@
 //! [3]: https://en.wikipedia.org/wiki/Stream_cipher
 
 #![no_std]
-#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg"
@@ -23,15 +23,12 @@ extern crate alloc;
 extern crate std;
 
 #[cfg(feature = "rand_core")]
-#[cfg_attr(docsrs, doc(cfg(feature = "rand_core")))]
 pub use crypto_common::rand_core;
 
 #[cfg(feature = "block-padding")]
-#[cfg_attr(docsrs, doc(cfg(feature = "block-padding")))]
 pub use inout::block_padding;
 
 #[cfg(feature = "zeroize")]
-#[cfg_attr(docsrs, doc(cfg(feature = "zeroize")))]
 pub use zeroize;
 
 #[cfg(feature = "dev")]

--- a/crypto-common/src/lib.rs
+++ b/crypto-common/src/lib.rs
@@ -1,7 +1,7 @@
 //! Common cryptographic traits.
 
 #![no_std]
-#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg"
@@ -158,7 +158,6 @@ pub trait KeyInit: KeySizeUser + Sized {
 
     /// Generate random key using the provided [`CryptoRngCore`].
     #[cfg(feature = "rand_core")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "rand_core")))]
     #[inline]
     fn generate_key(mut rng: impl CryptoRngCore) -> Key<Self> {
         let mut key = Key::<Self>::default();
@@ -182,7 +181,6 @@ pub trait KeyIvInit: KeySizeUser + IvSizeUser + Sized {
 
     /// Generate random key using the provided [`CryptoRngCore`].
     #[cfg(feature = "rand_core")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "rand_core")))]
     #[inline]
     fn generate_key(mut rng: impl CryptoRngCore) -> Key<Self> {
         let mut key = Key::<Self>::default();
@@ -192,7 +190,6 @@ pub trait KeyIvInit: KeySizeUser + IvSizeUser + Sized {
 
     /// Generate random IV using the provided [`CryptoRngCore`].
     #[cfg(feature = "rand_core")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "rand_core")))]
     #[inline]
     fn generate_iv(mut rng: impl CryptoRngCore) -> Iv<Self> {
         let mut iv = Iv::<Self>::default();
@@ -202,7 +199,6 @@ pub trait KeyIvInit: KeySizeUser + IvSizeUser + Sized {
 
     /// Generate random key and nonce using the provided [`CryptoRngCore`].
     #[cfg(feature = "rand_core")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "rand_core")))]
     #[inline]
     fn generate_key_iv(mut rng: impl CryptoRngCore) -> (Key<Self>, Iv<Self>) {
         (Self::generate_key(&mut rng), Self::generate_iv(&mut rng))
@@ -234,7 +230,6 @@ pub trait InnerIvInit: InnerUser + IvSizeUser + Sized {
 
     /// Generate random IV using the provided [`CryptoRngCore`].
     #[cfg(feature = "rand_core")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "rand_core")))]
     #[inline]
     fn generate_iv(mut rng: impl CryptoRngCore) -> Iv<Self> {
         let mut iv = Iv::<Self>::default();

--- a/digest/src/core_api/ct_variable.rs
+++ b/digest/src/core_api/ct_variable.rs
@@ -152,7 +152,6 @@ where
 }
 
 #[cfg(feature = "oid")]
-#[cfg_attr(docsrs, doc(cfg(feature = "oid")))]
 impl<T, OutSize, O> AssociatedOid for CtVariableCoreWrapper<T, OutSize, O>
 where
     T: VariableOutputCore,

--- a/digest/src/core_api/rt_variable.rs
+++ b/digest/src/core_api/rt_variable.rs
@@ -48,7 +48,6 @@ where
 impl<T> HashMarker for RtVariableCoreWrapper<T> where T: VariableOutputCore + HashMarker {}
 
 #[cfg(feature = "mac")]
-#[cfg_attr(docsrs, doc(cfg(feature = "mac")))]
 impl<T> MacMarker for RtVariableCoreWrapper<T> where T: VariableOutputCore + MacMarker {}
 
 impl<T> Reset for RtVariableCoreWrapper<T>
@@ -120,7 +119,6 @@ where
 }
 
 #[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl<T> std::io::Write for RtVariableCoreWrapper<T>
 where
     T: VariableOutputCore + UpdateCore,

--- a/digest/src/core_api/wrapper.rs
+++ b/digest/src/core_api/wrapper.rs
@@ -29,7 +29,6 @@ where
 impl<T> HashMarker for CoreWrapper<T> where T: BufferKindUser + HashMarker {}
 
 #[cfg(feature = "mac")]
-#[cfg_attr(docsrs, doc(cfg(feature = "mac")))]
 impl<T> MacMarker for CoreWrapper<T> where T: BufferKindUser + MacMarker {}
 
 // this blanket impl is needed for HMAC
@@ -185,7 +184,6 @@ where
 }
 
 #[cfg(feature = "oid")]
-#[cfg_attr(docsrs, doc(cfg(feature = "oid")))]
 impl<T> AssociatedOid for CoreWrapper<T>
 where
     T: BufferKindUser + AssociatedOid,
@@ -194,7 +192,6 @@ where
 }
 
 #[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl<T> std::io::Write for CoreWrapper<T>
 where
     T: BufferKindUser + UpdateCore,

--- a/digest/src/core_api/xof_reader.rs
+++ b/digest/src/core_api/xof_reader.rs
@@ -37,7 +37,6 @@ where
 }
 
 #[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl<T> std::io::Read for XofReaderCoreWrapper<T>
 where
     T: XofReaderCore,

--- a/digest/src/dev.rs
+++ b/digest/src/dev.rs
@@ -15,7 +15,6 @@ pub use xof::*;
 
 /// Define hash function test
 #[macro_export]
-#[cfg_attr(docsrs, doc(cfg(feature = "dev")))]
 macro_rules! new_test {
     ($name:ident, $test_name:expr, $hasher:ty, $test_func:ident $(,)?) => {
         #[test]
@@ -41,7 +40,6 @@ macro_rules! new_test {
 
 /// Define [`Update`][crate::Update] impl benchmark
 #[macro_export]
-#[cfg_attr(docsrs, doc(cfg(feature = "dev")))]
 macro_rules! bench_update {
     (
         $init:expr;

--- a/digest/src/dev/mac.rs
+++ b/digest/src/dev/mac.rs
@@ -1,7 +1,6 @@
 /// Define MAC test
 #[macro_export]
 #[cfg(feature = "mac")]
-#[cfg_attr(docsrs, doc(cfg(all(feature = "dev", feature = "mac"))))]
 macro_rules! new_mac_test {
     ($name:ident, $test_name:expr, $mac:ty $(,)?) => {
         digest::new_mac_test!($name, $test_name, $mac, "");
@@ -76,7 +75,6 @@ macro_rules! new_mac_test {
 /// Define resettable MAC test
 #[macro_export]
 #[cfg(feature = "mac")]
-#[cfg_attr(docsrs, doc(cfg(all(feature = "dev", feature = "mac"))))]
 macro_rules! new_resettable_mac_test {
     ($name:ident, $test_name:expr, $mac:ty $(,)?) => {
         digest::new_resettable_mac_test!($name, $test_name, $mac, "");

--- a/digest/src/digest.rs
+++ b/digest/src/digest.rs
@@ -137,7 +137,6 @@ pub trait DynDigest {
 
     /// Retrieve result and reset hasher instance
     #[cfg(feature = "alloc")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     fn finalize_reset(&mut self) -> Box<[u8]> {
         let mut result = vec![0; self.output_size()];
         self.finalize_into_reset(&mut result).unwrap();
@@ -146,7 +145,6 @@ pub trait DynDigest {
 
     /// Retrieve result and consume boxed hasher instance
     #[cfg(feature = "alloc")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     #[allow(clippy::boxed_local)]
     fn finalize(mut self: Box<Self>) -> Box<[u8]> {
         let mut result = vec![0; self.output_size()];
@@ -172,7 +170,6 @@ pub trait DynDigest {
 
     /// Clone hasher state into a boxed trait object
     #[cfg(feature = "alloc")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     fn box_clone(&self) -> Box<dyn DynDigest>;
 }
 
@@ -222,7 +219,6 @@ impl<D: Update + FixedOutputReset + Reset + Clone + 'static> DynDigest for D {
 }
 
 #[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 impl Clone for Box<dyn DynDigest> {
     fn clone(&self) -> Self {
         self.box_clone()

--- a/digest/src/lib.rs
+++ b/digest/src/lib.rs
@@ -23,7 +23,7 @@
 //! by hash implementation crates.
 
 #![no_std]
-#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![forbid(unsafe_code)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg",
@@ -39,28 +39,23 @@ extern crate alloc;
 extern crate std;
 
 #[cfg(feature = "rand_core")]
-#[cfg_attr(docsrs, doc(cfg(feature = "rand_core")))]
 pub use crypto_common::rand_core;
 
 #[cfg(feature = "alloc")]
 use alloc::boxed::Box;
 
 #[cfg(feature = "dev")]
-#[cfg_attr(docsrs, doc(cfg(feature = "dev")))]
 pub mod dev;
 
 #[cfg(feature = "core-api")]
-#[cfg_attr(docsrs, doc(cfg(feature = "core-api")))]
 pub mod core_api;
 mod digest;
 #[cfg(feature = "mac")]
 mod mac;
 
 #[cfg(feature = "core-api")]
-#[cfg_attr(docsrs, doc(cfg(feature = "core-api")))]
 pub use block_buffer;
 #[cfg(feature = "oid")]
-#[cfg_attr(docsrs, doc(cfg(feature = "oid")))]
 pub use const_oid;
 pub use crypto_common;
 
@@ -130,7 +125,6 @@ pub trait XofReader {
     /// `Box<[u8]>` is used instead of `Vec<u8>` to save stack space, since
     /// they have size of 2 and 3 words respectively.
     #[cfg(feature = "alloc")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     fn read_boxed(&mut self, n: usize) -> Box<[u8]> {
         let mut buf = vec![0u8; n].into_boxed_slice();
         self.read(&mut buf);
@@ -167,7 +161,6 @@ pub trait ExtendableOutput: Sized + Update {
     /// `Box<[u8]>` is used instead of `Vec<u8>` to save stack space, since
     /// they have size of 2 and 3 words respectively.
     #[cfg(feature = "alloc")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     fn finalize_boxed(self, output_size: usize) -> Box<[u8]> {
         let mut buf = vec![0u8; output_size].into_boxed_slice();
         self.finalize_xof().read(&mut buf);
@@ -191,7 +184,6 @@ pub trait ExtendableOutputReset: ExtendableOutput + Reset {
     /// `Box<[u8]>` is used instead of `Vec<u8>` to save stack space, since
     /// they have size of 2 and 3 words respectively.
     #[cfg(feature = "alloc")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     fn finalize_boxed_reset(&mut self, output_size: usize) -> Box<[u8]> {
         let mut buf = vec![0u8; output_size].into_boxed_slice();
         self.finalize_xof_reset().read(&mut buf);
@@ -240,7 +232,6 @@ pub trait VariableOutput: Sized + Update {
     /// `Box<[u8]>` is used instead of `Vec<u8>` to save stack space, since
     /// they have size of 2 and 3 words respectively.
     #[cfg(feature = "alloc")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     fn finalize_boxed(self) -> Box<[u8]> {
         let n = self.output_size();
         let mut buf = vec![0u8; n].into_boxed_slice();
@@ -263,7 +254,6 @@ pub trait VariableOutputReset: VariableOutput + Reset {
     /// `Box<[u8]>` is used instead of `Vec<u8>` to save stack space, since
     /// they have size of 2 and 3 words respectively.
     #[cfg(feature = "alloc")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     fn finalize_boxed_reset(&mut self) -> Box<[u8]> {
         let n = self.output_size();
         let mut buf = vec![0u8; n].into_boxed_slice();
@@ -284,7 +274,6 @@ impl fmt::Display for InvalidOutputSize {
 }
 
 #[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl std::error::Error for InvalidOutputSize {}
 
 /// Buffer length is not equal to hash output size.

--- a/digest/src/mac.rs
+++ b/digest/src/mac.rs
@@ -6,14 +6,12 @@ use crypto_common::typenum::Unsigned;
 use subtle::{Choice, ConstantTimeEq};
 
 /// Marker trait for Message Authentication algorithms.
-#[cfg_attr(docsrs, doc(cfg(feature = "mac")))]
 pub trait MacMarker {}
 
 /// Convenience wrapper trait covering functionality of Message Authentication algorithms.
 ///
 /// This trait wraps [`Update`], [`FixedOutput`], and [`MacMarker`] traits
 /// and provides additional convenience methods.
-#[cfg_attr(docsrs, doc(cfg(feature = "mac")))]
 pub trait Mac: OutputSizeUser + Sized {
     /// Update state using the provided data.
     fn update(&mut self, data: &[u8]);
@@ -195,7 +193,6 @@ impl<T: Update + FixedOutput + MacMarker> Mac for T {
 ///
 /// It is useful for implementing Message Authentication Codes (MACs).
 #[derive(Clone)]
-#[cfg_attr(docsrs, doc(cfg(feature = "mac")))]
 pub struct CtOutput<T: OutputSizeUser> {
     bytes: Output<T>,
 }
@@ -247,7 +244,6 @@ impl<T: OutputSizeUser> Eq for CtOutput<T> {}
 /// Error type for when the [`Output`] of a [`Mac`]
 /// is not equal to the expected value.
 #[derive(Default, Debug, Copy, Clone, Eq, PartialEq)]
-#[cfg_attr(docsrs, doc(cfg(feature = "mac")))]
 pub struct MacError;
 
 impl fmt::Display for MacError {

--- a/kem/src/lib.rs
+++ b/kem/src/lib.rs
@@ -1,6 +1,6 @@
 #![doc = include_str!("../README.md")]
 #![no_std]
-#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",

--- a/universal-hash/src/lib.rs
+++ b/universal-hash/src/lib.rs
@@ -22,7 +22,7 @@
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg"
 )]
-#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![deny(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]
 
@@ -172,7 +172,6 @@ impl core::fmt::Display for Error {
 }
 
 #[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl std::error::Error for Error {}
 
 /// Split message into slice of blocks and leftover tail.


### PR DESCRIPTION
Migrates the `aead`, `cipher`, `crypto-common`, `digest`, and `universal-hash` crates to use the `doc_auto_cfg` feature which automatically generates documentation for `cfg`-gated code, which in our uses is almost exclusively gated on crate features.

This allows the previous manual `doc_cfg` annotations to be removed, which is nice as they otherwise duplicate work whenever `cfg`-gated code is used.