### PR TITLE
digest: return `CtOutput::into_bytes` method

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -457,7 +457,7 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.11.0-pre.5"
+version = "0.11.0-pre.6"
 dependencies = [
  "blobby",
  "block-buffer 0.11.0-pre.4",

--- a/digest/Cargo.toml
+++ b/digest/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "digest"
 description = "Traits for cryptographic hash functions and message authentication codes"
-version = "0.11.0-pre.5"
+version = "0.11.0-pre.6"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/digest/src/mac.rs
+++ b/digest/src/mac.rs
@@ -204,10 +204,16 @@ impl<T: OutputSizeUser> CtOutput<T> {
         Self { bytes }
     }
 
-    /// Get the inner [`Output`] array this type wraps.
+    /// Get reference to the inner [`Output`] array this type wraps.
     #[inline(always)]
     pub fn as_bytes(&self) -> &Output<T> {
         &self.bytes
+    }
+
+    /// Get the inner [`Output`] array this type wraps.
+    #[inline(always)]
+    pub fn into_bytes(&self) -> Output<T> {
+        self.bytes.clone()
     }
 }
 


### PR DESCRIPTION
Bumps `digest` to 0.11.0-pre.6.