### PR TITLE
elliptic-curve v0.13.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -262,7 +262,7 @@ dependencies = [
  "cipher 0.4.4",
  "crypto-common 0.1.6",
  "digest 0.10.7",
- "elliptic-curve 0.13.6",
+ "elliptic-curve 0.13.7",
  "password-hash",
  "signature 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "universal-hash 0.5.1",
@@ -472,7 +472,7 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.13.6"
+version = "0.13.7"
 dependencies = [
  "base16ct 0.2.0",
  "base64ct",

--- a/elliptic-curve/CHANGELOG.md
+++ b/elliptic-curve/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.13.7 (2023-11-15)
+### Added
+- `BatchInvert` and `BatchNormalize` traits ([#1376])
+- `LinearCombinationExt` trait ([#1405])
+
+[#1376]: https://github.com/RustCrypto/traits/pull/1376
+[#1405]: https://github.com/RustCrypto/traits/pull/1405
+
 ## 0.13.6 (2023-10-02)
 ### Fixed
 - Minimum supported `hkdf` version is v0.12.1 ([#1353])

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elliptic-curve"
-version = "0.13.6"
+version = "0.13.7"
 description = """
 General purpose Elliptic Curve Cryptography (ECC) support, including types
 and traits for representing various elliptic curve forms, scalars, points,


### PR DESCRIPTION
### Added
- `BatchInvert` and `BatchNormalize` traits ([#1376])
- `LinearCombinationExt` trait ([#1405])

[#1376]: https://github.com/RustCrypto/traits/pull/1376
[#1405]: https://github.com/RustCrypto/traits/pull/1405