### PR TITLE
async-signature: bump `signature` to v2.3.0-pre.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,9 +56,9 @@ checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
 name = "async-signature"
-version = "0.5.0"
+version = "0.6.0-pre.0"
 dependencies = [
- "signature 2.2.0",
+ "signature 2.3.0-pre.2",
 ]
 
 [[package]]
@@ -1245,7 +1245,6 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,6 @@ members = [
     "signature_derive",
     "universal-hash",
 ]
+
+[patch.crates-io]
+signature = { path = "./signature" }

--- a/async-signature/Cargo.toml
+++ b/async-signature/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name          = "async-signature"
 description   = "Traits for cryptographic signature algorithms (e.g. ECDSA, Ed25519)"
-version       = "0.5.0"
+version       = "0.6.0-pre.0"
 authors       = ["RustCrypto Developers"]
 license       = "Apache-2.0 OR MIT"
 documentation = "https://docs.rs/async-signature"
@@ -13,7 +13,7 @@ edition       = "2021"
 rust-version  = "1.75"
 
 [dependencies]
-signature = ">= 2.0, <2.3"
+signature = "=2.3.0-pre.2"
 
 [features]
 digest = ["signature/digest"]


### PR DESCRIPTION
This would be required for https://github.com/RustCrypto/formats/pull/1280/ as I'm pulling both `signature` and `async-signature`.