### PR TITLE
async-signature v0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,7 +56,7 @@ checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
 name = "async-signature"
-version = "0.5.0-pre.0"
+version = "0.5.0"
 dependencies = [
  "signature 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/async-signature/CHANGELOG.md
+++ b/async-signature/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.5.0 (2024-01-02)
+### Added
+- Debug impls ([#1407])
+
+### Changed
+- Move to AFIT; MSRV 1.75 ([#1428])
+
+### Removed
+- `'static` bounds ([#1430])
+
+[#1407]: https://github.com/RustCrypto/traits/pull/1407
+[#1428]: https://github.com/RustCrypto/traits/pull/1428
+[#1430]: https://github.com/RustCrypto/traits/pull/1430
+
 ## 0.4.0 (2023-11-12)
 ### Changed
 - MSRV 1.60 ([#1387])

--- a/async-signature/Cargo.toml
+++ b/async-signature/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name          = "async-signature"
 description   = "Traits for cryptographic signature algorithms (e.g. ECDSA, Ed25519)"
-version       = "0.5.0-pre.0"
+version       = "0.5.0"
 authors       = ["RustCrypto Developers"]
 license       = "Apache-2.0 OR MIT"
 documentation = "https://docs.rs/async-signature"


### PR DESCRIPTION
### Added
- Debug impls ([#1407])

### Changed
- Move to AFIT; MSRV 1.75 ([#1428])

### Removed
- `'static` bounds ([#1430])

[#1407]: https://github.com/RustCrypto/traits/pull/1407
[#1428]: https://github.com/RustCrypto/traits/pull/1428
[#1430]: https://github.com/RustCrypto/traits/pull/1430