### PR TITLE
Bump `password-hash` to v0.6.0-pre

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -260,7 +260,7 @@ dependencies = [
  "crypto-common 0.1.6",
  "digest 0.10.7",
  "elliptic-curve 0.13.8",
- "password-hash",
+ "password-hash 0.5.0",
  "signature 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "universal-hash 0.5.1",
 ]
@@ -800,6 +800,17 @@ dependencies = [
 [[package]]
 name = "password-hash"
 version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "password-hash"
+version = "0.6.0-pre"
 dependencies = [
  "base64ct",
  "rand_core 0.6.4",

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -20,7 +20,7 @@ aead = { version = "0.5", optional = true }
 cipher = { version = "0.4", optional = true }
 digest = { version = "0.10", optional = true, features = ["mac"] }
 elliptic-curve = { version = "0.13", optional = true, path = "../elliptic-curve" }
-password-hash = { version = "0.5", optional = true, path = "../password-hash" }
+password-hash = { version = "0.5", optional = true }
 signature = { version = "2", optional = true, default-features = false }
 universal-hash = { version = "0.5", optional = true }
 

--- a/password-hash/Cargo.toml
+++ b/password-hash/Cargo.toml
@@ -5,7 +5,7 @@ Traits which describe the functionality of password hashing algorithms,
 as well as a `no_std`-friendly implementation of the PHC string format
 (a well-defined subset of the Modular Crypt Format a.k.a. MCF)
 """
-version = "0.5.0"
+version = "0.6.0-pre"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
This is not-for-release, but to signal that we are about to begin making breaking changes.

Notably it would be nice to finally land #1352, which adds `ShaCrypt` support and makes the `Encoding` enum `non_exhaustive` so we could potentially add additional encodings in the future without it being a breaking change.