### PR TITLE
async-signature: add CHANGELOG.md entry for v0.5.1

### DIFF
--- a/async-signature/CHANGELOG.md
+++ b/async-signature/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.5.1 (2024-04-02)
+### Added
+- `no_std` support ([#1544])
+
+[#1544]: https://github.com/RustCrypto/traits/pull/1544
+
 ## 0.5.0 (2024-01-02)
 ### Added
 - Debug impls ([#1407])


### PR DESCRIPTION
It contains a backport of #1544.

Tagged as https://github.com/RustCrypto/traits/tree/async-signature-v0.5.1