### PR TITLE
elliptic-curve: bump `crypto-bigint` to v0.6.0-pre.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -309,9 +309,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-bigint"
-version = "0.6.0-pre.9"
+version = "0.6.0-pre.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ccdf8183c2226b057661e7d89624e75108e67b28306c898581fee700ff2d992"
+checksum = "12979c1e0771d68f02c2fb93fb0ad54e597f82d608fb569db792d99ebd0bb3c5"
 dependencies = [
  "hybrid-array",
  "num-traits",
@@ -539,11 +539,11 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.14.0-pre.0"
+version = "0.14.0-pre.2"
 dependencies = [
  "base16ct 0.2.0",
  "base64ct",
- "crypto-bigint 0.6.0-pre.9",
+ "crypto-bigint 0.6.0-pre.10",
  "digest 0.11.0-pre.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "ff 0.13.0",
  "group 0.13.0",
@@ -1249,7 +1249,7 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "2.3.0-pre.0"
+version = "2.3.0-pre.1"
 dependencies = [
  "digest 0.11.0-pre.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex-literal",

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elliptic-curve"
-version = "0.14.0-pre.1"
+version = "0.14.0-pre.2"
 description = """
 General purpose Elliptic Curve Cryptography (ECC) support, including types
 and traits for representing various elliptic curve forms, scalars, points,
@@ -17,7 +17,7 @@ rust-version = "1.73"
 
 [dependencies]
 base16ct = "0.2"
-crypto-bigint = { version = "=0.6.0-pre.9", default-features = false, features = ["rand_core", "hybrid-array", "zeroize"] }
+crypto-bigint = { version = "=0.6.0-pre.10", default-features = false, features = ["rand_core", "hybrid-array", "zeroize"] }
 hybrid-array = { version = "0.2.0-rc.0", default-features = false, features = ["zeroize"] }
 rand_core = { version = "0.6.4", default-features = false }
 subtle = { version = "2", default-features = false }


### PR DESCRIPTION
Also cuts a v0.14.0-pre.2 release of `elliptic-curve`