### PR TITLE
elliptic-curve: remove references from batch generic params

### DIFF
--- a/elliptic-curve/src/arithmetic.rs
+++ b/elliptic-curve/src/arithmetic.rs
@@ -86,12 +86,12 @@ pub trait PrimeCurveArithmetic:
 }
 
 /// Normalize point(s) in projective representation by converting them to their affine ones.
-pub trait BatchNormalize<Points>: group::Curve {
+pub trait BatchNormalize<Points: ?Sized>: group::Curve {
     /// The output of the batch normalization; a container of affine points.
     type Output: AsRef<[Self::AffineRepr]>;
 
     /// Perform a batched conversion to affine representation on a sequence of projective points
     /// at an amortized cost that should be practically as efficient as a single conversion.
     /// Internally, implementors should rely upon `InvertBatch`.
-    fn batch_normalize(points: Points) -> <Self as BatchNormalize<Points>>::Output;
+    fn batch_normalize(points: &Points) -> <Self as BatchNormalize<Points>>::Output;
 }

--- a/elliptic-curve/src/ops.rs
+++ b/elliptic-curve/src/ops.rs
@@ -31,15 +31,16 @@ pub trait Invert {
 
 /// Perform a batched inversion on a sequence of field elements (i.e. base field elements or scalars)
 /// at an amortized cost that should be practically as efficient as a single inversion.
-pub trait BatchInvert<FieldElements>: Invert {
+pub trait BatchInvert<FieldElements: ?Sized>: Invert {
     /// The output of batch inversion. A container of field elements.
     type Output;
 
     /// Invert a batch of field elements.
-    fn batch_invert(field_elements: FieldElements) -> <Self as BatchInvert<FieldElements>>::Output;
+    fn batch_invert(field_elements: &FieldElements)
+        -> <Self as BatchInvert<FieldElements>>::Output;
 }
 
-impl<const N: usize, T> BatchInvert<&[T; N]> for T
+impl<const N: usize, T> BatchInvert<[T; N]> for T
 where
     T: Invert<Output = CtOption<Self>>
         + Mul<Self, Output = Self>
@@ -49,7 +50,7 @@ where
 {
     type Output = CtOption<[Self; N]>;
 
-    fn batch_invert(field_elements: &[Self; N]) -> <Self as BatchInvert<&[T; N]>>::Output {
+    fn batch_invert(field_elements: &[Self; N]) -> <Self as BatchInvert<[T; N]>>::Output {
         let mut field_elements_multiples = [Self::default(); N];
         let mut field_elements_multiples_inverses = [Self::default(); N];
         let mut field_elements_inverses = [Self::default(); N];
@@ -66,7 +67,7 @@ where
 }
 
 #[cfg(feature = "alloc")]
-impl<T> BatchInvert<&[T]> for T
+impl<T> BatchInvert<[T]> for T
 where
     T: Invert<Output = CtOption<Self>>
         + Mul<Self, Output = Self>
@@ -76,7 +77,7 @@ where
 {
     type Output = CtOption<Vec<Self>>;
 
-    fn batch_invert(field_elements: &[Self]) -> <Self as BatchInvert<&[T]>>::Output {
+    fn batch_invert(field_elements: &[Self]) -> <Self as BatchInvert<[T]>>::Output {
         let mut field_elements_multiples: Vec<Self> = vec![Self::default(); field_elements.len()];
         let mut field_elements_multiples_inverses: Vec<Self> =
             vec![Self::default(); field_elements.len()];

--- a/elliptic-curve/src/ops.rs
+++ b/elliptic-curve/src/ops.rs
@@ -31,13 +31,14 @@ pub trait Invert {
 
 /// Perform a batched inversion on a sequence of field elements (i.e. base field elements or scalars)
 /// at an amortized cost that should be practically as efficient as a single inversion.
-pub trait BatchInvert<FieldElements: ?Sized>: Invert {
+pub trait BatchInvert<FieldElements: ?Sized>: Invert + Sized {
     /// The output of batch inversion. A container of field elements.
-    type Output;
+    type Output: AsRef<[Self]>;
 
     /// Invert a batch of field elements.
-    fn batch_invert(field_elements: &FieldElements)
-        -> <Self as BatchInvert<FieldElements>>::Output;
+    fn batch_invert(
+        field_elements: &FieldElements,
+    ) -> CtOption<<Self as BatchInvert<FieldElements>>::Output>;
 }
 
 impl<const N: usize, T> BatchInvert<[T; N]> for T
@@ -48,9 +49,9 @@ where
         + Default
         + ConditionallySelectable,
 {
-    type Output = CtOption<[Self; N]>;
+    type Output = [Self; N];
 
-    fn batch_invert(field_elements: &[Self; N]) -> <Self as BatchInvert<[T; N]>>::Output {
+    fn batch_invert(field_elements: &[Self; N]) -> CtOption<[Self; N]> {
         let mut field_elements_multiples = [Self::default(); N];
         let mut field_elements_multiples_inverses = [Self::default(); N];
         let mut field_elements_inverses = [Self::default(); N];
@@ -75,9 +76,9 @@ where
         + Default
         + ConditionallySelectable,
 {
-    type Output = CtOption<Vec<Self>>;
+    type Output = Vec<Self>;
 
-    fn batch_invert(field_elements: &[Self]) -> <Self as BatchInvert<[T]>>::Output {
+    fn batch_invert(field_elements: &[Self]) -> CtOption<Vec<Self>> {
         let mut field_elements_multiples: Vec<Self> = vec![Self::default(); field_elements.len()];
         let mut field_elements_multiples_inverses: Vec<Self> =
             vec![Self::default(); field_elements.len()];


### PR DESCRIPTION
Previously the traits were generic around a reference type. The problem with that is reference types have lifetimes, which requires notating them in generic code, in this case requiring an HRTB per generic parameter.

HRTBs work because the output has no lifetime dependencies on the input, but if that's the case we can just explicitly borrow in the function signature in trait, which means no HRTB is needed in generic code, which makes notating the trait bounds significantly simpler.