### PR TITLE
Use util crate prereleases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
  "arrayvec",
  "blobby",
  "bytes",
- "crypto-common 0.2.0-pre.1",
+ "crypto-common 0.2.0-pre.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "heapless",
 ]
 
@@ -126,10 +126,11 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.11.0-pre"
-source = "git+https://github.com/RustCrypto/utils.git#314938fe8e16d55979e70d777f90a475abcfb7f4"
+version = "0.11.0-pre.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1333cbcd5375733783541e609d067fdfc8285c13b2f0363c878091a4abe7fa5f"
 dependencies = [
- "crypto-common 0.2.0-pre.1",
+ "crypto-common 0.2.0-pre.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -143,8 +144,9 @@ dependencies = [
 
 [[package]]
 name = "block-padding"
-version = "0.4.0-pre"
-source = "git+https://github.com/RustCrypto/utils.git#314938fe8e16d55979e70d777f90a475abcfb7f4"
+version = "0.4.0-pre.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6567958fbc0870d817afa281e82d557ce2c7ccc5c056cbf71ff3558a6e5a2a08"
 dependencies = [
  "hybrid-array",
 ]
@@ -217,8 +219,8 @@ name = "cipher"
 version = "0.5.0-pre"
 dependencies = [
  "blobby",
- "crypto-common 0.2.0-pre.1",
- "inout 0.2.0-pre",
+ "crypto-common 0.2.0-pre.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "inout 0.2.0-pre.1",
  "zeroize",
 ]
 
@@ -314,6 +316,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.0-pre.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47bf010313404f942f7da6931d00bd455bb4c36c36c9d4dd9497b5ac316f6fe1"
+dependencies = [
+ "getrandom",
+ "hybrid-array",
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "crypto-mac"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -399,9 +412,9 @@ name = "digest"
 version = "0.11.0-pre"
 dependencies = [
  "blobby",
- "block-buffer 0.11.0-pre",
+ "block-buffer 0.11.0-pre.1",
  "const-oid 0.9.6",
- "crypto-common 0.2.0-pre.1",
+ "crypto-common 0.2.0-pre.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "subtle",
 ]
 
@@ -699,10 +712,11 @@ dependencies = [
 
 [[package]]
 name = "inout"
-version = "0.2.0-pre"
-source = "git+https://github.com/RustCrypto/utils.git#314938fe8e16d55979e70d777f90a475abcfb7f4"
+version = "0.2.0-pre.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed415a0622334b6e89f6361616b133f5ca2a8a31c5007ca594d9180e5930ec8"
 dependencies = [
- "block-padding 0.4.0-pre",
+ "block-padding 0.4.0-pre.1",
  "hybrid-array",
 ]
 
@@ -1188,7 +1202,7 @@ dependencies = [
 name = "universal-hash"
 version = "0.6.0-pre"
 dependencies = [
- "crypto-common 0.2.0-pre.1",
+ "crypto-common 0.2.0-pre.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "subtle",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,3 @@ members = [
     "signature_derive",
     "universal-hash",
 ]
-
-[patch.crates-io]
-block-buffer = { git = "https://github.com/RustCrypto/utils.git" }
-crypto-common = { path = "crypto-common" }
-inout = { git = "https://github.com/RustCrypto/utils.git" }

--- a/cipher/Cargo.toml
+++ b/cipher/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["cryptography", "no-std"]
 
 [dependencies]
 crypto-common = "=0.2.0-pre.1"
-inout = "=0.2.0-pre"
+inout = "=0.2.0-pre.1"
 
 # optional dependencies
 blobby = { version = "0.3", optional = true }

--- a/digest/Cargo.toml
+++ b/digest/Cargo.toml
@@ -16,7 +16,7 @@ categories = ["cryptography", "no-std"]
 crypto-common = "=0.2.0-pre.1"
 
 # optional dependencies
-block-buffer = { version = "=0.11.0-pre", optional = true }
+block-buffer = { version = "=0.11.0-pre.1", optional = true }
 subtle = { version = "2.4", default-features = false, optional = true }
 blobby = { version = "0.3", optional = true }
 const-oid = { version = "0.9", optional = true }


### PR DESCRIPTION
Switches to the following prereleases:

- `block-buffer` v0.11.0-pre.1
- `inout` v0.4.0-pre.1