### PR TITLE
async-signature: move to AFIT

### DIFF
--- a/.github/workflows/async-signature.yml
+++ b/.github/workflows/async-signature.yml
@@ -23,8 +23,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.60.0 # MSRV
-          - stable
+          - beta
     steps:
       - uses: actions/checkout@v4
       - uses: RustCrypto/actions/cargo-cache@master

--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: RustCrypto/actions/cargo-cache@master
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.73.0
+          toolchain: beta
           components: clippy
       - run: cargo clippy --all --all-features --tests -- -D warnings
 
@@ -36,6 +36,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: stable
+          toolchain: beta
           components: rustfmt
       - run: cargo fmt --all -- --check

--- a/async-signature/Cargo.toml
+++ b/async-signature/Cargo.toml
@@ -18,6 +18,7 @@ signature = ">= 2.0, <2.3"
 
 [features]
 digest = ["signature/digest"]
+rand_core = ["signature/rand_core"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/async-signature/Cargo.toml
+++ b/async-signature/Cargo.toml
@@ -10,7 +10,7 @@ readme        = "README.md"
 keywords      = ["crypto", "ecdsa", "ed25519", "signature", "signing"]
 categories    = ["cryptography", "no-std"]
 edition       = "2021"
-rust-version  = "1.60"
+rust-version  = "1.75"
 
 [dependencies]
 async-trait = "0.1.9"

--- a/async-signature/src/lib.rs
+++ b/async-signature/src/lib.rs
@@ -17,13 +17,12 @@ pub use signature::{self, Error};
 #[cfg(feature = "digest")]
 pub use signature::digest::{self, Digest};
 
-use async_trait::async_trait;
 
 /// Asynchronously sign the provided message bytestring using `Self`
 /// (e.g. client for a Cloud KMS or HSM), returning a digital signature.
 ///
 /// This trait is an async equivalent of the [`signature::Signer`] trait.
-#[async_trait(?Send)]
+#[allow(async_fn_in_trait)]
 pub trait AsyncSigner<S: 'static> {
     /// Attempt to sign the given message, returning a digital signature on
     /// success, or an error if something went wrong.
@@ -33,7 +32,6 @@ pub trait AsyncSigner<S: 'static> {
     async fn sign_async(&self, msg: &[u8]) -> Result<S, Error>;
 }
 
-#[async_trait(?Send)]
 impl<S, T> AsyncSigner<S> for T
 where
     S: 'static,
@@ -48,7 +46,7 @@ where
 ///
 /// This trait is an async equivalent of the [`signature::DigestSigner`] trait.
 #[cfg(feature = "digest")]
-#[async_trait(?Send)]
+#[allow(async_fn_in_trait)]
 pub trait AsyncDigestSigner<D, S>
 where
     D: Digest + 'static,
@@ -60,7 +58,6 @@ where
 }
 
 #[cfg(feature = "digest")]
-#[async_trait(?Send)]
 impl<D, S, T> AsyncDigestSigner<D, S> for T
 where
     D: Digest + 'static,


### PR DESCRIPTION
`AFIT` is expected in the upcoming rust-1.75 release (scheduled for 2023/12/28).

`#[allow(async_fn_in_trait)]` is required until a solution to RPITIT is merged in rust.
This put responsability on the implementor of `async_signature::AsyncSigner` to make sure their future is `Send`able.
see https://github.com/rust-lang/rust/pull/115822#issuecomment-1731149475 for more context.