### PR TITLE
aead: enable `missing_debug_implementations` lint and add `Debug` impls

### DIFF
--- a/aead/src/lib.rs
+++ b/aead/src/lib.rs
@@ -6,7 +6,12 @@
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg"
 )]
 #![forbid(unsafe_code)]
-#![warn(clippy::unwrap_used, missing_docs, rust_2018_idioms)]
+#![warn(
+    clippy::unwrap_used,
+    missing_docs,
+    rust_2018_idioms,
+    missing_debug_implementations
+)]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;
@@ -472,6 +477,7 @@ impl<Alg: AeadInPlace> AeadMutInPlace for Alg {
 /// If you don't care about AAD, you can pass a `&[u8]` as the payload to
 /// `encrypt`/`decrypt` and it will automatically be coerced to this type.
 #[cfg(feature = "alloc")]
+#[derive(Debug)]
 pub struct Payload<'msg, 'aad> {
     /// Message to be encrypted/decrypted
     pub msg: &'msg [u8],

--- a/aead/src/stream.rs
+++ b/aead/src/stream.rs
@@ -199,6 +199,7 @@ macro_rules! impl_stream_object {
         #[doc = "[Online Authenticated-Encryption and its Nonce-Reuse Misuse-Resistance][1]."]
         #[doc = ""]
         #[doc = "[1]: https://eprint.iacr.org/2015/189.pdf"]
+        #[derive(Debug)]
         pub struct $name<A, S>
         where
             A: AeadInPlace,
@@ -361,6 +362,7 @@ impl_stream_object!(
 /// the last 5-bytes of the AEAD nonce.
 ///
 /// [1]: https://eprint.iacr.org/2015/189.pdf
+#[derive(Debug)]
 pub struct StreamBE32<A>
 where
     A: AeadInPlace,
@@ -450,6 +452,7 @@ where
 /// when interpreted as a 32-bit integer.
 ///
 /// The 31-bit + 1-bit value is stored as the last 4 bytes of the AEAD nonce.
+#[derive(Debug)]
 pub struct StreamLE31<A>
 where
     A: AeadInPlace,


### PR DESCRIPTION
The `Payload` fields may be considered secret, but they are public in the first place. Plus, usually it's used as a temporary value, so risk of unintentionally exposing sensitive data through it is quite low. IIUC nonce and position fields in the stream constructions are not considered secret, so we can expose them in `Debug`, while AEAD internals will be protected by its own `Debug` impl (if it exists).

Relevant issue: #1389