### PR TITLE
cipher: rename `BlockCipher*`/`BlockMode*`

### DIFF
--- a/cipher/src/block.rs
+++ b/cipher/src/block.rs
@@ -317,39 +317,39 @@ pub trait BlockCipherDecrypt: BlockSizeUser {
 /// underlying hardware peripheral.
 pub trait BlockModeEncrypt: BlockSizeUser + Sized {
     /// Encrypt data using backend provided to the rank-2 closure.
-    fn encrypt_with_backend_mut(&mut self, f: impl BlockClosure<BlockSize = Self::BlockSize>);
+    fn encrypt_with_backend(&mut self, f: impl BlockClosure<BlockSize = Self::BlockSize>);
 
     /// Encrypt single `inout` block.
     #[inline]
-    fn encrypt_block_inout_mut(&mut self, block: InOut<'_, '_, Block<Self>>) {
-        self.encrypt_with_backend_mut(BlockCtx { block });
+    fn encrypt_block_inout(&mut self, block: InOut<'_, '_, Block<Self>>) {
+        self.encrypt_with_backend(BlockCtx { block });
     }
 
     /// Encrypt `inout` blocks.
     #[inline]
-    fn encrypt_blocks_inout_mut(&mut self, blocks: InOutBuf<'_, '_, Block<Self>>) {
-        self.encrypt_with_backend_mut(BlocksCtx { blocks });
+    fn encrypt_blocks_inout(&mut self, blocks: InOutBuf<'_, '_, Block<Self>>) {
+        self.encrypt_with_backend(BlocksCtx { blocks });
     }
 
     /// Encrypt single block in-place.
     #[inline]
-    fn encrypt_block_mut(&mut self, block: &mut Block<Self>) {
+    fn encrypt_block(&mut self, block: &mut Block<Self>) {
         let block = block.into();
-        self.encrypt_with_backend_mut(BlockCtx { block });
+        self.encrypt_with_backend(BlockCtx { block });
     }
 
     /// Encrypt `in_block` and write result to `out_block`.
     #[inline]
-    fn encrypt_block_b2b_mut(&mut self, in_block: &Block<Self>, out_block: &mut Block<Self>) {
+    fn encrypt_block_b2b(&mut self, in_block: &Block<Self>, out_block: &mut Block<Self>) {
         let block = (in_block, out_block).into();
-        self.encrypt_with_backend_mut(BlockCtx { block });
+        self.encrypt_with_backend(BlockCtx { block });
     }
 
     /// Encrypt blocks in-place.
     #[inline]
-    fn encrypt_blocks_mut(&mut self, blocks: &mut [Block<Self>]) {
+    fn encrypt_blocks(&mut self, blocks: &mut [Block<Self>]) {
         let blocks = blocks.into();
-        self.encrypt_with_backend_mut(BlocksCtx { blocks });
+        self.encrypt_with_backend(BlocksCtx { blocks });
     }
 
     /// Encrypt blocks buffer-to-buffer.
@@ -357,13 +357,13 @@ pub trait BlockModeEncrypt: BlockSizeUser + Sized {
     /// Returns [`NotEqualError`] if provided `in_blocks` and `out_blocks`
     /// have different lengths.
     #[inline]
-    fn encrypt_blocks_b2b_mut(
+    fn encrypt_blocks_b2b(
         &mut self,
         in_blocks: &[Block<Self>],
         out_blocks: &mut [Block<Self>],
     ) -> Result<(), NotEqualError> {
         InOutBuf::new(in_blocks, out_blocks)
-            .map(|blocks| self.encrypt_with_backend_mut(BlocksCtx { blocks }))
+            .map(|blocks| self.encrypt_with_backend(BlocksCtx { blocks }))
     }
 
     /// Pad input and encrypt. Returns resulting ciphertext slice.
@@ -371,14 +371,14 @@ pub trait BlockModeEncrypt: BlockSizeUser + Sized {
     /// Returns [`PadError`] if length of output buffer is not sufficient.
     #[cfg(feature = "block-padding")]
     #[inline]
-    fn encrypt_padded_inout_mut<'out, P: Padding<Self::BlockSize>>(
+    fn encrypt_padded_inout<'out, P: Padding<Self::BlockSize>>(
         mut self,
         data: InOutBufReserved<'_, 'out, u8>,
     ) -> Result<&'out [u8], PadError> {
         let mut buf = data.into_padded_blocks::<P, Self::BlockSize>()?;
-        self.encrypt_blocks_inout_mut(buf.get_blocks());
+        self.encrypt_blocks_inout(buf.get_blocks());
         if let Some(block) = buf.get_tail_block() {
-            self.encrypt_block_inout_mut(block);
+            self.encrypt_block_inout(block);
         }
         Ok(buf.into_out())
     }
@@ -388,13 +388,13 @@ pub trait BlockModeEncrypt: BlockSizeUser + Sized {
     /// Returns [`PadError`] if length of output buffer is not sufficient.
     #[cfg(feature = "block-padding")]
     #[inline]
-    fn encrypt_padded_mut<P: Padding<Self::BlockSize>>(
+    fn encrypt_padded<P: Padding<Self::BlockSize>>(
         self,
         buf: &mut [u8],
         msg_len: usize,
     ) -> Result<&[u8], PadError> {
         let buf = InOutBufReserved::from_mut_slice(buf, msg_len).map_err(|_| PadError)?;
-        self.encrypt_padded_inout_mut::<P>(buf)
+        self.encrypt_padded_inout::<P>(buf)
     }
 
     /// Pad input and encrypt buffer-to-buffer. Returns resulting ciphertext slice.
@@ -402,22 +402,22 @@ pub trait BlockModeEncrypt: BlockSizeUser + Sized {
     /// Returns [`PadError`] if length of output buffer is not sufficient.
     #[cfg(feature = "block-padding")]
     #[inline]
-    fn encrypt_padded_b2b_mut<'a, P: Padding<Self::BlockSize>>(
+    fn encrypt_padded_b2b<'a, P: Padding<Self::BlockSize>>(
         self,
         msg: &[u8],
         out_buf: &'a mut [u8],
     ) -> Result<&'a [u8], PadError> {
         let buf = InOutBufReserved::from_slices(msg, out_buf).map_err(|_| PadError)?;
-        self.encrypt_padded_inout_mut::<P>(buf)
+        self.encrypt_padded_inout::<P>(buf)
     }
 
     /// Pad input and encrypt into a newly allocated Vec. Returns resulting ciphertext Vec.
     #[cfg(all(feature = "block-padding", feature = "alloc"))]
     #[inline]
-    fn encrypt_padded_vec_mut<P: Padding<Self::BlockSize>>(self, msg: &[u8]) -> Vec<u8> {
+    fn encrypt_padded_vec<P: Padding<Self::BlockSize>>(self, msg: &[u8]) -> Vec<u8> {
         let mut out = allocate_out_vec::<Self>(msg.len());
         let len = self
-            .encrypt_padded_b2b_mut::<P>(msg, &mut out)
+            .encrypt_padded_b2b::<P>(msg, &mut out)
             .expect("enough space for encrypting is allocated")
             .len();
         out.truncate(len);
@@ -432,39 +432,39 @@ pub trait BlockModeEncrypt: BlockSizeUser + Sized {
 /// underlying hardware peripheral.
 pub trait BlockModeDecrypt: BlockSizeUser + Sized {
     /// Decrypt data using backend provided to the rank-2 closure.
-    fn decrypt_with_backend_mut(&mut self, f: impl BlockClosure<BlockSize = Self::BlockSize>);
+    fn decrypt_with_backend(&mut self, f: impl BlockClosure<BlockSize = Self::BlockSize>);
 
     /// Decrypt single `inout` block.
     #[inline]
-    fn decrypt_block_inout_mut(&mut self, block: InOut<'_, '_, Block<Self>>) {
-        self.decrypt_with_backend_mut(BlockCtx { block });
+    fn decrypt_block_inout(&mut self, block: InOut<'_, '_, Block<Self>>) {
+        self.decrypt_with_backend(BlockCtx { block });
     }
 
     /// Decrypt `inout` blocks.
     #[inline]
-    fn decrypt_blocks_inout_mut(&mut self, blocks: InOutBuf<'_, '_, Block<Self>>) {
-        self.decrypt_with_backend_mut(BlocksCtx { blocks });
+    fn decrypt_blocks_inout(&mut self, blocks: InOutBuf<'_, '_, Block<Self>>) {
+        self.decrypt_with_backend(BlocksCtx { blocks });
     }
 
     /// Decrypt single block in-place.
     #[inline]
-    fn decrypt_block_mut(&mut self, block: &mut Block<Self>) {
+    fn decrypt_block(&mut self, block: &mut Block<Self>) {
         let block = block.into();
-        self.decrypt_with_backend_mut(BlockCtx { block });
+        self.decrypt_with_backend(BlockCtx { block });
     }
 
     /// Decrypt `in_block` and write result to `out_block`.
     #[inline]
-    fn decrypt_block_b2b_mut(&mut self, in_block: &Block<Self>, out_block: &mut Block<Self>) {
+    fn decrypt_block_b2b(&mut self, in_block: &Block<Self>, out_block: &mut Block<Self>) {
         let block = (in_block, out_block).into();
-        self.decrypt_with_backend_mut(BlockCtx { block });
+        self.decrypt_with_backend(BlockCtx { block });
     }
 
     /// Decrypt blocks in-place.
     #[inline]
-    fn decrypt_blocks_mut(&mut self, blocks: &mut [Block<Self>]) {
+    fn decrypt_blocks(&mut self, blocks: &mut [Block<Self>]) {
         let blocks = blocks.into();
-        self.decrypt_with_backend_mut(BlocksCtx { blocks });
+        self.decrypt_with_backend(BlocksCtx { blocks });
     }
 
     /// Decrypt blocks buffer-to-buffer.
@@ -472,13 +472,13 @@ pub trait BlockModeDecrypt: BlockSizeUser + Sized {
     /// Returns [`NotEqualError`] if provided `in_blocks` and `out_blocks`
     /// have different lengths.
     #[inline]
-    fn decrypt_blocks_b2b_mut(
+    fn decrypt_blocks_b2b(
         &mut self,
         in_blocks: &[Block<Self>],
         out_blocks: &mut [Block<Self>],
     ) -> Result<(), NotEqualError> {
         InOutBuf::new(in_blocks, out_blocks)
-            .map(|blocks| self.decrypt_with_backend_mut(BlocksCtx { blocks }))
+            .map(|blocks| self.decrypt_with_backend(BlocksCtx { blocks }))
     }
 
     /// Decrypt input and unpad it. Returns resulting ciphertext slice.
@@ -487,7 +487,7 @@ pub trait BlockModeDecrypt: BlockSizeUser + Sized {
     /// not multiple of `Self::BlockSize`.
     #[cfg(feature = "block-padding")]
     #[inline]
-    fn decrypt_padded_inout_mut<'out, P: Padding<Self::BlockSize>>(
+    fn decrypt_padded_inout<'out, P: Padding<Self::BlockSize>>(
         mut self,
         data: InOutBuf<'_, 'out, u8>,
     ) -> Result<&'out [u8], UnpadError> {
@@ -495,7 +495,7 @@ pub trait BlockModeDecrypt: BlockSizeUser + Sized {
         if !tail.is_empty() {
             return Err(UnpadError);
         }
-        self.decrypt_blocks_inout_mut(blocks.reborrow());
+        self.decrypt_blocks_inout(blocks.reborrow());
         P::unpad_blocks(blocks.into_out())
     }
 
@@ -505,11 +505,11 @@ pub trait BlockModeDecrypt: BlockSizeUser + Sized {
     /// not multiple of `Self::BlockSize`.
     #[cfg(feature = "block-padding")]
     #[inline]
-    fn decrypt_padded_mut<P: Padding<Self::BlockSize>>(
+    fn decrypt_padded<P: Padding<Self::BlockSize>>(
         self,
         buf: &mut [u8],
     ) -> Result<&[u8], UnpadError> {
-        self.decrypt_padded_inout_mut::<P>(buf.into())
+        self.decrypt_padded_inout::<P>(buf.into())
     }
 
     /// Decrypt input and unpad it buffer-to-buffer. Returns resulting
@@ -519,7 +519,7 @@ pub trait BlockModeDecrypt: BlockSizeUser + Sized {
     /// not multiple of `Self::BlockSize`.
     #[cfg(feature = "block-padding")]
     #[inline]
-    fn decrypt_padded_b2b_mut<'a, P: Padding<Self::BlockSize>>(
+    fn decrypt_padded_b2b<'a, P: Padding<Self::BlockSize>>(
         self,
         in_buf: &[u8],
         out_buf: &'a mut [u8],
@@ -530,7 +530,7 @@ pub trait BlockModeDecrypt: BlockSizeUser + Sized {
         let n = in_buf.len();
         // note: `new` always returns `Ok` here
         let buf = InOutBuf::new(in_buf, &mut out_buf[..n]).map_err(|_| UnpadError)?;
-        self.decrypt_padded_inout_mut::<P>(buf)
+        self.decrypt_padded_inout::<P>(buf)
     }
 
     /// Decrypt input and unpad it in a newly allocated Vec. Returns resulting
@@ -540,12 +540,12 @@ pub trait BlockModeDecrypt: BlockSizeUser + Sized {
     /// not multiple of `Self::BlockSize`.
     #[cfg(all(feature = "block-padding", feature = "alloc"))]
     #[inline]
-    fn decrypt_padded_vec_mut<P: Padding<Self::BlockSize>>(
+    fn decrypt_padded_vec<P: Padding<Self::BlockSize>>(
         self,
         buf: &[u8],
     ) -> Result<Vec<u8>, UnpadError> {
         let mut out = vec![0; buf.len()];
-        let len = self.decrypt_padded_b2b_mut::<P>(buf, &mut out)?.len();
+        let len = self.decrypt_padded_b2b::<P>(buf, &mut out)?.len();
         out.truncate(len);
         Ok(out)
     }

--- a/cipher/src/block.rs
+++ b/cipher/src/block.rs
@@ -78,7 +78,7 @@ pub trait BlockClosure: BlockSizeUser {
 }
 
 /// Encrypt-only functionality for block ciphers.
-pub trait BlockEncrypt: BlockSizeUser + Sized {
+pub trait BlockCipherEncrypt: BlockSizeUser + Sized {
     /// Encrypt data using backend provided to the rank-2 closure.
     fn encrypt_with_backend(&self, f: impl BlockClosure<BlockSize = Self::BlockSize>);
 
@@ -189,7 +189,7 @@ pub trait BlockEncrypt: BlockSizeUser + Sized {
 }
 
 /// Decrypt-only functionality for block ciphers.
-pub trait BlockDecrypt: BlockSizeUser {
+pub trait BlockCipherDecrypt: BlockSizeUser {
     /// Decrypt data using backend provided to the rank-2 closure.
     fn decrypt_with_backend(&self, f: impl BlockClosure<BlockSize = Self::BlockSize>);
 
@@ -315,7 +315,7 @@ pub trait BlockDecrypt: BlockSizeUser {
 /// The main use case for this trait is blocks modes, but it also can be used
 /// for hardware cryptographic engines which require `&mut self` access to an
 /// underlying hardware peripheral.
-pub trait BlockEncryptMut: BlockSizeUser + Sized {
+pub trait BlockModeEncrypt: BlockSizeUser + Sized {
     /// Encrypt data using backend provided to the rank-2 closure.
     fn encrypt_with_backend_mut(&mut self, f: impl BlockClosure<BlockSize = Self::BlockSize>);
 
@@ -430,7 +430,7 @@ pub trait BlockEncryptMut: BlockSizeUser + Sized {
 /// The main use case for this trait is blocks modes, but it also can be used
 /// for hardware cryptographic engines which require `&mut self` access to an
 /// underlying hardware peripheral.
-pub trait BlockDecryptMut: BlockSizeUser + Sized {
+pub trait BlockModeDecrypt: BlockSizeUser + Sized {
     /// Decrypt data using backend provided to the rank-2 closure.
     fn decrypt_with_backend_mut(&mut self, f: impl BlockClosure<BlockSize = Self::BlockSize>);
 
@@ -551,27 +551,15 @@ pub trait BlockDecryptMut: BlockSizeUser + Sized {
     }
 }
 
-impl<Alg: BlockEncrypt> BlockEncryptMut for Alg {
-    fn encrypt_with_backend_mut(&mut self, f: impl BlockClosure<BlockSize = Self::BlockSize>) {
-        self.encrypt_with_backend(f);
-    }
-}
-
-impl<Alg: BlockDecrypt> BlockDecryptMut for Alg {
-    fn decrypt_with_backend_mut(&mut self, f: impl BlockClosure<BlockSize = Self::BlockSize>) {
-        self.decrypt_with_backend(f);
-    }
-}
-
 impl<Alg: BlockCipher> BlockCipher for &Alg {}
 
-impl<Alg: BlockEncrypt> BlockEncrypt for &Alg {
+impl<Alg: BlockCipherEncrypt> BlockCipherEncrypt for &Alg {
     fn encrypt_with_backend(&self, f: impl BlockClosure<BlockSize = Self::BlockSize>) {
         Alg::encrypt_with_backend(self, f);
     }
 }
 
-impl<Alg: BlockDecrypt> BlockDecrypt for &Alg {
+impl<Alg: BlockCipherDecrypt> BlockCipherDecrypt for &Alg {
     fn decrypt_with_backend(&self, f: impl BlockClosure<BlockSize = Self::BlockSize>) {
         Alg::decrypt_with_backend(self, f);
     }
@@ -638,7 +626,7 @@ macro_rules! impl_simple_block_encdec {
             type BlockSize = $block_size;
         }
 
-        impl<$($N$(:$b0$(+$b)*)?),*> $crate::BlockEncrypt for $cipher<$($N),*> {
+        impl<$($N$(:$b0$(+$b)*)?),*> $crate:BlockEncryptt for $cipher<$($N),*> {
             fn encrypt_with_backend(&self, f: impl $crate::BlockClosure<BlockSize = $block_size>) {
                 struct EncBack<'a, $($N$(:$b0$(+$b)*)?),* >(&'a $cipher<$($N),*>);
 
@@ -665,7 +653,7 @@ macro_rules! impl_simple_block_encdec {
             }
         }
 
-        impl<$($N$(:$b0$(+$b)*)?),*> $crate::BlockDecrypt for $cipher<$($N),*> {
+        impl<$($N$(:$b0$(+$b)*)?),*> $crate:BlockDecryptt for $cipher<$($N),*> {
             fn decrypt_with_backend(&self, f: impl $crate::BlockClosure<BlockSize = $block_size>) {
                 struct DecBack<'a, $($N$(:$b0$(+$b)*)?),* >(&'a $cipher<$($N),*>);
 

--- a/cipher/src/stream.rs
+++ b/cipher/src/stream.rs
@@ -5,7 +5,7 @@
 
 use crate::errors::{OverflowError, StreamCipherError};
 use crate::stream_core::Counter;
-use crate::{Block, BlockDecryptMut, BlockEncryptMut};
+use crate::{Block, BlockModeDecrypt, BlockModeEncrypt};
 use inout::{InOutBuf, NotEqualError};
 
 /// Marker trait for block-level asynchronous stream ciphers
@@ -13,7 +13,7 @@ pub trait AsyncStreamCipher: Sized {
     /// Encrypt data using `InOutBuf`.
     fn encrypt_inout(mut self, data: InOutBuf<'_, '_, u8>)
     where
-        Self: BlockEncryptMut,
+        Self: BlockModeEncrypt,
     {
         let (blocks, mut tail) = data.into_chunks();
         self.encrypt_blocks_inout_mut(blocks);
@@ -29,7 +29,7 @@ pub trait AsyncStreamCipher: Sized {
     /// Decrypt data using `InOutBuf`.
     fn decrypt_inout(mut self, data: InOutBuf<'_, '_, u8>)
     where
-        Self: BlockDecryptMut,
+        Self: BlockModeDecrypt,
     {
         let (blocks, mut tail) = data.into_chunks();
         self.decrypt_blocks_inout_mut(blocks);
@@ -44,7 +44,7 @@ pub trait AsyncStreamCipher: Sized {
     /// Encrypt data in place.
     fn encrypt(self, buf: &mut [u8])
     where
-        Self: BlockEncryptMut,
+        Self: BlockModeEncrypt,
     {
         self.encrypt_inout(buf.into());
     }
@@ -52,7 +52,7 @@ pub trait AsyncStreamCipher: Sized {
     /// Decrypt data in place.
     fn decrypt(self, buf: &mut [u8])
     where
-        Self: BlockDecryptMut,
+        Self: BlockModeDecrypt,
     {
         self.decrypt_inout(buf.into());
     }
@@ -60,7 +60,7 @@ pub trait AsyncStreamCipher: Sized {
     /// Encrypt data from buffer to buffer.
     fn encrypt_b2b(self, in_buf: &[u8], out_buf: &mut [u8]) -> Result<(), NotEqualError>
     where
-        Self: BlockEncryptMut,
+        Self: BlockModeEncrypt,
     {
         InOutBuf::new(in_buf, out_buf).map(|b| self.encrypt_inout(b))
     }
@@ -68,7 +68,7 @@ pub trait AsyncStreamCipher: Sized {
     /// Decrypt data from buffer to buffer.
     fn decrypt_b2b(self, in_buf: &[u8], out_buf: &mut [u8]) -> Result<(), NotEqualError>
     where
-        Self: BlockDecryptMut,
+        Self: BlockModeDecrypt,
     {
         InOutBuf::new(in_buf, out_buf).map(|b| self.decrypt_inout(b))
     }

--- a/cipher/src/stream.rs
+++ b/cipher/src/stream.rs
@@ -16,12 +16,12 @@ pub trait AsyncStreamCipher: Sized {
         Self: BlockModeEncrypt,
     {
         let (blocks, mut tail) = data.into_chunks();
-        self.encrypt_blocks_inout_mut(blocks);
+        self.encrypt_blocks_inout(blocks);
         let n = tail.len();
         if n != 0 {
             let mut block = Block::<Self>::default();
             block[..n].copy_from_slice(tail.get_in());
-            self.encrypt_block_mut(&mut block);
+            self.encrypt_block(&mut block);
             tail.get_out().copy_from_slice(&block[..n]);
         }
     }
@@ -32,12 +32,12 @@ pub trait AsyncStreamCipher: Sized {
         Self: BlockModeDecrypt,
     {
         let (blocks, mut tail) = data.into_chunks();
-        self.decrypt_blocks_inout_mut(blocks);
+        self.decrypt_blocks_inout(blocks);
         let n = tail.len();
         if n != 0 {
             let mut block = Block::<Self>::default();
             block[..n].copy_from_slice(tail.get_in());
-            self.decrypt_block_mut(&mut block);
+            self.decrypt_block(&mut block);
             tail.get_out().copy_from_slice(&block[..n]);
         }
     }


### PR DESCRIPTION
Renames the following traits:

- `BlockEncrypt` => `BlockCipherEncrypt`
- `BlockDecrypt` => `BlockCipherDecrypt`
- `BlockEncryptMut` => `BlockModeEncrypt`
- `BlockDecryptMut` => `BlockModeDecrypt`

As originally suggested in this comment:

https://github.com/RustCrypto/block-modes/pull/14#issuecomment-1073304690

This better reflects how these traits are actually used, i.e. `BlockCipher*` is used by ciphers, and `BlockMode*` is used by their modes of operation.