### PR TITLE
Fix regressions introduced in #1388

### DIFF
--- a/cipher/src/stream_wrapper.rs
+++ b/cipher/src/stream_wrapper.rs
@@ -157,7 +157,7 @@ impl<T: StreamCipherCore> StreamCipher for StreamCipherCoreWrapper<T> {
             // but after XORing keystream block with `tail`, we immediately
             // overwrite the first byte with a correct value.
             self.core.write_keystream_block(&mut self.buffer);
-            tail.xor_in2out(&self.buffer[..data_len]);
+            tail.xor_in2out(&self.buffer[..tail.len()]);
             tail.len()
         };
 
@@ -219,9 +219,11 @@ impl<T: IvSizeUser + StreamCipherCore> IvSizeUser for StreamCipherCoreWrapper<T>
 impl<T: KeyIvInit + StreamCipherCore> KeyIvInit for StreamCipherCoreWrapper<T> {
     #[inline]
     fn new(key: &Key<Self>, iv: &Iv<Self>) -> Self {
+        let mut buffer = Default::default();
+        buffer[0] = T::BlockSize::U8;
         Self {
             core: T::new(key, iv),
-            buffer: Default::default(),
+            buffer,
         }
     }
 }
@@ -229,9 +231,11 @@ impl<T: KeyIvInit + StreamCipherCore> KeyIvInit for StreamCipherCoreWrapper<T> {
 impl<T: KeyInit + StreamCipherCore> KeyInit for StreamCipherCoreWrapper<T> {
     #[inline]
     fn new(key: &Key<Self>) -> Self {
+        let mut buffer = Default::default();
+        buffer[0] = T::BlockSize::U8
         Self {
             core: T::new(key),
-            buffer: Default::default(),
+            buffer,
         }
     }
 }

--- a/cipher/src/stream_wrapper.rs
+++ b/cipher/src/stream_wrapper.rs
@@ -219,7 +219,7 @@ impl<T: IvSizeUser + StreamCipherCore> IvSizeUser for StreamCipherCoreWrapper<T>
 impl<T: KeyIvInit + StreamCipherCore> KeyIvInit for StreamCipherCoreWrapper<T> {
     #[inline]
     fn new(key: &Key<Self>, iv: &Iv<Self>) -> Self {
-        let mut buffer = Default::default();
+        let mut buffer = Block::<T>::default();
         buffer[0] = T::BlockSize::U8;
         Self {
             core: T::new(key, iv),
@@ -231,7 +231,7 @@ impl<T: KeyIvInit + StreamCipherCore> KeyIvInit for StreamCipherCoreWrapper<T> {
 impl<T: KeyInit + StreamCipherCore> KeyInit for StreamCipherCoreWrapper<T> {
     #[inline]
     fn new(key: &Key<Self>) -> Self {
-        let mut buffer = Default::default();
+        let mut buffer = Block::<T>::default();
         buffer[0] = T::BlockSize::U8;
         Self {
             core: T::new(key),

--- a/cipher/src/stream_wrapper.rs
+++ b/cipher/src/stream_wrapper.rs
@@ -232,7 +232,7 @@ impl<T: KeyInit + StreamCipherCore> KeyInit for StreamCipherCoreWrapper<T> {
     #[inline]
     fn new(key: &Key<Self>) -> Self {
         let mut buffer = Default::default();
-        buffer[0] = T::BlockSize::U8
+        buffer[0] = T::BlockSize::U8;
         Self {
             core: T::new(key),
             buffer,


### PR DESCRIPTION
When `StreamCipherCoreWrapper` is instantiated via `KeyIvInit::new` or `KeyInit::new`, the first byte of the buffer remains zero. This makes the initial call to `StreamCipherCoreWrapper::get_pos` result in undefined behaviour in release builds.

Additionally, the wrong length is used to index into the buffer when XORing with the tail end of the stream after blocks are processed.

I am performing this commit on a mobile device using the web interface, so I might have missed things. These two issues immediately jumped at me while casually browsing the code.

I see no open issue regarding this and no other PRs attempting to fix this, so I'm just doing this hasty fix. If there is a more fundamental issue at play here that I am not seeing, feel free to suggest/open a fix that supersedes this.

Also, if I'm way off base here, I apologise and you may close this PR, because I'm making this change solely after a glance through the source without performing any testing.

Since this change hasn't rolled out publicly and isn't in use by any crates in RustCrypto/stream-ciphers, I am thinking this doesn't constitute a security vulnerability and directly submitting a patch is OK.

Cheers.