### PR TITLE
cipher: fixup `block_{encryptor,decryptor}_bench`

### DIFF
--- a/cipher/src/dev/block.rs
+++ b/cipher/src/dev/block.rs
@@ -289,7 +289,8 @@ macro_rules! block_encryptor_bench {
     ($init:block, $cipher:ty, $block_name:ident, $blocks_name:ident $(,)? ) => {
         #[bench]
         pub fn $block_name(bh: &mut test::Bencher) {
-            use cipher::BlockCipherEncrypt;
+            #[allow(unused)]
+            use cipher::{BlockCipherEncrypt, BlockModeEncrypt};
 
             let mut cipher = $init;
             let mut blocks = vec![Default::default(); 1024];
@@ -305,7 +306,8 @@ macro_rules! block_encryptor_bench {
 
         #[bench]
         pub fn $blocks_name(bh: &mut test::Bencher) {
-            use cipher::BlockCipherEncrypt;
+            #[allow(unused)]
+            use cipher::{BlockCipherEncrypt, BlockModeEncrypt};
 
             let mut cipher = $init;
             let mut blocks = vec![Default::default(); 1024];
@@ -350,7 +352,8 @@ macro_rules! block_decryptor_bench {
     ($init:block, $cipher:ty, $block_name:ident, $blocks_name:ident $(,)? ) => {
         #[bench]
         pub fn $block_name(bh: &mut test::Bencher) {
-            use cipher::BlockCipherDecrypt;
+            #[allow(unused)]
+            use cipher::{BlockCipherDecrypt, BlockModeDecrypt};
 
             let mut cipher = $init;
             let mut blocks = vec![Default::default(); 1024];
@@ -366,7 +369,8 @@ macro_rules! block_decryptor_bench {
 
         #[bench]
         pub fn $blocks_name(bh: &mut test::Bencher) {
-            use cipher::BlockCipherDecrypt;
+            #[allow(unused)]
+            use cipher::{BlockCipherDecrypt, BlockModeDecrypt};
 
             let mut cipher = $init;
             let mut blocks = vec![Default::default(); 1024];


### PR DESCRIPTION
Those benchmark macros are reused for both `block-ciphers` and `block-modes`. We need to import both `BlockMode` and `BlockCipher` for them to work.