### PR TITLE
Add kem trait impls when ECDH is supported

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -552,6 +552,7 @@ dependencies = [
  "hex-literal",
  "hkdf 0.13.0-pre.3",
  "hybrid-array",
+ "kem 0.3.0-pre.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pem-rfc7468 1.0.0-pre.0",
  "pkcs8 0.11.0-pre.0",
  "rand_core 0.6.4",
@@ -841,6 +842,16 @@ dependencies = [
  "rand",
  "rand_core 0.6.4",
  "x3dh-ke",
+ "zeroize",
+]
+
+[[package]]
+name = "kem"
+version = "0.3.0-pre.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b8645470337db67b01a7f966decf7d0bafedbae74147d33e641c67a91df239f"
+dependencies = [
+ "rand_core 0.6.4",
  "zeroize",
 ]
 

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -19,6 +19,7 @@ rust-version = "1.73"
 base16ct = "0.2"
 crypto-bigint = { version = "=0.6.0-pre.12", default-features = false, features = ["rand_core", "hybrid-array", "zeroize"] }
 hybrid-array = { version = "0.2.0-rc.8", default-features = false, features = ["zeroize"] }
+kem = { version = "=0.3.0-pre.0", optional = true }
 rand_core = { version = "0.6.4", default-features = false }
 subtle = { version = "2", default-features = false }
 zeroize = { version = "1.7", default-features = false }
@@ -64,6 +65,7 @@ bits = ["arithmetic", "ff/bits", "dep:tap"]
 dev = ["arithmetic", "dep:hex-literal", "pem", "pkcs8"]
 hash2curve = ["arithmetic", "digest"]
 ecdh = ["arithmetic", "digest", "dep:hkdf"]
+ecdh-kem = ["ecdh", "kem"]
 group = ["dep:group", "ff"]
 hazmat = []
 jwk = ["dep:base64ct", "dep:serde_json", "alloc", "serde", "zeroize/alloc"]

--- a/elliptic-curve/src/ecdh_kem.rs
+++ b/elliptic-curve/src/ecdh_kem.rs
@@ -18,8 +18,8 @@
 //!    "encapsulated" [`PublicKey`] returned by the server and uses the resulting
 //!    [`SharedSecret`]
 
-use crate::{CurveArithmetic, PublicKey};
 use crate::ecdh::{EphemeralSecret, SharedSecret};
+use crate::{CurveArithmetic, PublicKey};
 use kem::{Decapsulate, Encapsulate};
 
 impl<C> Decapsulate<PublicKey<C>, SharedSecret<C>> for EphemeralSecret<C>
@@ -39,7 +39,10 @@ where
 {
     type Error = ();
 
-    fn encapsulate(&self, rng: &mut impl rand_core::CryptoRngCore) -> Result<(PublicKey<C>, SharedSecret<C>), Self::Error> {
+    fn encapsulate(
+        &self,
+        rng: &mut impl rand_core::CryptoRngCore,
+    ) -> Result<(PublicKey<C>, SharedSecret<C>), Self::Error> {
         // generate another ephemeral ecdh secret
         let secret = EphemeralSecret::<C>::random(rng);
         let pk = secret.public_key();

--- a/elliptic-curve/src/ecdh_kem.rs
+++ b/elliptic-curve/src/ecdh_kem.rs
@@ -1,0 +1,50 @@
+//! # ECDH as a KEM
+//!
+//! This module turns the existing ECDH implementation into a suitable KEM by
+//! modeling encapsulation of `g^x` as the generation of another ephemeral secret
+//! `y`, computing the encapsulated ciphertext as `g^y`, and computing the shared
+//! secret `g^xy`. Decapsulation of `x` is modelled as computing the shared secret
+//! `g^xy` from `g^y`.
+//!
+//! # ECDH-KEM Usage
+//!
+//! ECDH-KEM allows for an unauthenticated key agreement protocol as follows
+//!
+//! 1. The client generates an [`EphemeralSecret`] value
+//! 2. The client sends the corresponding [`PublicKey`] for their secret
+//! 3. The server runs [`encapsulate`](Encapsulate::encapsulate) on the given
+//!    [`PublicKey`] and holds on to the resulting [`SharedSecret`]
+//! 4. The client runs [`decapsulate`](Decapsulate::decapsulate) on the
+//!    "encapsulated" [`PublicKey`] returned by the server and uses the resulting
+//!    [`SharedSecret`]
+
+use crate::{CurveArithmetic, PublicKey};
+use crate::ecdh::{EphemeralSecret, SharedSecret};
+use kem::{Decapsulate, Encapsulate};
+
+impl<C> Decapsulate<PublicKey<C>, SharedSecret<C>> for EphemeralSecret<C>
+where
+    C: CurveArithmetic,
+{
+    type Error = ();
+
+    fn decapsulate(&self, encapsulated_key: &PublicKey<C>) -> Result<SharedSecret<C>, Self::Error> {
+        Ok(self.diffie_hellman(encapsulated_key))
+    }
+}
+
+impl<C> Encapsulate<PublicKey<C>, SharedSecret<C>> for EphemeralSecret<C>
+where
+    C: CurveArithmetic,
+{
+    type Error = ();
+
+    fn encapsulate(&self, rng: &mut impl rand_core::CryptoRngCore) -> Result<(PublicKey<C>, SharedSecret<C>), Self::Error> {
+        // generate another ephemeral ecdh secret
+        let secret = EphemeralSecret::<C>::random(rng);
+        let pk = secret.public_key();
+        let ss = self.diffie_hellman(&pk);
+
+        Ok((pk, ss))
+    }
+}

--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -88,6 +88,8 @@ pub mod scalar;
 pub mod dev;
 #[cfg(feature = "ecdh")]
 pub mod ecdh;
+#[cfg(feature = "ecdh-kem")]
+pub mod ecdh_kem;
 #[cfg(feature = "hash2curve")]
 pub mod hash2curve;
 #[cfg(feature = "arithmetic")]


### PR DESCRIPTION
This will allow easy integration of the generic TLS 1.3 KEM combiner, since the current plan is to take any two KEMs that support Encapsulate/Decapsulate and combine them piecewise, and this turns the DH implementations into a KEM as described by TLS. I wonder if this should go into KEMs instead, however.