### PR TITLE
async-signature: re-add 'static bound

### DIFF
--- a/async-signature/src/lib.rs
+++ b/async-signature/src/lib.rs
@@ -19,7 +19,7 @@ use async_trait::async_trait;
 ///
 /// This trait is an async equivalent of the [`signature::Signer`] trait.
 #[async_trait(?Send)]
-pub trait AsyncSigner<S> {
+pub trait AsyncSigner<S: 'static> {
     /// Attempt to sign the given message, returning a digital signature on
     /// success, or an error if something went wrong.
     ///


### PR DESCRIPTION
Accidentally removed in #1375