### PR TITLE
Bump subtle to 2.5 in digest

### DIFF
--- a/digest/Cargo.toml
+++ b/digest/Cargo.toml
@@ -17,7 +17,7 @@ crypto-common = "=0.2.0-pre.5"
 
 # optional dependencies
 block-buffer = { version = "=0.11.0-pre.5", optional = true }
-subtle = { version = "2.4", default-features = false, optional = true }
+subtle = { version = "2.5", default-features = false, optional = true }
 blobby = { version = "0.3", optional = true }
 const-oid = { version = "=0.10.0-pre.2", optional = true }
 zeroize = { version = "1.7", optional = true, default-features = false }


### PR DESCRIPTION
This is conflicting in one of my projects which needs `tonic = 0.11` which requires `subtle = 2.5`


```
error: failed to select a version for `subtle`.
    ... required by package `digest v0.10.7`
    ... which satisfies dependency `digest = "^0.10.7"` (locked to 0.10.7) of package `md-5 v0.10.6`
    ... which satisfies dependency `md-5 = "^0.10.6"` (locked to 0.10.6) of package `object_store v0.9.1`
    ... which satisfies dependency `object_store = "^0.9.0"` (locked to 0.9.1) of package `spiced v0.11.0-alpha (/Users/phillip/code/spiceai/spiceai/bin/spiced)`
versions that meet the requirements `^2.4` (locked to 2.4.1) are: 2.4.1

all possible versions conflict with previously selected packages.

  previously selected package `subtle v2.5.0`
    ... which satisfies dependency `subtle = "^2.5.0"` of package `rustls v0.22.3`
    ... which satisfies dependency `rustls = "^0.22"` (locked to 0.22.3) of package `tokio-rustls v0.25.0`
    ... which satisfies dependency `tokio-rustls = "^0.25"` (locked to 0.25.0) of package `tonic v0.11.0`
    ... which satisfies dependency `tonic = "^0.11.0"` (locked to 0.11.0) of package `flightpublisher v0.11.0-alpha (/Users/phillip/code/spiceai/spiceai/tools/flightpublisher)`

failed to select a version for `subtle` which could resolve this conflict
```