### PR TITLE
async-signature v0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,7 +56,7 @@ checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
 name = "async-signature"
-version = "0.4.0-pre"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "signature 2.1.0",

--- a/async-signature/CHANGELOG.md
+++ b/async-signature/CHANGELOG.md
@@ -4,7 +4,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.3.0 (2022-01-15)
+## 0.4.0 (2023-11-12)
+### Changed
+- MSRV 1.60 ([#1387])
+
+### Removed
+- Mandatory `Send` + `Sync` bounds ([#1375])
+
+[#1375]: https://github.com/RustCrypto/traits/pull/1375
+[#1387]: https://github.com/RustCrypto/traits/pull/1387
+
+## 0.3.0 (2023-01-15)
 ### Changed
 - Bump `signature` to v2 ([#1141], [#1211])
 

--- a/async-signature/Cargo.toml
+++ b/async-signature/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name          = "async-signature"
 description   = "Traits for cryptographic signature algorithms (e.g. ECDSA, Ed25519)"
-version       = "0.4.0-pre"
+version       = "0.4.0"
 authors       = ["RustCrypto Developers"]
 license       = "Apache-2.0 OR MIT"
 documentation = "https://docs.rs/async-signature"


### PR DESCRIPTION
### Changed
- MSRV 1.60 ([#1387])

### Removed
- Mandatory `Send` + `Sync` bounds ([#1375])

[#1375]: https://github.com/RustCrypto/traits/pull/1375
[#1387]: https://github.com/RustCrypto/traits/pull/1387