### PR TITLE
build(deps) update stable from 2.4.0 to 2.5.0

### DIFF
--- a/digest/Cargo.toml
+++ b/digest/Cargo.toml
@@ -17,7 +17,7 @@ crypto-common = "=0.2.0-pre.5"
 
 # optional dependencies
 block-buffer = { version = "=0.11.0-pre.5", optional = true }
-subtle = { version = "2.4", default-features = false, optional = true }
+subtle = { version = "2.5", default-features = false, optional = true }
 blobby = { version = "0.3", optional = true }
 const-oid = { version = "=0.10.0-pre.2", optional = true }
 zeroize = { version = "1.7", optional = true, default-features = false }


### PR DESCRIPTION
Update stable from 2.4.0 to 2.5.0

Plenty of other project, specifically `rust-tls` has ported to `2.5.0` causing version conflicts with any users of the `digest` crate. 

Perhaps a minor patch can be released for it.