### PR TITLE
Extends JWK implementation to include optional fields

### DIFF
--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -33,13 +33,14 @@ hex-literal = { version = "0.4", optional = true }
 pem-rfc7468 = { version = "=1.0.0-pre.0", optional = true, features = ["alloc"] }
 pkcs8 = { version = "=0.11.0-pre.0", optional = true, default-features = false }
 sec1 = { version = "=0.8.0-pre.1", optional = true, features = ["subtle", "zeroize"] }
-serdect = { version = "=0.3.0-pre.0", optional = true, default-features = false, features = ["alloc"] }
+#serdect = { version = "=0.3.0-pre.0", optional = true, default-features = false, features = ["alloc"] }
+serdect = { git="https://github.com/rustcrypto/formats.git", optional = true, default-features = false, features = ["alloc", "derive"] }
 serde_json = { version = "1.0.114", optional = true, default-features = false, features = ["alloc"] }
+sha2 = "=0.11.0-pre.3"
 tap = { version = "1.0.1", optional = true, default-features = false } # hack for minimal-versions support for `bits`
 
 [dev-dependencies]
 hex-literal = "0.4"
-sha2 = "=0.11.0-pre.3"
 sha3 = "=0.11.0-pre.3"
 
 [features]


### PR DESCRIPTION
The intent is to provide access to the additional fields that a JWK may contain to avoid re-processing the JWK file to get at that data.

This MR will need to wait for the next release of serdect (for serde derive features) and I think elliptic-curves needs updating to make it usable? (at least the master branch emits a load of primeorder related missing trait implementations).

The main change is to add the optional fields to the JwkEcKey struct and make all fields public. I replaced the custom (de)serializer to use the derive based one, it should now be order agnostic but still enforce "EC" key types. It should also cope with any additional fields gracefully - non-standard fields would still need to be decoded separately.

I have also added in a thumbprint method which is very useful.

