### PR TITLE
Remove redundant imports

### DIFF
--- a/elliptic-curve/src/dev.rs
+++ b/elliptic-curve/src/dev.rs
@@ -8,7 +8,6 @@ use crate::{
     bigint::{Limb, U256},
     error::{Error, Result},
     ops::{Invert, LinearCombination, MulByGenerator, Reduce, ShrAssign},
-    pkcs8,
     point::AffineCoordinates,
     rand_core::RngCore,
     scalar::{FromUintUnchecked, IsHigh},

--- a/elliptic-curve/src/error.rs
+++ b/elliptic-curve/src/error.rs
@@ -2,9 +2,6 @@
 
 use core::fmt::{self, Display};
 
-#[cfg(feature = "pkcs8")]
-use crate::pkcs8;
-
 /// Result type with the `elliptic-curve` crate's [`Error`] type.
 pub type Result<T> = core::result::Result<T, Error>;
 

--- a/elliptic-curve/src/hash2curve/hash2field/expand_msg/xof.rs
+++ b/elliptic-curve/src/hash2curve/hash2field/expand_msg/xof.rs
@@ -65,10 +65,7 @@ mod test {
     use super::*;
     use core::mem;
     use hex_literal::hex;
-    use hybrid_array::{
-        typenum::{U128, U32},
-        Array, ArraySize,
-    };
+    use hybrid_array::{typenum::U128, Array, ArraySize};
     use sha3::Shake128;
 
     fn assert_message(msg: &[u8], domain: &Domain<'_, U32>, len_in_bytes: u16, bytes: &[u8]) {

--- a/elliptic-curve/src/public_key.rs
+++ b/elliptic-curve/src/public_key.rs
@@ -43,10 +43,7 @@ use pkcs8::DecodePublicKey;
 
 #[cfg(all(feature = "sec1", feature = "pkcs8"))]
 use {
-    crate::{
-        pkcs8::{self, AssociatedOid},
-        ALGORITHM_OID,
-    },
+    crate::{pkcs8::AssociatedOid, ALGORITHM_OID},
     pkcs8::der,
 };
 

--- a/elliptic-curve/src/secret_key/pkcs8.rs
+++ b/elliptic-curve/src/secret_key/pkcs8.rs
@@ -2,7 +2,7 @@
 
 use super::SecretKey;
 use crate::{
-    pkcs8::{self, der::Decode, AssociatedOid},
+    pkcs8::{der::Decode, AssociatedOid},
     sec1::{ModulusSize, ValidatePublicKey},
     Curve, FieldBytesSize, ALGORITHM_OID,
 };

--- a/password-hash/src/output.rs
+++ b/password-hash/src/output.rs
@@ -1,11 +1,7 @@
 //! Outputs from password hashing functions.
 
 use crate::{Encoding, Error, Result};
-use core::{
-    cmp::{Ordering, PartialEq},
-    fmt,
-    str::FromStr,
-};
+use core::{cmp::Ordering, fmt, str::FromStr};
 use subtle::{Choice, ConstantTimeEq};
 
 /// Output from password hashing functions, i.e. the "hash" or "digest"

--- a/password-hash/src/params.rs
+++ b/password-hash/src/params.rs
@@ -7,7 +7,6 @@ use crate::{
 };
 use core::{
     fmt::{self, Debug, Write},
-    iter::FromIterator,
     str::{self, FromStr},
 };
 
@@ -328,7 +327,7 @@ impl Write for Buffer {
 
 #[cfg(test)]
 mod tests {
-    use super::{Error, FromIterator, Ident, ParamsString, Value};
+    use super::{Error, Ident, ParamsString, Value};
 
     #[cfg(feature = "alloc")]
     use alloc::string::ToString;


### PR DESCRIPTION
Recent nightlies warn for items which are imported redundantly, of which there were a few in the `elliptic-curve` and `password-hash` crates