### PR TITLE
elliptic-curve: `SecretKey::from_slice` allows >=24-bytes

### DIFF
--- a/elliptic-curve/src/secret_key.rs
+++ b/elliptic-curve/src/secret_key.rs
@@ -12,7 +12,7 @@ use crate::{Curve, Error, FieldBytes, Result, ScalarPrimitive};
 use core::fmt::{self, Debug};
 use generic_array::typenum::Unsigned;
 use subtle::{Choice, ConstantTimeEq};
-use zeroize::{Zeroize, ZeroizeOnDrop};
+use zeroize::{Zeroize, ZeroizeOnDrop, Zeroizing};
 
 #[cfg(feature = "arithmetic")]
 use crate::{rand_core::CryptoRngCore, CurveArithmetic, NonZeroScalar, PublicKey};
@@ -40,7 +40,6 @@ use {
     },
     alloc::vec::Vec,
     sec1::der::Encode,
-    zeroize::Zeroizing,
 };
 
 #[cfg(all(feature = "arithmetic", any(feature = "jwk", feature = "pem")))]
@@ -85,6 +84,11 @@ impl<C> SecretKey<C>
 where
     C: Curve,
 {
+    /// Minimum allowed size of an elliptic curve secret key in bytes.
+    ///
+    /// This provides the equivalent of 96-bits of symmetric security.
+    const MIN_SIZE: usize = 24;
+
     /// Generate a random [`SecretKey`].
     #[cfg(feature = "arithmetic")]
     pub fn random(rng: &mut impl CryptoRngCore) -> Self
@@ -148,31 +152,20 @@ where
         Ok(Self { inner })
     }
 
-    /// Deserialize secret key from an encoded secret scalar passed as a
-    /// byte slice.
+    /// Deserialize secret key from an encoded secret scalar passed as a byte slice.
     ///
-    /// The slice is expected to be at most `C::FieldBytesSize` bytes in
-    /// length but may be up to 4-bytes shorter than that, which is handled by
-    /// zero-padding the value.
+    /// The slice is expected to be a minimum of 24-bytes (192-byts) and at most `C::FieldBytesSize`
+    /// bytes in length.
+    ///
+    /// Byte slices shorter than the field size are handled by zero padding the input.
     pub fn from_slice(slice: &[u8]) -> Result<Self> {
-        if slice.len() > C::FieldBytesSize::USIZE {
-            return Err(Error);
-        }
-
-        /// Maximum number of "missing" bytes to interpret as zeroes.
-        const MAX_LEADING_ZEROES: usize = 4;
-
-        let offset = C::FieldBytesSize::USIZE.saturating_sub(slice.len());
-
-        if offset == 0 {
+        if slice.len() == C::FieldBytesSize::USIZE {
             Self::from_bytes(FieldBytes::<C>::from_slice(slice))
-        } else if offset <= MAX_LEADING_ZEROES {
-            let mut bytes = FieldBytes::<C>::default();
+        } else if (Self::MIN_SIZE..C::FieldBytesSize::USIZE).contains(&slice.len()) {
+            let mut bytes = Zeroizing::new(FieldBytes::<C>::default());
+            let offset = C::FieldBytesSize::USIZE.saturating_sub(slice.len());
             bytes[offset..].copy_from_slice(slice);
-
-            let ret = Self::from_bytes(&bytes);
-            bytes.zeroize();
-            ret
+            Self::from_bytes(&bytes)
         } else {
             Err(Error)
         }

--- a/elliptic-curve/tests/secret_key.rs
+++ b/elliptic-curve/tests/secret_key.rs
@@ -5,7 +5,7 @@
 use elliptic_curve::dev::SecretKey;
 
 #[test]
-fn from_slice_undersize() {
+fn from_empty_slice() {
     assert!(SecretKey::from_slice(&[]).is_err());
 }
 
@@ -17,12 +17,12 @@ fn from_slice_expected_size() {
 
 #[test]
 fn from_slice_allowed_short() {
-    let bytes = [1u8; 28];
+    let bytes = [1u8; 24];
     assert!(SecretKey::from_slice(&bytes).is_ok());
 }
 
 #[test]
 fn from_slice_too_short() {
-    let bytes = [1u8; 27];
+    let bytes = [1u8; 23]; // min 24-bytes
     assert!(SecretKey::from_slice(&bytes).is_err());
 }


### PR DESCRIPTION
To address the concerns in #1330, sets a global minimum elliptic curve key size of 24-bytes (192-bits), which provides the equivalent of 96-bit symmetric security.