### PR TITLE
signature_derive v2.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1178,7 +1178,7 @@ dependencies = [
 
 [[package]]
 name = "signature_derive"
-version = "2.0.1"
+version = "2.1.0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/signature_derive/CHANGELOG.md
+++ b/signature_derive/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.1.0 (2023-11-12)
+### Changed
+- MSRV 1.60 ([#1387])
+
+[#1387]: https://github.com/RustCrypto/traits/pull/1387
+
 ## 2.0.1 (2023-04-17)
 ### Changed
 - Bump `syn` to v2 ([#1299])

--- a/signature_derive/Cargo.toml
+++ b/signature_derive/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name          = "signature_derive"
-version       = "2.0.1"
+version       = "2.1.0"
 authors       = ["RustCrypto Developers"]
 license       = "Apache-2.0 OR MIT"
 description   = "Custom derive support for the 'signature' crate"
 documentation = "https://docs.rs/signature"
-repository    = "https://github.com/RustCrypto/traits/tree/master/signature-derive"
+repository    = "https://github.com/RustCrypto/traits/tree/master/signature_derive"
 readme        = "README.md"
 edition       = "2021"
 rust-version  = "1.60"


### PR DESCRIPTION
### Changed
- MSRV 1.60 ([#1387])

[#1387]: https://github.com/RustCrypto/traits/pull/1387