### PR TITLE
aead: fixup `hybrid-array` migration

### DIFF
--- a/aead/src/dev.rs
+++ b/aead/src/dev.rs
@@ -8,8 +8,8 @@ macro_rules! new_test {
         #[test]
         fn $name() {
             use aead::{
+                array::{typenum::Unsigned, Array},
                 dev::blobby::Blob6Iterator,
-                generic_array::{typenum::Unsigned, GenericArray},
                 Aead, KeyInit, Payload,
             };
 


### PR DESCRIPTION
This macro is pulled from `AEADs.git` crates.