### PR TITLE
crypto-common: bump `hybrid-array` to v0.2.0-rc.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
  "arrayvec",
  "blobby",
  "bytes",
- "crypto-common 0.2.0-pre.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crypto-common 0.2.0-pre.3",
  "heapless",
 ]
 
@@ -136,7 +136,7 @@ version = "0.11.0-pre.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72bc448e41b30773616b4f51a23f1a51634d41ce0d06a9bf6c3065ee85e227a1"
 dependencies = [
- "crypto-common 0.2.0-pre.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crypto-common 0.2.0-pre.3",
 ]
 
 [[package]]
@@ -225,7 +225,7 @@ name = "cipher"
 version = "0.5.0-pre.1"
 dependencies = [
  "blobby",
- "crypto-common 0.2.0-pre.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crypto-common 0.2.0-pre.3",
  "inout 0.2.0-pre.3",
  "zeroize",
 ]
@@ -329,15 +329,6 @@ dependencies = [
  "generic-array",
  "rand_core 0.6.4",
  "typenum",
-]
-
-[[package]]
-name = "crypto-common"
-version = "0.2.0-pre.3"
-dependencies = [
- "getrandom",
- "hybrid-array",
- "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -449,7 +440,7 @@ dependencies = [
  "blobby",
  "block-buffer 0.11.0-pre.3",
  "const-oid 0.10.0-pre.2",
- "crypto-common 0.2.0-pre.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crypto-common 0.2.0-pre.3",
  "subtle",
 ]
 
@@ -461,7 +452,7 @@ checksum = "eb3be3c52e023de5662dc05a32f747d09a1d6024fdd1f64b0850e373269efb43"
 dependencies = [
  "block-buffer 0.11.0-pre.3",
  "const-oid 0.10.0-pre.2",
- "crypto-common 0.2.0-pre.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crypto-common 0.2.0-pre.3",
  "subtle",
 ]
 
@@ -1351,7 +1342,7 @@ dependencies = [
 name = "universal-hash"
 version = "0.6.0-pre"
 dependencies = [
- "crypto-common 0.2.0-pre.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crypto-common 0.2.0-pre.3",
  "subtle",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = [
     "async-signature",
     "cipher",
     "crypto",
-    "crypto-common",
+#    "crypto-common",
     "digest",
     "elliptic-curve",
     "kem",
@@ -14,3 +14,4 @@ members = [
     "signature_derive",
     "universal-hash",
 ]
+exclude = ["crypto-common"]

--- a/crypto-common/Cargo.lock
+++ b/crypto-common/Cargo.lock
@@ -30,8 +30,9 @@ dependencies = [
 
 [[package]]
 name = "hybrid-array"
-version = "0.2.0-pre.8"
-source = "git+https://github.com/RustCrypto/utils.git?branch=hybrid-array/v0.2.0-pre.8#eac3be7a9c959152b37d6c51e1aaf2f44e9c2c40"
+version = "0.2.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c5517ac29f08e88170b9647d85cc5f21c2596de177b4867232e20b214b8da1"
 dependencies = [
  "typenum",
 ]

--- a/crypto-common/Cargo.toml
+++ b/crypto-common/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "crypto-common"
 description = "Common cryptographic traits"
-version = "0.2.0-pre.3"
+version = "0.2.0-pre.4"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
@@ -13,7 +13,7 @@ keywords = ["crypto", "traits"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-hybrid-array = "=0.2.0-pre.8"
+hybrid-array = "0.2.0-rc.0"
 
 # optional dependencies
 rand_core = { version = "0.6.4", optional = true }


### PR DESCRIPTION
Relaxes the `hybrid-array` requirement so we can release additional compatible versions without having to upgrade `crypto-common` each time.

Also bumps `crypto-common` to v0.2.0-pre.4 (for release)