### PR TITLE
signature: define a `RandomizedSignerMut` trait

### DIFF
--- a/signature/CHANGELOG.md
+++ b/signature/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Added
+- `RandomizedSignerMut` trait
+
+[#1448](https://github.com/RustCrypto/traits/pull/1448)
+
 ## 2.2.0 (2023-11-12)
 ### Changed
 - MSRV 1.60 ([#1387])

--- a/signature/src/signer.rs
+++ b/signature/src/signer.rs
@@ -124,7 +124,7 @@ pub trait RandomizedDigestSigner<D: Digest, S> {
 pub trait RandomizedSignerMut<S> {
     /// Sign the given message, update the state, and return a digital signature.
     fn sign_with_rng(&mut self, rng: &mut impl CryptoRngCore, msg: &[u8]) -> S {
-        self.try_sign(msg).expect("signature operation failed")
+        self.try_sign_with_rng(rng, msg).expect("signature operation failed")
     }
 
     /// Attempt to sign the given message, updating the state, and returning a
@@ -132,13 +132,13 @@ pub trait RandomizedSignerMut<S> {
     ///
     /// Signing can fail, e.g., if the number of time periods allowed by the
     /// current key is exceeded.
-    fn try_sign_with_rng(&mut self, msg: &[u8]) -> Result<S, Error>;
+    fn try_sign_with_rng(&mut self, rng: &mut impl CryptoRngCore, msg: &[u8]) -> Result<S, Error>;
 }
 
 /// Blanket impl of [`RandomizedSignerMut`] for all [`RandomizedSigner`] types.
 #[cfg(feature = "rand_core")]
 impl<S, T: RandomizedSigner<S>> RandomizedSignerMut<S> for T {
-    fn try_sign(&mut self, msg: &[u8]) -> Result<S, Error> {
-        T::try_sign_with_rng(self, msg)
+    fn try_sign_with_rng(&mut self, rng: &mut impl CryptoRngCore, msg: &[u8]) -> Result<S, Error> {
+        T::try_sign_with_rng(self, rng, msg)
     }
 }

--- a/signature/src/signer.rs
+++ b/signature/src/signer.rs
@@ -124,7 +124,8 @@ pub trait RandomizedDigestSigner<D: Digest, S> {
 pub trait RandomizedSignerMut<S> {
     /// Sign the given message, update the state, and return a digital signature.
     fn sign_with_rng(&mut self, rng: &mut impl CryptoRngCore, msg: &[u8]) -> S {
-        self.try_sign_with_rng(rng, msg).expect("signature operation failed")
+        self.try_sign_with_rng(rng, msg)
+            .expect("signature operation failed")
     }
 
     /// Attempt to sign the given message, updating the state, and returning a


### PR DESCRIPTION
Extends #734 with a randomized version. This is useful for [LMS / LM-OTS](https://datatracker.ietf.org/doc/html/rfc8554) signatures, which are stateful and randomized.