### PR TITLE
elliptic-curve: `SecretKey::from_slice` timing note

### DIFF
--- a/elliptic-curve/src/secret_key.rs
+++ b/elliptic-curve/src/secret_key.rs
@@ -158,6 +158,9 @@ where
     /// `C::FieldBytesSize` bytes in length.
     ///
     /// Byte slices shorter than the field size are handled by zero padding the input.
+    ///
+    /// NOTE: this function is variable-time with respect to the input length. To avoid a timing
+    /// sidechannel, always ensure that the input has been pre-padded to `C::FieldBytesSize`.
     pub fn from_slice(slice: &[u8]) -> Result<Self> {
         if slice.len() == C::FieldBytesSize::USIZE {
             Self::from_bytes(FieldBytes::<C>::from_slice(slice))


### PR DESCRIPTION
Adds a note to the documentation that `SecretKey::from_slice` is variable-time with respect to the input size.