### PR TITLE
elliptic-curve: move `BatchNormalize` trait under `point`

### DIFF
--- a/elliptic-curve/src/arithmetic.rs
+++ b/elliptic-curve/src/arithmetic.rs
@@ -84,14 +84,3 @@ pub trait PrimeCurveArithmetic:
     /// Prime order elliptic curve group.
     type CurveGroup: group::prime::PrimeCurve<Affine = <Self as CurveArithmetic>::AffinePoint>;
 }
-
-/// Normalize point(s) in projective representation by converting them to their affine ones.
-pub trait BatchNormalize<Points: ?Sized>: group::Curve {
-    /// The output of the batch normalization; a container of affine points.
-    type Output: AsRef<[Self::AffineRepr]>;
-
-    /// Perform a batched conversion to affine representation on a sequence of projective points
-    /// at an amortized cost that should be practically as efficient as a single conversion.
-    /// Internally, implementors should rely upon `InvertBatch`.
-    fn batch_normalize(points: &Points) -> <Self as BatchNormalize<Points>>::Output;
-}

--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -127,8 +127,8 @@ pub use zeroize;
 #[cfg(feature = "arithmetic")]
 pub use {
     crate::{
-        arithmetic::{BatchNormalize, CurveArithmetic, PrimeCurveArithmetic},
-        point::{AffinePoint, ProjectivePoint},
+        arithmetic::{CurveArithmetic, PrimeCurveArithmetic},
+        point::{AffinePoint, BatchNormalize, ProjectivePoint},
         public_key::PublicKey,
         scalar::{NonZeroScalar, Scalar},
     },

--- a/elliptic-curve/src/point.rs
+++ b/elliptic-curve/src/point.rs
@@ -32,6 +32,18 @@ pub trait AffineCoordinates {
     fn y_is_odd(&self) -> Choice;
 }
 
+/// Normalize point(s) in projective representation by converting them to their affine ones.
+#[cfg(feature = "arithmetic")]
+pub trait BatchNormalize<Points: ?Sized>: group::Curve {
+    /// The output of the batch normalization; a container of affine points.
+    type Output: AsRef<[Self::AffineRepr]>;
+
+    /// Perform a batched conversion to affine representation on a sequence of projective points
+    /// at an amortized cost that should be practically as efficient as a single conversion.
+    /// Internally, implementors should rely upon `InvertBatch`.
+    fn batch_normalize(points: &Points) -> <Self as BatchNormalize<Points>>::Output;
+}
+
 /// Double a point (i.e. add it to itself)
 pub trait Double {
     /// Double this point.


### PR DESCRIPTION
Since it's functionality related to elliptic curve points, put it under the corresponding module.