### PR TITLE
elliptic-curve,signature: bump deps; add back to workspace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,6 +62,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "autocfg"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
 name = "base16ct"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -86,6 +92,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
 ]
 
 [[package]]
@@ -290,6 +308,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-bigint"
+version = "0.6.0-pre.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ccdf8183c2226b057661e7d89624e75108e67b28306c898581fee700ff2d992"
+dependencies = [
+ "hybrid-array",
+ "num-traits",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -381,6 +412,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "der"
+version = "0.8.0-pre.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b489fd2221710c1dd46637d66b984161fb66134f81437a8489800306bcc2ecea"
+dependencies = [
+ "const-oid 0.10.0-pre.2",
+ "pem-rfc7468 1.0.0-pre.0",
+ "zeroize",
+]
+
+[[package]]
 name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -405,6 +447,18 @@ name = "digest"
 version = "0.11.0-pre.4"
 dependencies = [
  "blobby",
+ "block-buffer 0.11.0-pre.4",
+ "const-oid 0.10.0-pre.2",
+ "crypto-common 0.2.0-pre.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.0-pre.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b429fb535b92bad18c86f1d7ee7584a175c2810800c7ac5b75b9408b13981979"
+dependencies = [
  "block-buffer 0.11.0-pre.4",
  "const-oid 0.10.0-pre.2",
  "crypto-common 0.2.0-pre.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -484,6 +538,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "elliptic-curve"
+version = "0.14.0-pre.0"
+dependencies = [
+ "base16ct 0.2.0",
+ "base64ct",
+ "crypto-bigint 0.6.0-pre.9",
+ "digest 0.11.0-pre.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ff 0.13.0",
+ "group 0.13.0",
+ "hex-literal",
+ "hkdf 0.13.0-pre.1",
+ "hybrid-array",
+ "pem-rfc7468 1.0.0-pre.0",
+ "pkcs8 0.11.0-pre.0",
+ "rand_core 0.6.4",
+ "sec1 0.8.0-pre.1",
+ "serde_json",
+ "serdect",
+ "sha2 0.11.0-pre.1",
+ "sha3",
+ "subtle",
+ "tap",
+ "zeroize",
+]
+
+[[package]]
 name = "ff"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -509,9 +589,16 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
 dependencies = [
+ "bitvec",
  "rand_core 0.6.4",
  "subtle",
 ]
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "generic-array"
@@ -604,6 +691,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hex-literal"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
+
+[[package]]
 name = "hkdf"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -623,6 +716,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hkdf"
+version = "0.13.0-pre.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8030479f3be0f2d183d7fcb5a8bb3c08c31ba40c49a1af5780544272ab8494fb"
+dependencies = [
+ "hmac 0.13.0-pre.1",
+]
+
+[[package]]
 name = "hmac"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -639,6 +741,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0-pre.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad9bdb2c4daa57033321e5e64c7a8cab02086ee130f8702f72b5c164893026a"
+dependencies = [
+ "digest 0.11.0-pre.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -670,6 +781,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8c5517ac29f08e88170b9647d85cc5f21c2596de177b4867232e20b214b8da1"
 dependencies = [
  "typenum",
+ "zeroize",
 ]
 
 [[package]]
@@ -693,12 +805,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "itoa"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
+
+[[package]]
 name = "jobserver"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c37f63953c4c63420ed5fd3d6d398c719489b9f872b9fa683262f8edd363c7d"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "keccak"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f6d5ed8676d904364de097082f4e7d240b571b67989ced0240f08b7f966f940"
+dependencies = [
+ "cpufeatures",
 ]
 
 [[package]]
@@ -721,6 +848,15 @@ name = "libc"
 version = "0.2.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "302d7ab3130588088d277783b1e2d2e10c9e9e4a16dd9050e6ec93fb3e7048f4"
+
+[[package]]
+name = "num-traits"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "opaque-debug"
@@ -778,13 +914,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem-rfc7468"
+version = "1.0.0-pre.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a65e1c27d1680f8805b3f8c9949f08d6aa5d6cbd088c9896e64a53821dc27d"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
 name = "pkcs8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee3ef9b64d26bad0536099c816c6734379e45bbd5f14798def6809e5cc350447"
 dependencies = [
  "der 0.4.5",
- "pem-rfc7468",
+ "pem-rfc7468 0.2.3",
  "spki 0.4.1",
  "zeroize",
 ]
@@ -797,6 +942,16 @@ checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
  "der 0.7.8",
  "spki 0.7.3",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.11.0-pre.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "935c09e0aecb0cb8f8907b57438b19a068cb74a25189b06724f061170b2465ff"
+dependencies = [
+ "der 0.8.0-pre.0",
+ "spki 0.8.0-pre.0",
 ]
 
 [[package]]
@@ -888,6 +1043,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -924,6 +1085,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c"
+
+[[package]]
 name = "sec1"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -946,6 +1113,21 @@ dependencies = [
  "der 0.7.8",
  "generic-array",
  "pkcs8 0.10.2",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "sec1"
+version = "0.8.0-pre.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02dc081ed777a3bab68583b52ffb8221677b6e90d483b320963a247e2c07f328"
+dependencies = [
+ "base16ct 0.2.0",
+ "der 0.8.0-pre.0",
+ "hybrid-array",
+ "pkcs8 0.11.0-pre.0",
+ "serdect",
  "subtle",
  "zeroize",
 ]
@@ -980,6 +1162,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_json"
+version = "1.0.111"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "176e46fa42316f18edd598015a5166857fc835ec732f5215eac6b7bdbf0a84f4"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serdect"
+version = "0.3.0-pre.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "791ef964bfaba6be28a5c3f0c56836e17cb711ac009ca1074b9c735a3ebf240a"
+dependencies = [
+ "base16ct 0.2.0",
+ "serde",
+]
+
+[[package]]
 name = "sha2"
 version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1004,6 +1207,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.11.0-pre.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9daa731ca112bb569b34b41775363a461422813d8ed1ea6dba352eb58ec4e684"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.11.0-pre.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "sha3"
+version = "0.11.0-pre.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23f5da8ebbbfc6bd857bb4d209bb42109772703b118ea137d57352c2a95b3322"
+dependencies = [
+ "digest 0.11.0-pre.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "keccak",
+]
+
+[[package]]
 name = "signature"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1021,6 +1245,17 @@ checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest 0.10.7",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "signature"
+version = "2.3.0-pre.0"
+dependencies = [
+ "digest 0.11.0-pre.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hex-literal",
+ "rand_core 0.6.4",
+ "sha2 0.11.0-pre.1",
+ "signature_derive",
 ]
 
 [[package]]
@@ -1052,6 +1287,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "spki"
+version = "0.8.0-pre.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb2b56670f5ef52934c97efad30bf42585de0c33ec3e2a886e38b80d2db67243"
+dependencies = [
+ "base64ct",
+ "der 0.8.0-pre.0",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1073,6 +1318,12 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "typenum"
@@ -1115,6 +1366,15 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
 
 [[package]]
 name = "x25519-dalek"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,11 +7,10 @@ members = [
     "crypto",
     "crypto-common",
     "digest",
-#    "elliptic-curve",
+    "elliptic-curve",
     "kem",
     "password-hash",
-#    "signature",
+    "signature",
     "signature_derive",
     "universal-hash",
 ]
-exclude = ["elliptic-curve", "signature"]

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elliptic-curve"
-version = "0.14.0-pre.0"
+version = "0.14.0-pre.1"
 description = """
 General purpose Elliptic Curve Cryptography (ECC) support, including types
 and traits for representing various elliptic curve forms, scalars, points,
@@ -17,30 +17,30 @@ rust-version = "1.73"
 
 [dependencies]
 base16ct = "0.2"
-crypto-bigint = { version = "=0.6.0-pre.8", default-features = false, features = ["rand_core", "hybrid-array", "zeroize"] }
-hybrid-array = { version = "=0.2.0-pre.8", default-features = false, features = ["zeroize"] }
+crypto-bigint = { version = "=0.6.0-pre.9", default-features = false, features = ["rand_core", "hybrid-array", "zeroize"] }
+hybrid-array = { version = "0.2.0-rc.0", default-features = false, features = ["zeroize"] }
 rand_core = { version = "0.6.4", default-features = false }
 subtle = { version = "2", default-features = false }
 zeroize = { version = "1.7", default-features = false }
 
 # optional dependencies
 base64ct = { version = "1", optional = true, default-features = false, features = ["alloc"] }
-digest = { version = "=0.11.0-pre.3", optional = true }
+digest = { version = "=0.11.0-pre.4", optional = true }
 ff = { version = "0.13", optional = true, default-features = false }
 group = { version = "0.13", optional = true, default-features = false }
-hkdf = { version = "=0.13.0-pre.0", optional = true, default-features = false }
+hkdf = { version = "=0.13.0-pre.1", optional = true, default-features = false }
 hex-literal = { version = "0.4", optional = true }
 pem-rfc7468 = { version = "=1.0.0-pre.0", optional = true, features = ["alloc"] }
 pkcs8 = { version = "=0.11.0-pre.0", optional = true, default-features = false }
-sec1 = { version = "=0.8.0-pre.0", optional = true, features = ["subtle", "zeroize"] }
+sec1 = { version = "=0.8.0-pre.1", optional = true, features = ["subtle", "zeroize"] }
 serdect = { version = "=0.3.0-pre.0", optional = true, default-features = false, features = ["alloc"] }
 serde_json = { version = "1.0.47", optional = true, default-features = false, features = ["alloc"] }
 tap = { version = "1.0.1", optional = true, default-features = false } # hack for minimal-versions support for `bits`
 
 [dev-dependencies]
 hex-literal = "0.4"
-sha2 = "=0.11.0-pre.0"
-sha3 = "=0.11.0-pre.0"
+sha2 = "=0.11.0-pre.1"
+sha3 = "=0.11.0-pre.1"
 
 [features]
 default = ["arithmetic"]

--- a/elliptic-curve/src/secret_key.rs
+++ b/elliptic-curve/src/secret_key.rs
@@ -160,7 +160,7 @@ where
     /// Byte slices shorter than the field size are handled by zero padding the input.
     pub fn from_slice(slice: &[u8]) -> Result<Self> {
         if slice.len() == C::FieldBytesSize::USIZE {
-            Self::from_bytes(FieldBytes::<C>::ref_from_slice(slice))
+            Self::from_bytes(FieldBytes::<C>::from_slice(slice))
         } else if (Self::MIN_SIZE..C::FieldBytesSize::USIZE).contains(&slice.len()) {
             let mut bytes = Zeroizing::new(FieldBytes::<C>::default());
             let offset = C::FieldBytesSize::USIZE.saturating_sub(slice.len());

--- a/signature/Cargo.toml
+++ b/signature/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name          = "signature"
 description   = "Traits for cryptographic signature algorithms (e.g. ECDSA, Ed25519)"
-version       = "2.3.0-pre.0"
+version       = "2.3.0-pre.1"
 authors       = ["RustCrypto Developers"]
 license       = "Apache-2.0 OR MIT"
 documentation = "https://docs.rs/signature"
@@ -14,12 +14,12 @@ rust-version  = "1.71"
 
 [dependencies]
 derive = { package = "signature_derive", version = "2", optional = true, path = "../signature_derive" }
-digest = { version = "=0.11.0-pre.3", optional = true, default-features = false }
+digest = { version = "=0.11.0-pre.4", optional = true, default-features = false }
 rand_core = { version = "0.6.4", optional = true, default-features = false }
 
 [dev-dependencies]
 hex-literal = "0.4"
-sha2 = { version = "=0.11.0-pre.0", default-features = false }
+sha2 = { version = "=0.11.0-pre.1", default-features = false }
 
 [features]
 alloc = []


### PR DESCRIPTION
Also cuts v0.14.0-pre.1 and v2.3.0-pre.1 releases respectively