### PR TITLE
signature v2.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1161,7 +1161,7 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "2.2.0-pre"
+version = "2.2.0"
 dependencies = [
  "digest 0.10.7",
  "hex-literal",

--- a/signature/CHANGELOG.md
+++ b/signature/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.2.0 (2023-11-12)
+### Changed
+- MSRV 1.60 ([#1387])
+
+### Fixed
+- No longer vendoring async/derive crates unintentionally ([#1391]) 
+
+[#1387]: https://github.com/RustCrypto/traits/pull/1387
+[#1391]: https://github.com/RustCrypto/traits/pull/1391
+
 ## 2.1.0 (2023-04-01)
 ### Added
 - `SignatureEncoding::encoded_len` ([#1283])

--- a/signature/Cargo.toml
+++ b/signature/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name          = "signature"
 description   = "Traits for cryptographic signature algorithms (e.g. ECDSA, Ed25519)"
-version       = "2.2.0-pre"
+version       = "2.2.0"
 authors       = ["RustCrypto Developers"]
 license       = "Apache-2.0 OR MIT"
 documentation = "https://docs.rs/signature"


### PR DESCRIPTION
### Changed
- MSRV 1.60 ([#1387])

### Fixed
- No longer vendoring async/derive crates unintentionally ([#1391]) 

[#1387]: https://github.com/RustCrypto/traits/pull/1387
[#1391]: https://github.com/RustCrypto/traits/pull/1391