### PR TITLE
async-signature: bump version to v0.5.0-pre

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,7 +56,7 @@ checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
 name = "async-signature"
-version = "0.4.0"
+version = "0.5.0-pre"
 dependencies = [
  "signature 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/async-signature/Cargo.toml
+++ b/async-signature/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name          = "async-signature"
 description   = "Traits for cryptographic signature algorithms (e.g. ECDSA, Ed25519)"
-version       = "0.4.0"
+version       = "0.5.0-pre"
 authors       = ["RustCrypto Developers"]
 license       = "Apache-2.0 OR MIT"
 documentation = "https://docs.rs/async-signature"


### PR DESCRIPTION
NOTE: this is not a release, but just to denote that the current `master` contains breaking changes, which were introduced in #1428