### PR TITLE
crypto-common v0.2.0-pre.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
  "arrayvec",
  "blobby",
  "bytes",
- "crypto-common 0.2.0-pre.4",
+ "crypto-common 0.2.0-pre.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "heapless",
 ]
 
@@ -132,11 +132,11 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.11.0-pre.4"
+version = "0.11.0-pre.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0edadbde8e0243b49d434f9a23ec0590af201f400a34d7d51049284e4a77c568"
+checksum = "3ded684142010808eb980d9974ef794da2bcf97d13396143b1515e9f0fb4a10e"
 dependencies = [
- "crypto-common 0.2.0-pre.4",
+ "crypto-common 0.2.0-pre.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "zeroize",
 ]
 
@@ -226,7 +226,7 @@ name = "cipher"
 version = "0.5.0-pre.2"
 dependencies = [
  "blobby",
- "crypto-common 0.2.0-pre.4",
+ "crypto-common 0.2.0-pre.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "inout 0.2.0-pre.4",
  "zeroize",
 ]
@@ -334,7 +334,18 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.0-pre.4"
+version = "0.2.0-pre.5"
+dependencies = [
+ "getrandom",
+ "hybrid-array",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.0-pre.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7aa2ec04f5120b830272a481e8d9d8ba4dda140d2cda59b0f1110d5eb93c38e"
 dependencies = [
  "getrandom",
  "hybrid-array",
@@ -437,9 +448,9 @@ name = "digest"
 version = "0.11.0-pre.7"
 dependencies = [
  "blobby",
- "block-buffer 0.11.0-pre.4",
+ "block-buffer 0.11.0-pre.5",
  "const-oid 0.10.0-pre.2",
- "crypto-common 0.2.0-pre.4",
+ "crypto-common 0.2.0-pre.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "subtle",
  "zeroize",
 ]
@@ -1328,7 +1339,7 @@ dependencies = [
 name = "universal-hash"
 version = "0.6.0-pre"
 dependencies = [
- "crypto-common 0.2.0-pre.4",
+ "crypto-common 0.2.0-pre.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "subtle",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ members = [
 ]
 
 [patch.crates-io]
-crypto-common = { path = "./crypto-common" }
 digest = { path = "./digest" }
 signature = { path = "./signature" }
 sha2 = { git = "https://github.com/RustCrypto/hashes.git" }

--- a/aead/Cargo.toml
+++ b/aead/Cargo.toml
@@ -16,7 +16,7 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.65"
 
 [dependencies]
-crypto-common = "=0.2.0-pre.4"
+crypto-common = "=0.2.0-pre.5"
 
 # optional dependencies
 arrayvec = { version = "0.7", optional = true, default-features = false }

--- a/cipher/Cargo.toml
+++ b/cipher/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["crypto", "block-cipher", "stream-cipher", "trait"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-crypto-common = "=0.2.0-pre.4"
+crypto-common = "=0.2.0-pre.5"
 inout = "=0.2.0-pre.4"
 
 # optional dependencies

--- a/crypto-common/Cargo.toml
+++ b/crypto-common/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "crypto-common"
 description = "Common cryptographic traits"
-version = "0.2.0-pre.4"
+version = "0.2.0-pre.5"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/digest/Cargo.toml
+++ b/digest/Cargo.toml
@@ -13,10 +13,10 @@ keywords = ["digest", "crypto", "hash"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-crypto-common = "=0.2.0-pre.4"
+crypto-common = "=0.2.0-pre.5"
 
 # optional dependencies
-block-buffer = { version = "=0.11.0-pre.4", optional = true }
+block-buffer = { version = "=0.11.0-pre.5", optional = true }
 subtle = { version = "2.4", default-features = false, optional = true }
 blobby = { version = "0.3", optional = true }
 const-oid = { version = "=0.10.0-pre.2", optional = true }

--- a/universal-hash/Cargo.toml
+++ b/universal-hash/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["crypto", "mac"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-crypto-common = "=0.2.0-pre.4"
+crypto-common = "=0.2.0-pre.5"
 subtle = { version = "2.4", default-features = false }
 
 [features]


### PR DESCRIPTION
These sorts of releases are a bit tricky due to the circular dependency of `block-buffer` on `crypto-common`