### PR TITLE
crypto-common: weakly activate `rand_core/getrandom`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -286,6 +286,7 @@ dependencies = [
 name = "crypto-common"
 version = "0.2.0-pre"
 dependencies = [
+ "getrandom",
  "hybrid-array",
  "rand_core 0.6.4",
 ]

--- a/crypto-common/Cargo.toml
+++ b/crypto-common/Cargo.toml
@@ -20,6 +20,7 @@ rand_core = { version = "0.6.4", optional = true }
 getrandom = { version = "0.2", optional = true }
 
 [features]
+getrandom = ["dep:getrandom", "rand_core?/getrandom"]
 std = []
 
 [package.metadata.docs.rs]

--- a/crypto-common/src/lib.rs
+++ b/crypto-common/src/lib.rs
@@ -12,6 +12,8 @@
 #[cfg(feature = "std")]
 extern crate std;
 
+#[cfg(feature = "getrandom")]
+pub use getrandom;
 #[cfg(feature = "rand_core")]
 pub use rand_core;
 


### PR DESCRIPTION
When both `getrandom` and `rand_core` are enabled, activates the `rand_core/getrandom` feature, which makes `OsRng` available as `crypto_common::rand_core::OsRng`.