### PR TITLE
digest: fixup imports for `hash_serialization_test` macro

### DIFF
--- a/digest/src/dev.rs
+++ b/digest/src/dev.rs
@@ -44,7 +44,7 @@ macro_rules! hash_serialization_test {
         #[test]
         fn $name() {
             use digest::{
-                crypto_common::{BlockSizeUser, SerializableState},
+                crypto_common::{hazmat::SerializableState, BlockSizeUser},
                 typenum::Unsigned,
                 Digest,
             };

--- a/digest/src/dev.rs
+++ b/digest/src/dev.rs
@@ -77,7 +77,7 @@ macro_rules! hash_rt_outsize_serialization_test {
         #[test]
         fn $name() {
             use digest::{
-                crypto_common::{BlockSizeUser, SerializableState},
+                crypto_common::{hazmat::SerializableState, BlockSizeUser},
                 typenum::Unsigned,
                 Digest, Update, VariableOutput,
             };


### PR DESCRIPTION
This fixes #1487 which moed the `SerialiationState` to `hazmat` submodule