### PR TITLE
Cargo.lock: bump dependencies

### DIFF
--- a/.github/workflows/kem.yml
+++ b/.github/workflows/kem.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.61.0 # Next MSRV candidate
+          - 1.66.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -36,26 +36,12 @@ jobs:
           targets: ${{ matrix.target }}
       - run: cargo build --no-default-features --release --target ${{ matrix.target }}
 
-  # TODO: use the reusable workflow after this crate will be part of the
-  # toot workspace
-  # minimal-versions:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - uses: RustCrypto/actions/cargo-cache@master
-  #     - uses: dtolnay/rust-toolchain@master
-  #       with:
-  #         toolchain: nightly
-  #     - uses: RustCrypto/actions/cargo-hack-install@master
-  #     - run: cargo update -Z minimal-versions
-  #     - run: cargo hack test --release --feature-powerset
-
   test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         rust:
-          - 1.61.0 # Next MSRV candidate
+          - 1.66.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v4
@@ -67,15 +53,3 @@ jobs:
       - run: cargo test --no-default-features --release
       - run: cargo test --release
       - run: cargo test --all-features --release
-
-  # build-only test of MSRV
-  # TODO: remove on MSRV bump higher than MSRV of `cc`
-  test-msrv:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: RustCrypto/actions/cargo-cache@master
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: 1.60.0
-      - run: cargo check --all-features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,9 +64,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.74"
+version = "0.1.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a66537f1bb974b254c98ed142ff995236e81b9d0fe4db0575f46612cb15eb0f9"
+checksum = "fdf6721fb0140e4f897002dd086c06f6c27775df19cfe1fccb21181a48fd2c98"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -139,7 +139,7 @@ dependencies = [
 [[package]]
 name = "block-buffer"
 version = "0.11.0-pre"
-source = "git+https://github.com/RustCrypto/utils.git#708aa72b9ebde06a02e862368e890fb3ddcb2fb9"
+source = "git+https://github.com/RustCrypto/utils.git#cc772039c62a0a2f4761b28df796d8b2dbda12e6"
 dependencies = [
  "crypto-common 0.2.0-pre",
 ]
@@ -156,16 +156,16 @@ dependencies = [
 [[package]]
 name = "block-padding"
 version = "0.4.0-pre"
-source = "git+https://github.com/RustCrypto/utils.git#708aa72b9ebde06a02e862368e890fb3ddcb2fb9"
+source = "git+https://github.com/RustCrypto/utils.git#cc772039c62a0a2f4761b28df796d8b2dbda12e6"
 dependencies = [
  "hybrid-array",
 ]
 
 [[package]]
 name = "byteorder"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -175,10 +175,11 @@ checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
 
 [[package]]
 name = "cc"
-version = "1.0.84"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f8e7c90afad890484a21653d08b6e209ae34770fb5ee298f9c699fcc1e5c856"
+checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
 dependencies = [
+ "jobserver",
  "libc",
 ]
 
@@ -692,7 +693,7 @@ dependencies = [
 [[package]]
 name = "hybrid-array"
 version = "0.2.0-pre.5"
-source = "git+https://github.com/RustCrypto/utils.git#708aa72b9ebde06a02e862368e890fb3ddcb2fb9"
+source = "git+https://github.com/RustCrypto/utils.git#cc772039c62a0a2f4761b28df796d8b2dbda12e6"
 dependencies = [
  "typenum",
 ]
@@ -710,7 +711,7 @@ dependencies = [
 [[package]]
 name = "inout"
 version = "0.2.0-pre"
-source = "git+https://github.com/RustCrypto/utils.git#708aa72b9ebde06a02e862368e890fb3ddcb2fb9"
+source = "git+https://github.com/RustCrypto/utils.git#cc772039c62a0a2f4761b28df796d8b2dbda12e6"
 dependencies = [
  "block-padding 0.4.0-pre",
  "hybrid-array",
@@ -718,9 +719,18 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
+checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
+
+[[package]]
+name = "jobserver"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c37f63953c4c63420ed5fd3d6d398c719489b9f872b9fa683262f8edd363c7d"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "keccak"
@@ -733,7 +743,7 @@ dependencies = [
 
 [[package]]
 name = "kem"
-version = "0.2.0"
+version = "0.3.0-pre"
 dependencies = [
  "generic-array",
  "hpke",
@@ -748,9 +758,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.150"
+version = "0.2.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
+checksum = "302d7ab3130588088d277783b1e2d2e10c9e9e4a16dd9050e6ec93fb3e7048f4"
 
 [[package]]
 name = "opaque-debug"
@@ -824,7 +834,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
  "der 0.7.8",
- "spki 0.7.2",
+ "spki 0.7.3",
 ]
 
 [[package]]
@@ -899,9 +909,9 @@ checksum = "94e851c7654eed9e68d7d27164c454961a616cf8c203d500607ef22c737b51bb"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.69"
+version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
+checksum = "75cb1540fadbd5b8fbccc4dddad2734eba435053f725621c070711a14bb5f4b8"
 dependencies = [
  "unicode-ident",
 ]
@@ -959,9 +969,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.15"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
+checksum = "f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c"
 
 [[package]]
 name = "sec1"
@@ -993,27 +1003,27 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.192"
+version = "1.0.193"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bca2a08484b285dcb282d0f67b26cadc0df8b19f8c12502c13d966bf9482f001"
+checksum = "25dd9975e68d0cb5aa1120c288333fc98731bd1dd12f561e468ea4728c042b89"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_bytes"
-version = "0.11.12"
+version = "0.11.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab33ec92f677585af6d88c65593ae2375adde54efdbf16d597f2cbc7a6d368ff"
+checksum = "8bb1879ea93538b78549031e2d54da3e901fd7e75f2e4dc758d760937b123d10"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.192"
+version = "1.0.193"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6c7207fbec9faa48073f3e3074cbe553af6ea512d7c21ba46e434e70ea9fbc1"
+checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1126,9 +1136,9 @@ dependencies = [
 
 [[package]]
 name = "spki"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d1e996ef02c474957d681f1b05213dfb0abab947b446a62d37770b23500184a"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
  "der 0.7.8",
@@ -1148,9 +1158,9 @@ checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "syn"
-version = "2.0.39"
+version = "2.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23e78b90f2fcf45d3e842032ce32e3f2d1545ba6636271dcbf24fa306d87be7a"
+checksum = "ee659fb5f3d355364e1f3e5bc10fb82068efbf824a1e9d1c9504244a6469ad53"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/kem/Cargo.toml
+++ b/kem/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name          = "kem"
 description   = "Traits for key encapsulation mechanisms"
-version       = "0.2.0"
+version       = "0.3.0-pre"
 authors       = ["RustCrypto Developers"]
 license       = "Apache-2.0 OR MIT"
 documentation = "https://docs.rs/kem"
@@ -10,7 +10,7 @@ readme        = "README.md"
 edition       = "2021"
 keywords      = ["crypto"]
 categories    = ["cryptography", "no-std"]
-rust-version  = "1.60"
+rust-version  = "1.66"
 
 [dependencies]
 rand_core = "0.6"

--- a/kem/README.md
+++ b/kem/README.md
@@ -15,7 +15,7 @@ The crate exposes four traits, `Encapsulator`, `Decapsulator`, `AuthEncapsulator
 
 ## Minimum Supported Rust Version
 
-Rust **1.60** or higher.
+Rust **1.66** or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be
 done with a minor version bump.
@@ -47,7 +47,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/kem/badge.svg
 [docs-link]: https://docs.rs/kem/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.60+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.66+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260048-signatures
 [build-image]: https://github.com/RustCrypto/traits/workflows/kem/badge.svg?branch=master&event=push


### PR DESCRIPTION
Upgrades the following dependencies:

```
$ cargo update
    Updating git repository `https://github.com/RustCrypto/utils.git`
   708aa72..cc77203             -> origin/HEAD
    Updating crates.io index
    Updating async-trait v0.1.74 -> v0.1.75
    Updating block-buffer v0.11.0-pre (https://github.com/RustCrypto/utils.git#708aa72b) -> #cc772039
    Updating block-padding v0.4.0-pre (https://github.com/RustCrypto/utils.git#708aa72b) -> #cc772039
    Updating byteorder v1.4.3 -> v1.5.0
 Downgrading cc v1.0.84 -> v1.0.83
    Updating hybrid-array v0.2.0-pre.5 (https://github.com/RustCrypto/utils.git#708aa72b) -> #cc772039
    Updating inout v0.2.0-pre (https://github.com/RustCrypto/utils.git#708aa72b) -> #cc772039
    Updating itoa v1.0.9 -> v1.0.10
      Adding jobserver v0.1.27
    Updating libc v0.2.150 -> v0.2.151
    Updating proc-macro2 v1.0.69 -> v1.0.71
    Updating ryu v1.0.15 -> v1.0.16
    Updating serde v1.0.192 -> v1.0.193
    Updating serde_bytes v0.11.12 -> v0.11.13
    Updating serde_derive v1.0.192 -> v1.0.193
    Updating spki v0.7.2 -> v0.7.3
    Updating syn v2.0.39 -> v2.0.43
```