### PR TITLE
elliptic-curve: migrate to hybrid-array; MSRV 1.71

### DIFF
--- a/.github/workflows/elliptic-curve.yml
+++ b/.github/workflows/elliptic-curve.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.65.0 # MSRV
+          - 1.71.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -74,7 +74,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.65.0 # MSRV
+          - 1.71.0 # MSRV
           - stable
           - nightly
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -389,7 +389,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fffa369a668c8af7dbf8b5e56c9f744fbd399949ed171606040001947de40b1c"
 dependencies = [
  "const-oid 0.9.6",
- "pem-rfc7468 0.7.0",
+ "zeroize",
+]
+
+[[package]]
+name = "der"
+version = "0.8.0-pre.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b489fd2221710c1dd46637d66b984161fb66134f81437a8489800306bcc2ecea"
+dependencies = [
+ "const-oid 0.10.0-pre.2",
+ "pem-rfc7468 1.0.0-pre.0",
  "zeroize",
 ]
 
@@ -418,6 +428,18 @@ name = "digest"
 version = "0.11.0-pre.3"
 dependencies = [
  "blobby",
+ "block-buffer 0.11.0-pre.3",
+ "const-oid 0.10.0-pre.2",
+ "crypto-common 0.2.0-pre.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.0-pre.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb3be3c52e023de5662dc05a32f747d09a1d6024fdd1f64b0850e373269efb43"
+dependencies = [
  "block-buffer 0.11.0-pre.3",
  "const-oid 0.10.0-pre.2",
  "crypto-common 0.2.0-pre.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -481,23 +503,41 @@ dependencies = [
 [[package]]
 name = "elliptic-curve"
 version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct 0.2.0",
+ "crypto-bigint 0.5.5",
+ "ff 0.13.0",
+ "generic-array",
+ "group 0.13.0",
+ "pkcs8 0.10.2",
+ "rand_core 0.6.4",
+ "sec1 0.7.3",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.14.0-pre"
 dependencies = [
  "base16ct 0.2.0",
  "base64ct",
  "crypto-bigint 0.5.5",
- "digest 0.10.7",
+ "digest 0.11.0-pre.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "ff 0.13.0",
- "generic-array",
  "group 0.13.0",
  "hex-literal",
- "hkdf 0.12.4",
- "pem-rfc7468 0.7.0",
- "pkcs8 0.10.2",
+ "hkdf 0.13.0-pre.0",
+ "hybrid-array",
+ "pem-rfc7468 1.0.0-pre.0",
+ "pkcs8 0.11.0-pre.0",
  "rand_core 0.6.4",
- "sec1 0.7.3",
+ "sec1 0.8.0-pre.0",
  "serde_json",
  "serdect",
- "sha2 0.10.8",
+ "sha2 0.11.0-pre.0",
  "sha3",
  "subtle",
  "tap",
@@ -657,6 +697,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hkdf"
+version = "0.13.0-pre.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f3bed625061d9ed27cd87356cb46c3c8269a585be23d56c6f179c722bbea471"
+dependencies = [
+ "hmac 0.13.0-pre.0",
+]
+
+[[package]]
 name = "hmac"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -673,6 +722,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0-pre.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22cb0183a745c3444af57c24aa1293e1f3e538717acce39a9d3b271c999b24f"
+dependencies = [
+ "digest 0.11.0-pre.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -704,6 +762,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27fbaf242418fe980caf09ed348d5a6aeabe71fc1bd8bebad641f4591ae0a46d"
 dependencies = [
  "typenum",
+ "zeroize",
 ]
 
 [[package]]
@@ -828,9 +887,9 @@ dependencies = [
 
 [[package]]
 name = "pem-rfc7468"
-version = "0.7.0"
+version = "1.0.0-pre.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+checksum = "76a65e1c27d1680f8805b3f8c9949f08d6aa5d6cbd088c9896e64a53821dc27d"
 dependencies = [
  "base64ct",
 ]
@@ -855,6 +914,16 @@ checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
  "der 0.7.8",
  "spki 0.7.3",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.11.0-pre.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "935c09e0aecb0cb8f8907b57438b19a068cb74a25189b06724f061170b2465ff"
+dependencies = [
+ "der 0.8.0-pre.0",
+ "spki 0.8.0-pre.0",
 ]
 
 [[package]]
@@ -1016,6 +1085,20 @@ dependencies = [
  "der 0.7.8",
  "generic-array",
  "pkcs8 0.10.2",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "sec1"
+version = "0.8.0-pre.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ccf9d914303f6606a4fa47933f65b92ce13991573a3c61118a458ec5b5ca6cb"
+dependencies = [
+ "base16ct 0.2.0",
+ "der 0.8.0-pre.0",
+ "hybrid-array",
+ "pkcs8 0.11.0-pre.0",
  "serdect",
  "subtle",
  "zeroize",
@@ -1063,9 +1146,9 @@ dependencies = [
 
 [[package]]
 name = "serdect"
-version = "0.2.0"
+version = "0.3.0-pre.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a84f14a19e9a014bb9f4512488d9829a68e04ecabffb0f9904cd1ace94598177"
+checksum = "791ef964bfaba6be28a5c3f0c56836e17cb711ac009ca1074b9c735a3ebf240a"
 dependencies = [
  "base16ct 0.2.0",
  "serde",
@@ -1096,12 +1179,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha3"
-version = "0.10.8"
+name = "sha2"
+version = "0.11.0-pre.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
+checksum = "de0628cd6fd8219612c2d71ad52ab8c2014a18cbdbedbde17de04d400df65997"
 dependencies = [
- "digest 0.10.7",
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.11.0-pre.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "sha3"
+version = "0.11.0-pre.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab80aa0f8ab215182f50d06bf13ed44929975b0f57ec4f2ddf97f01a4f6a41ab"
+dependencies = [
+ "digest 0.11.0-pre.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "keccak",
 ]
 
@@ -1162,6 +1256,16 @@ checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
  "der 0.7.8",
+]
+
+[[package]]
+name = "spki"
+version = "0.8.0-pre.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb2b56670f5ef52934c97efad30bf42585de0c33ec3e2a886e38b80d2db67243"
+dependencies = [
+ "base64ct",
+ "der 0.8.0-pre.0",
 ]
 
 [[package]]

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -19,7 +19,7 @@ crypto-common = { version = "0.1", default-features = false }
 aead = { version = "0.5", optional = true }
 cipher = { version = "0.4", optional = true }
 digest = { version = "0.10", optional = true, features = ["mac"] }
-elliptic-curve = { version = "0.13", optional = true, path = "../elliptic-curve" }
+elliptic-curve = { version = "0.13", optional = true }
 password-hash = { version = "0.5", optional = true }
 signature = { version = "2", optional = true, default-features = false }
 universal-hash = { version = "0.5", optional = true }

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elliptic-curve"
-version = "0.13.8"
+version = "0.14.0-pre"
 description = """
 General purpose Elliptic Curve Cryptography (ECC) support, including types
 and traits for representing various elliptic curve forms, scalars, points,
@@ -13,34 +13,34 @@ readme = "README.md"
 categories = ["cryptography", "no-std"]
 keywords = ["crypto", "ecc", "elliptic", "weierstrass"]
 edition = "2021"
-rust-version = "1.65"
+rust-version = "1.71"
 
 [dependencies]
 base16ct = "0.2"
 crypto-bigint = { version = "0.5", default-features = false, features = ["rand_core", "generic-array", "zeroize"] }
-generic-array = { version = "0.14.6", default-features = false, features = ["zeroize"] }
+hybrid-array = { version = "=0.2.0-pre.8", default-features = false, features = ["zeroize"] }
 rand_core = { version = "0.6.4", default-features = false }
 subtle = { version = "2", default-features = false }
 zeroize = { version = "1.7", default-features = false }
 
 # optional dependencies
 base64ct = { version = "1", optional = true, default-features = false, features = ["alloc"] }
-digest = { version = "0.10", optional = true }
+digest = { version = "=0.11.0-pre.3", optional = true }
 ff = { version = "0.13", optional = true, default-features = false }
 group = { version = "0.13", optional = true, default-features = false }
-hkdf = { version = "0.12.4", optional = true, default-features = false }
+hkdf = { version = "=0.13.0-pre.0", optional = true, default-features = false }
 hex-literal = { version = "0.4", optional = true }
-pem-rfc7468 = { version = "0.7", optional = true, features = ["alloc"] }
-pkcs8 = { version = "0.10.2", optional = true, default-features = false }
-sec1 = { version = "0.7.1", optional = true, features = ["subtle", "zeroize"] }
-serdect = { version = "0.2", optional = true, default-features = false, features = ["alloc"] }
+pem-rfc7468 = { version = "=1.0.0-pre.0", optional = true, features = ["alloc"] }
+pkcs8 = { version = "=0.11.0-pre.0", optional = true, default-features = false }
+sec1 = { version = "=0.8.0-pre.0", optional = true, features = ["subtle", "zeroize"] }
+serdect = { version = "=0.3.0-pre.0", optional = true, default-features = false, features = ["alloc"] }
 serde_json = { version = "1.0.47", optional = true, default-features = false, features = ["alloc"] }
 tap = { version = "1.0.1", optional = true, default-features = false } # hack for minimal-versions support for `bits`
 
 [dev-dependencies]
 hex-literal = "0.4"
-sha2 = "0.10"
-sha3 = "0.10"
+sha2 = "=0.11.0-pre.0"
+sha3 = "=0.11.0-pre.0"
 
 [features]
 default = ["arithmetic"]

--- a/elliptic-curve/README.md
+++ b/elliptic-curve/README.md
@@ -15,7 +15,7 @@ and public/secret keys composed thereof.
 
 ## Minimum Supported Rust Version
 
-Requires Rust **1.65** or higher.
+Requires Rust **1.71** or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be
 done with a minor version bump.
@@ -49,6 +49,6 @@ dual licensed as above, without any additional terms or conditions.
 [build-image]: https://github.com/RustCrypto/traits/actions/workflows/elliptic-curve.yml/badge.svg
 [build-link]: https://github.com/RustCrypto/traits/actions/workflows/elliptic-curve.yml
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.65+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.71+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260040-elliptic-curves

--- a/elliptic-curve/src/dev.rs
+++ b/elliptic-curve/src/dev.rs
@@ -6,7 +6,7 @@
 use crate::{
     bigint::{Limb, U256},
     error::{Error, Result},
-    generic_array::typenum::U32,
+    hybrid_array::typenum::U32,
     ops::{Invert, LinearCombination, MulByGenerator, Reduce, ShrAssign},
     pkcs8,
     point::AffineCoordinates,

--- a/elliptic-curve/src/field.rs
+++ b/elliptic-curve/src/field.rs
@@ -4,13 +4,13 @@ use crate::{
     bigint::{ArrayEncoding, ByteArray, Integer},
     Curve,
 };
-use generic_array::{typenum::Unsigned, GenericArray};
+use hybrid_array::{typenum::Unsigned, Array};
 
 /// Size of serialized field elements of this elliptic curve.
 pub type FieldBytesSize<C> = <C as Curve>::FieldBytesSize;
 
 /// Byte representation of a base/scalar field element of a given curve.
-pub type FieldBytes<C> = GenericArray<u8, FieldBytesSize<C>>;
+pub type FieldBytes<C> = Array<u8, FieldBytesSize<C>>;
 
 /// Trait for decoding/encoding `Curve::Uint` from/to [`FieldBytes`] using
 /// curve-specific rules.

--- a/elliptic-curve/src/hash2curve/hash2field.rs
+++ b/elliptic-curve/src/hash2curve/hash2field.rs
@@ -7,15 +7,15 @@ mod expand_msg;
 pub use expand_msg::{xmd::*, xof::*, *};
 
 use crate::{Error, Result};
-use generic_array::{typenum::Unsigned, ArrayLength, GenericArray};
+use hybrid_array::{typenum::Unsigned, Array, ArraySize};
 
 /// The trait for helping to convert to a field element.
 pub trait FromOkm {
     /// The number of bytes needed to convert to a field element.
-    type Length: ArrayLength<u8>;
+    type Length: ArraySize;
 
     /// Convert a byte sequence into a field element.
-    fn from_okm(data: &GenericArray<u8, Self::Length>) -> Self;
+    fn from_okm(data: &Array<u8, Self::Length>) -> Self;
 }
 
 /// Convert an arbitrary byte sequence into a field element.
@@ -38,7 +38,7 @@ where
     T: FromOkm + Default,
 {
     let len_in_bytes = T::Length::to_usize().checked_mul(out.len()).ok_or(Error)?;
-    let mut tmp = GenericArray::<u8, <T as FromOkm>::Length>::default();
+    let mut tmp = Array::<u8, <T as FromOkm>::Length>::default();
     let mut expander = E::expand_message(data, domain, len_in_bytes)?;
     for o in out.iter_mut() {
         expander.fill_bytes(&mut tmp);

--- a/elliptic-curve/src/hash2curve/hash2field/expand_msg.rs
+++ b/elliptic-curve/src/hash2curve/hash2field/expand_msg.rs
@@ -5,8 +5,8 @@ pub(super) mod xof;
 
 use crate::{Error, Result};
 use digest::{Digest, ExtendableOutput, Update, XofReader};
-use generic_array::typenum::{IsLess, U256};
-use generic_array::{ArrayLength, GenericArray};
+use hybrid_array::typenum::{IsLess, U256};
+use hybrid_array::{Array, ArraySize};
 
 /// Salt when the DST is too long
 const OVERSIZE_DST_SALT: &[u8] = b"H2C-OVERSIZE-DST-";
@@ -45,17 +45,17 @@ pub trait Expander {
 /// [dst]: https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-hash-to-curve-13#section-5.4.3
 pub(crate) enum Domain<'a, L>
 where
-    L: ArrayLength<u8> + IsLess<U256>,
+    L: ArraySize + IsLess<U256>,
 {
     /// > 255
-    Hashed(GenericArray<u8, L>),
+    Hashed(Array<u8, L>),
     /// <= 255
     Array(&'a [&'a [u8]]),
 }
 
 impl<'a, L> Domain<'a, L>
 where
-    L: ArrayLength<u8> + IsLess<U256>,
+    L: ArraySize + IsLess<U256>,
 {
     pub fn xof<X>(dsts: &'a [&'a [u8]]) -> Result<Self>
     where
@@ -64,7 +64,7 @@ where
         if dsts.is_empty() {
             Err(Error)
         } else if dsts.iter().map(|dst| dst.len()).sum::<usize>() > MAX_DST_LEN {
-            let mut data = GenericArray::<u8, L>::default();
+            let mut data = Array::<u8, L>::default();
             let mut hash = X::default();
             hash.update(OVERSIZE_DST_SALT);
 

--- a/elliptic-curve/src/hash2curve/hash2field/expand_msg/xof.rs
+++ b/elliptic-curve/src/hash2curve/hash2field/expand_msg/xof.rs
@@ -3,7 +3,7 @@
 use super::{Domain, ExpandMsg, Expander};
 use crate::{Error, Result};
 use digest::{ExtendableOutput, Update, XofReader};
-use generic_array::typenum::U32;
+use hybrid_array::typenum::U32;
 
 /// Placeholder type for implementing `expand_message_xof` based on an extendable output function
 ///
@@ -64,11 +64,11 @@ where
 mod test {
     use super::*;
     use core::mem;
-    use generic_array::{
-        typenum::{U128, U32},
-        ArrayLength, GenericArray,
-    };
     use hex_literal::hex;
+    use hybrid_array::{
+        typenum::{U128, U32},
+        Array, ArraySize,
+    };
     use sha3::Shake128;
 
     fn assert_message(msg: &[u8], domain: &Domain<'_, U32>, len_in_bytes: u16, bytes: &[u8]) {
@@ -101,14 +101,14 @@ mod test {
         fn assert<HashT, L>(&self, dst: &'static [u8], domain: &Domain<'_, U32>) -> Result<()>
         where
             HashT: Default + ExtendableOutput + Update,
-            L: ArrayLength<u8>,
+            L: ArraySize,
         {
             assert_message(self.msg, domain, L::to_u16(), self.msg_prime);
 
             let mut expander =
                 ExpandMsgXof::<HashT>::expand_message(&[self.msg], &[dst], L::to_usize())?;
 
-            let mut uniform_bytes = GenericArray::<u8, L>::default();
+            let mut uniform_bytes = Array::<u8, L>::default();
             expander.fill_bytes(&mut uniform_bytes);
 
             assert_eq!(uniform_bytes.as_slice(), self.uniform_bytes);

--- a/elliptic-curve/src/hash2curve/isogeny.rs
+++ b/elliptic-curve/src/hash2curve/isogeny.rs
@@ -4,7 +4,7 @@
 
 use core::ops::{AddAssign, Mul};
 use ff::Field;
-use generic_array::{typenum::Unsigned, ArrayLength, GenericArray};
+use hybrid_array::{typenum::Unsigned, Array, ArraySize};
 
 /// The coefficients for mapping from one isogenous curve to another
 pub struct IsogenyCoefficients<F: Field + AddAssign + Mul<Output = F>> {
@@ -21,13 +21,13 @@ pub struct IsogenyCoefficients<F: Field + AddAssign + Mul<Output = F>> {
 /// The [`Isogeny`] methods to map to another curve.
 pub trait Isogeny: Field + AddAssign + Mul<Output = Self> {
     /// The maximum number of coefficients
-    type Degree: ArrayLength<Self>;
+    type Degree: ArraySize;
     /// The isogeny coefficients
     const COEFFICIENTS: IsogenyCoefficients<Self>;
 
     /// Map from the isogeny points to the main curve
     fn isogeny(x: Self, y: Self) -> (Self, Self) {
-        let mut xs = GenericArray::<Self, Self::Degree>::default();
+        let mut xs = Array::<Self, Self::Degree>::default();
         xs[0] = Self::ONE;
         xs[1] = x;
         xs[2] = x.square();

--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -119,7 +119,7 @@ pub use crate::{
     secret_key::SecretKey,
 };
 pub use crypto_bigint as bigint;
-pub use generic_array::{self, typenum::consts};
+pub use hybrid_array::{self, typenum::consts};
 pub use rand_core;
 pub use subtle;
 pub use zeroize;
@@ -149,7 +149,7 @@ use core::{
     fmt::Debug,
     ops::{Add, ShrAssign},
 };
-use generic_array::ArrayLength;
+use hybrid_array::ArraySize;
 
 /// Algorithm [`ObjectIdentifier`][`pkcs8::ObjectIdentifier`] for elliptic
 /// curve public key cryptography (`id-ecPublicKey`).
@@ -172,7 +172,7 @@ pub trait Curve: 'static + Copy + Clone + Debug + Default + Eq + Ord + Send + Sy
     ///
     /// This is typically the same as `Self::Uint::ByteSize` but for curves
     /// with an unusual field modulus (e.g. P-224, P-521) it may be different.
-    type FieldBytesSize: ArrayLength<u8> + Add + Eq;
+    type FieldBytesSize: ArraySize + Add + Eq;
 
     /// Integer type used to represent field elements of this elliptic curve.
     type Uint: bigint::ArrayEncoding

--- a/elliptic-curve/src/scalar/nonzero.rs
+++ b/elliptic-curve/src/scalar/nonzero.rs
@@ -13,7 +13,7 @@ use core::{
 };
 use crypto_bigint::{ArrayEncoding, Integer};
 use ff::{Field, PrimeField};
-use generic_array::{typenum::Unsigned, GenericArray};
+use hybrid_array::{typenum::Unsigned, Array};
 use rand_core::CryptoRngCore;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 use zeroize::Zeroize;
@@ -286,10 +286,7 @@ where
 
     fn try_from(bytes: &[u8]) -> Result<Self, Error> {
         if bytes.len() == C::FieldBytesSize::USIZE {
-            Option::from(NonZeroScalar::from_repr(GenericArray::clone_from_slice(
-                bytes,
-            )))
-            .ok_or(Error)
+            Option::from(NonZeroScalar::from_repr(Array::clone_from_slice(bytes))).ok_or(Error)
         } else {
             Err(Error)
         }

--- a/elliptic-curve/src/scalar/primitive.rs
+++ b/elliptic-curve/src/scalar/primitive.rs
@@ -13,7 +13,7 @@ use core::{
     ops::{Add, AddAssign, Neg, ShrAssign, Sub, SubAssign},
     str,
 };
-use generic_array::{typenum::Unsigned, GenericArray};
+use hybrid_array::Array;
 use rand_core::CryptoRngCore;
 use subtle::{
     Choice, ConditionallySelectable, ConstantTimeEq, ConstantTimeGreater, ConstantTimeLess,
@@ -83,11 +83,8 @@ where
 
     /// Decode [`ScalarPrimitive`] from a big endian byte slice.
     pub fn from_slice(slice: &[u8]) -> Result<Self> {
-        if slice.len() == C::FieldBytesSize::USIZE {
-            Option::from(Self::from_bytes(GenericArray::from_slice(slice))).ok_or(Error)
-        } else {
-            Err(Error)
-        }
+        let bytes = Array::try_from(slice).map_err(|_| Error)?;
+        Option::from(Self::from_bytes(&bytes)).ok_or(Error)
     }
 
     /// Borrow the inner `C::Uint`.

--- a/elliptic-curve/src/sec1.rs
+++ b/elliptic-curve/src/sec1.rs
@@ -5,14 +5,14 @@
 pub use sec1::point::{Coordinates, ModulusSize, Tag};
 
 use crate::{Curve, FieldBytesSize, Result, SecretKey};
-use generic_array::GenericArray;
+use hybrid_array::Array;
 use subtle::CtOption;
 
 #[cfg(feature = "arithmetic")]
 use crate::{AffinePoint, CurveArithmetic, Error};
 
 /// Encoded elliptic curve point with point compression.
-pub type CompressedPoint<C> = GenericArray<u8, CompressedPointSize<C>>;
+pub type CompressedPoint<C> = Array<u8, CompressedPointSize<C>>;
 
 /// Size of a compressed elliptic curve point.
 pub type CompressedPointSize<C> = <FieldBytesSize<C> as ModulusSize>::CompressedPointSize;
@@ -21,7 +21,7 @@ pub type CompressedPointSize<C> = <FieldBytesSize<C> as ModulusSize>::Compressed
 pub type EncodedPoint<C> = sec1::point::EncodedPoint<FieldBytesSize<C>>;
 
 /// Encoded elliptic curve point *without* point compression.
-pub type UncompressedPoint<C> = GenericArray<u8, UncompressedPointSize<C>>;
+pub type UncompressedPoint<C> = Array<u8, UncompressedPointSize<C>>;
 
 /// Size of an uncompressed elliptic curve point.
 pub type UncompressedPointSize<C> = <FieldBytesSize<C> as ModulusSize>::UncompressedPointSize;

--- a/elliptic-curve/src/secret_key.rs
+++ b/elliptic-curve/src/secret_key.rs
@@ -10,7 +10,7 @@ mod pkcs8;
 
 use crate::{Curve, Error, FieldBytes, Result, ScalarPrimitive};
 use core::fmt::{self, Debug};
-use generic_array::typenum::Unsigned;
+use hybrid_array::typenum::Unsigned;
 use subtle::{Choice, ConstantTimeEq};
 use zeroize::{Zeroize, ZeroizeOnDrop, Zeroizing};
 
@@ -154,13 +154,13 @@ where
 
     /// Deserialize secret key from an encoded secret scalar passed as a byte slice.
     ///
-    /// The slice is expected to be a minimum of 24-bytes (192-byts) and at most `C::FieldBytesSize`
-    /// bytes in length.
+    /// The slice is expected to be a minimum of 24-bytes (192-bytes) and at most
+    /// `C::FieldBytesSize` bytes in length.
     ///
     /// Byte slices shorter than the field size are handled by zero padding the input.
     pub fn from_slice(slice: &[u8]) -> Result<Self> {
         if slice.len() == C::FieldBytesSize::USIZE {
-            Self::from_bytes(FieldBytes::<C>::from_slice(slice))
+            Self::from_bytes(FieldBytes::<C>::ref_from_slice(slice))
         } else if (Self::MIN_SIZE..C::FieldBytesSize::USIZE).contains(&slice.len()) {
             let mut bytes = Zeroizing::new(FieldBytes::<C>::default());
             let offset = C::FieldBytesSize::USIZE.saturating_sub(slice.len());


### PR DESCRIPTION
Migrates from `generic-array` to the `hybrid-array` crate, which provides an `Array` newtype for a public inner core array type, and significantly less unsafe code.

Also bumps `digest` and the encoding format crates (`pem-rfc7468`, `pkcs8`, `sec1`), which have also received similar `hybrid-array` upgrades.