### PR TITLE
elliptic-curve: bump `crypto-bigint` to v0.6.0-pre.8; MSRV 1.73

### DIFF
--- a/.github/workflows/elliptic-curve.yml
+++ b/.github/workflows/elliptic-curve.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.71.0 # MSRV
+          - 1.73.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -74,7 +74,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.71.0 # MSRV
+          - 1.73.0 # MSRV
           - stable
           - nightly
     steps:

--- a/.github/workflows/elliptic-curve.yml
+++ b/.github/workflows/elliptic-curve.yml
@@ -58,6 +58,8 @@ jobs:
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features alloc,digest,ecdh,hazmat,hash2curve,jwk,pem,pkcs8,sec1,serde,voprf
 
   minimal-versions:
+    # Temporarily disabled until elliptic-curve 0.13.0-pre.0 is published
+    if: false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,6 +62,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "autocfg"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
 name = "base16ct"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -302,6 +308,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-bigint"
+version = "0.6.0-pre.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f83f24a157ad881f072a0ba6b4950dc0d1fbbea38df4dcc271d9a4a1501b96e"
+dependencies = [
+ "hybrid-array",
+ "num-traits",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -524,7 +543,7 @@ version = "0.14.0-pre"
 dependencies = [
  "base16ct 0.2.0",
  "base64ct",
- "crypto-bigint 0.5.5",
+ "crypto-bigint 0.6.0-pre.8",
  "digest 0.11.0-pre.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "ff 0.13.0",
  "group 0.13.0",
@@ -829,6 +848,15 @@ name = "libc"
 version = "0.2.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "302d7ab3130588088d277783b1e2d2e10c9e9e4a16dd9050e6ec93fb3e7048f4"
+
+[[package]]
+name = "num-traits"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "opaque-debug"

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -17,7 +17,7 @@ rust-version = "1.71"
 
 [dependencies]
 base16ct = "0.2"
-crypto-bigint = { version = "0.5", default-features = false, features = ["rand_core", "generic-array", "zeroize"] }
+crypto-bigint = { version = "=0.6.0-pre.8", default-features = false, features = ["rand_core", "hybrid-array", "zeroize"] }
 hybrid-array = { version = "=0.2.0-pre.8", default-features = false, features = ["zeroize"] }
 rand_core = { version = "0.6.4", default-features = false }
 subtle = { version = "2", default-features = false }

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 categories = ["cryptography", "no-std"]
 keywords = ["crypto", "ecc", "elliptic", "weierstrass"]
 edition = "2021"
-rust-version = "1.71"
+rust-version = "1.73"
 
 [dependencies]
 base16ct = "0.2"

--- a/elliptic-curve/README.md
+++ b/elliptic-curve/README.md
@@ -15,7 +15,7 @@ and public/secret keys composed thereof.
 
 ## Minimum Supported Rust Version
 
-Requires Rust **1.71** or higher.
+Requires Rust **1.73** or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be
 done with a minor version bump.
@@ -49,6 +49,6 @@ dual licensed as above, without any additional terms or conditions.
 [build-image]: https://github.com/RustCrypto/traits/actions/workflows/elliptic-curve.yml/badge.svg
 [build-link]: https://github.com/RustCrypto/traits/actions/workflows/elliptic-curve.yml
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.71+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.73+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260040-elliptic-curves

--- a/elliptic-curve/src/dev.rs
+++ b/elliptic-curve/src/dev.rs
@@ -4,9 +4,9 @@
 //! the traits in this crate.
 
 use crate::{
+    array::typenum::U32,
     bigint::{Limb, U256},
     error::{Error, Result},
-    hybrid_array::typenum::U32,
     ops::{Invert, LinearCombination, MulByGenerator, Reduce, ShrAssign},
     pkcs8,
     point::AffineCoordinates,

--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -119,7 +119,8 @@ pub use crate::{
     secret_key::SecretKey,
 };
 pub use crypto_bigint as bigint;
-pub use hybrid_array::{self, typenum::consts};
+pub use hybrid_array as array;
+pub use hybrid_array::typenum::consts;
 pub use rand_core;
 pub use subtle;
 pub use zeroize;
@@ -178,7 +179,7 @@ pub trait Curve: 'static + Copy + Clone + Debug + Default + Eq + Ord + Send + Sy
     type Uint: bigint::ArrayEncoding
         + bigint::AddMod<Output = Self::Uint>
         + bigint::Encoding
-        + bigint::Integer
+        + bigint::FixedInteger
         + bigint::NegMod<Output = Self::Uint>
         + bigint::Random
         + bigint::RandomMod

--- a/elliptic-curve/src/scalar.rs
+++ b/elliptic-curve/src/scalar.rs
@@ -7,6 +7,7 @@ mod nonzero;
 mod primitive;
 
 pub use self::primitive::ScalarPrimitive;
+
 #[cfg(feature = "arithmetic")]
 pub use self::{blinded::BlindedScalar, nonzero::NonZeroScalar};
 

--- a/elliptic-curve/src/scalar/primitive.rs
+++ b/elliptic-curve/src/scalar/primitive.rs
@@ -1,6 +1,7 @@
 //! Generic scalar type with primitive functionality.
 
 use crate::{
+    array::Array,
     bigint::{prelude::*, Limb, NonZero},
     scalar::FromUintUnchecked,
     scalar::IsHigh,
@@ -13,7 +14,6 @@ use core::{
     ops::{Add, AddAssign, Neg, ShrAssign, Sub, SubAssign},
     str,
 };
-use hybrid_array::Array;
 use rand_core::CryptoRngCore;
 use subtle::{
     Choice, ConditionallySelectable, ConstantTimeEq, ConstantTimeGreater, ConstantTimeLess,
@@ -357,7 +357,7 @@ where
     C: Curve,
 {
     fn is_high(&self) -> Choice {
-        let n_2 = C::ORDER >> 1;
+        let n_2 = C::ORDER >> 1u32;
         self.inner.ct_gt(&n_2)
     }
 }


### PR DESCRIPTION
The latest prerelease of `crypto-bigint` includes changes necessary to also support heap-backed integers (not that we're planning on using them), but also includes expanded modular arithmetic support including an implementation of the Bernstein-Yang modular inversion algorithm.

It also includes a migration to `hybrid-array` which will be necessary for everything to work together correctly.