### PR TITLE
Fix `missing_debug_implementations` for some crates

### DIFF
--- a/async-signature/src/lib.rs
+++ b/async-signature/src/lib.rs
@@ -5,7 +5,12 @@
 )]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![forbid(unsafe_code)]
-#![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
+#![warn(
+    missing_docs,
+    rust_2018_idioms,
+    unused_qualifications,
+    missing_debug_implementations
+)]
 
 pub use signature::{self, Error};
 

--- a/cipher/src/lib.rs
+++ b/cipher/src/lib.rs
@@ -11,7 +11,12 @@
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg"
 )]
-#![warn(missing_docs, rust_2018_idioms, unused_lifetimes)]
+#![warn(
+    missing_docs,
+    rust_2018_idioms,
+    unused_lifetimes,
+    missing_debug_implementations
+)]
 
 pub use crypto_common;
 pub use inout;

--- a/crypto-common/src/lib.rs
+++ b/crypto-common/src/lib.rs
@@ -7,7 +7,7 @@
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg"
 )]
 #![forbid(unsafe_code)]
-#![warn(missing_docs, rust_2018_idioms)]
+#![warn(missing_docs, rust_2018_idioms, missing_debug_implementations)]
 
 #[cfg(feature = "std")]
 extern crate std;

--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -6,7 +6,7 @@
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg"
 )]
 #![forbid(unsafe_code)]
-#![warn(rust_2018_idioms)]
+#![warn(rust_2018_idioms, missing_debug_implementations)]
 
 pub use crypto_common as common;
 

--- a/digest/src/core_api/ct_variable.rs
+++ b/digest/src/core_api/ct_variable.rs
@@ -162,6 +162,17 @@ where
     const OID: ObjectIdentifier = O::OID;
 }
 
+impl<T, OutSize, O> fmt::Debug for CtVariableCoreWrapper<T, OutSize, O>
+where
+    T: VariableOutputCore + AlgorithmName,
+    OutSize: ArraySize + IsLessOrEqual<T::OutputSize>,
+    LeEq<OutSize, T::OutputSize>: NonZero,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        Self::write_alg_name(f)
+    }
+}
+
 /// Implement dummy type with hidden docs which is used to "carry" hasher
 /// OID for [`CtVariableCoreWrapper`].
 #[macro_export]

--- a/digest/src/lib.rs
+++ b/digest/src/lib.rs
@@ -29,7 +29,7 @@
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg"
 )]
-#![warn(missing_docs, rust_2018_idioms)]
+#![warn(missing_docs, rust_2018_idioms, missing_debug_implementations)]
 
 #[cfg(feature = "alloc")]
 #[macro_use]

--- a/digest/src/mac.rs
+++ b/digest/src/mac.rs
@@ -241,6 +241,12 @@ impl<T: OutputSizeUser> PartialEq for CtOutput<T> {
 
 impl<T: OutputSizeUser> Eq for CtOutput<T> {}
 
+impl<T: OutputSizeUser> fmt::Debug for CtOutput<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("CtOutput { ... }")
+    }
+}
+
 /// Error type for when the [`Output`] of a [`Mac`]
 /// is not equal to the expected value.
 #[derive(Default, Debug, Copy, Clone, Eq, PartialEq)]

--- a/kem/src/kem.rs
+++ b/kem/src/kem.rs
@@ -2,7 +2,7 @@
 
 use crate::errors::Error;
 
-use core::fmt::Debug;
+use core::fmt;
 
 use generic_array::{ArrayLength, GenericArray};
 use rand_core::{CryptoRng, RngCore};
@@ -10,7 +10,7 @@ use zeroize::{Zeroize, ZeroizeOnDrop};
 
 /// Trait impl'd by concrete types that represent an encapsulated key. This is intended to be, in
 /// essence, a bag of bytes.
-pub trait EncappedKey: AsRef<[u8]> + Debug + Sized {
+pub trait EncappedKey: AsRef<[u8]> + fmt::Debug + Sized {
     /// The size, in bytes, of an encapsulated key.
     type EncappedKeySize: ArrayLength<u8>;
 
@@ -37,6 +37,12 @@ pub trait EncappedKey: AsRef<[u8]> + Debug + Sized {
 
 /// The shared secret that results from key exchange.
 pub struct SharedSecret<EK: EncappedKey>(GenericArray<u8, EK::SharedSecretSize>);
+
+impl<EK: EncappedKey> fmt::Debug for SharedSecret<EK> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("SharedSecret { ... }")
+    }
+}
 
 // Zero the secret on drop
 impl<EK: EncappedKey> Drop for SharedSecret<EK> {

--- a/kem/src/lib.rs
+++ b/kem/src/lib.rs
@@ -7,7 +7,7 @@
     html_root_url = "https://docs.rs/kem"
 )]
 #![forbid(unsafe_code)]
-#![warn(missing_docs, unused_qualifications)]
+#![warn(missing_docs, unused_qualifications, missing_debug_implementations)]
 
 #[cfg(feature = "std")]
 extern crate std;

--- a/password-hash/src/lib.rs
+++ b/password-hash/src/lib.rs
@@ -6,7 +6,12 @@
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg"
 )]
 #![forbid(unsafe_code)]
-#![warn(missing_docs, rust_2018_idioms, unused_lifetimes)]
+#![warn(
+    missing_docs,
+    rust_2018_idioms,
+    unused_lifetimes,
+    missing_debug_implementations
+)]
 
 //!
 //! # Usage

--- a/password-hash/src/params.rs
+++ b/password-hash/src/params.rs
@@ -239,6 +239,7 @@ impl fmt::Debug for ParamsString {
 }
 
 /// Iterator over algorithm parameters stored in a [`ParamsString`] struct.
+#[derive(Debug)]
 pub struct Iter<'a> {
     inner: Option<str::Split<'a, char>>,
 }

--- a/signature/src/lib.rs
+++ b/signature/src/lib.rs
@@ -12,6 +12,7 @@
     missing_docs,
     rust_2018_idioms,
     unused_lifetimes,
+    missing_debug_implementations,
     unused_qualifications
 )]
 

--- a/signature_derive/src/lib.rs
+++ b/signature_derive/src/lib.rs
@@ -6,6 +6,7 @@
     rust_2018_idioms,
     trivial_casts,
     unused_import_braces,
+    missing_debug_implementations,
     unused_qualifications
 )]
 

--- a/universal-hash/src/lib.rs
+++ b/universal-hash/src/lib.rs
@@ -6,7 +6,7 @@
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg"
 )]
 #![forbid(unsafe_code)]
-#![warn(missing_docs, rust_2018_idioms)]
+#![warn(missing_docs, rust_2018_idioms, missing_debug_implementations)]
 
 #[cfg(feature = "std")]
 extern crate std;


### PR DESCRIPTION
Relevant issue: #1389