### PR TITLE
signature: bump `digest` to v0.11.0-pre.3; MSRV 1.71

### DIFF
--- a/.github/workflows/signature.yml
+++ b/.github/workflows/signature.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.60.0 # MSRV
+          - 1.71.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -52,7 +52,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.60.0 # MSRV
+          - 1.71.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v4
@@ -70,7 +70,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.60.0 # MSRV
+          - 1.71.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,7 +58,7 @@ checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 name = "async-signature"
 version = "0.5.0"
 dependencies = [
- "signature 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "signature 2.2.0",
 ]
 
 [[package]]
@@ -267,7 +267,7 @@ dependencies = [
  "digest 0.10.7",
  "elliptic-curve 0.13.8",
  "password-hash 0.5.0",
- "signature 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "signature 2.2.0",
  "universal-hash 0.5.1",
 ]
 
@@ -1240,22 +1240,22 @@ dependencies = [
 [[package]]
 name = "signature"
 version = "2.2.0"
-dependencies = [
- "digest 0.10.7",
- "hex-literal",
- "rand_core 0.6.4",
- "sha2 0.10.8",
- "signature_derive",
-]
-
-[[package]]
-name = "signature"
-version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest 0.10.7",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "signature"
+version = "2.3.0"
+dependencies = [
+ "digest 0.11.0-pre.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hex-literal",
+ "rand_core 0.6.4",
+ "sha2 0.11.0-pre.0",
+ "signature_derive",
 ]
 
 [[package]]

--- a/signature/Cargo.toml
+++ b/signature/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name          = "signature"
 description   = "Traits for cryptographic signature algorithms (e.g. ECDSA, Ed25519)"
-version       = "2.2.0"
+version       = "2.3.0-pre"
 authors       = ["RustCrypto Developers"]
 license       = "Apache-2.0 OR MIT"
 documentation = "https://docs.rs/signature"
@@ -10,16 +10,16 @@ readme        = "README.md"
 keywords      = ["crypto", "ecdsa", "ed25519", "signature", "signing"]
 categories    = ["cryptography", "no-std"]
 edition       = "2021"
-rust-version  = "1.60"
+rust-version  = "1.71"
 
 [dependencies]
 derive = { package = "signature_derive", version = "2", optional = true, path = "../signature_derive" }
-digest = { version = "0.10.6", optional = true, default-features = false }
+digest = { version = "=0.11.0-pre.3", optional = true, default-features = false }
 rand_core = { version = "0.6.4", optional = true, default-features = false }
 
 [dev-dependencies]
 hex-literal = "0.4"
-sha2 = { version = "0.10", default-features = false }
+sha2 = { version = "=0.11.0-pre.0", default-features = false }
 
 [features]
 alloc = []

--- a/signature/README.md
+++ b/signature/README.md
@@ -17,7 +17,7 @@ the [RustCrypto] organization, as well as [`ed25519-dalek`].
 
 ## Minimum Supported Rust Version
 
-Rust **1.60** or higher.
+Rust **1.71** or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be
 done with a minor version bump.
@@ -56,7 +56,7 @@ dual licensed as above, without any additional terms or conditions.
 [build-image]: https://github.com/RustCrypto/traits/actions/workflows/signature.yml/badge.svg
 [build-link]: https://github.com/RustCrypto/traits/actions/workflows/signature.yml
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.60+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.71+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260048-signatures
 

--- a/signature/tests/derive.rs
+++ b/signature/tests/derive.rs
@@ -2,7 +2,7 @@
 
 #![cfg(all(feature = "derive", feature = "digest"))]
 
-use digest::{generic_array::GenericArray, Digest, OutputSizeUser};
+use digest::{array::Array, Digest, OutputSizeUser};
 use hex_literal::hex;
 use sha2::Sha256;
 use signature::{
@@ -17,7 +17,7 @@ const INPUT_STRING: &[u8] = b"abc";
 const INPUT_STRING_DIGEST: [u8; 32] =
     hex!("ba7816bf 8f01cfea 414140de 5dae2223 b00361a3 96177a9c b410ff61 f20015ad");
 
-type Repr = GenericArray<u8, <Sha256 as OutputSizeUser>::OutputSize>;
+type Repr = Array<u8, <Sha256 as OutputSizeUser>::OutputSize>;
 
 /// Dummy signature which just contains a digest output
 #[derive(Clone, Debug)]
@@ -35,7 +35,7 @@ impl TryFrom<&[u8]> for DummySignature {
     type Error = Error;
 
     fn try_from(bytes: &[u8]) -> Result<Self, Error> {
-        Ok(DummySignature(GenericArray::clone_from_slice(bytes)))
+        Ok(DummySignature(Array::clone_from_slice(bytes)))
     }
 }
 


### PR DESCRIPTION
Per our SemVer policy, this is exempt as a SemVer breaking change.

However, per the same policy, this bumps the version to v2.3.0-pre as a minor version bump is required.