### PR TITLE
Add SimpleKEM and FullKEM traits to kem

### DIFF
--- a/kem/Cargo.toml
+++ b/kem/Cargo.toml
@@ -18,7 +18,7 @@ zeroize = { version = "1.7", default-features = false }
 
 [dev-dependencies]
 hpke = "0.10"
-p256 = { version = "0.9", features = ["ecdsa"] }
+p256 = { version = "0.9", features = ["ecdh", "ecdsa"] }
 pqcrypto = { version = "0.15", default-features = false, features = [
     "pqcrypto-saber",
 ] }

--- a/kem/src/lib.rs
+++ b/kem/src/lib.rs
@@ -41,6 +41,9 @@ pub trait KEM {
     /// The type that will implement [`Decapsulate`]
     type DecapsulatingKey: Decapsulate<Self::EncapsulatedKey, Self::SharedSecret>;
 
+    /// The public key produced by [`random_keypair`]
+    type PublicKey;
+
     /// The type that will implement [`Encapsulate`]
     type EncapsulatingKey: Encapsulate<Self::EncapsulatedKey, Self::SharedSecret>;
 
@@ -51,5 +54,5 @@ pub trait KEM {
     type SharedSecret;
 
     /// Generates a new (decapsulating key, encapsulating key) keypair for the KEM model
-    fn random_keypair(rng: &mut impl CryptoRngCore) -> (Self::DecapsulatingKey, Self::EncapsulatingKey);
+    fn random_keypair(rng: &mut impl CryptoRngCore) -> (Self::DecapsulatingKey, Self::PublicKey);
 }

--- a/kem/src/lib.rs
+++ b/kem/src/lib.rs
@@ -34,14 +34,37 @@ pub trait Decapsulate<EK, SS> {
     fn decapsulate(&self, encapsulated_key: &EK) -> Result<SS, Self::Error>;
 }
 
-/// This is a trait that all KEM models should implement, and should probably be promoted to the kem
-/// crate itself. It specifies the types of encapsulating and decapsulating keys created by key
-/// generation, the shared secret type, and the encapsulated key type
-pub trait KEM {
+/// This trait represents a simplified KEM model, where the encapsulating key and public key are the
+/// same type.
+pub trait SimpleKEM {
     /// The type that will implement [`Decapsulate`]
     type DecapsulatingKey: Decapsulate<Self::EncapsulatedKey, Self::SharedSecret>;
 
-    /// The public key produced by [`random_keypair`]
+    /// The type that will implement [`Encapsulate`]
+    type EncapsulatingKey: Encapsulate<Self::EncapsulatedKey, Self::SharedSecret>;
+
+    /// The type of the encapsulated key
+    type EncapsulatedKey;
+
+    /// The type of the shared secret
+    type SharedSecret;
+
+    /// Generates a new (decapsulating key, encapsulating key) keypair for the KEM model
+    fn random_keypair(
+        rng: &mut impl CryptoRngCore,
+    ) -> (Self::DecapsulatingKey, Self::EncapsulatingKey);
+}
+
+/// This is a trait that all KEM models should implement. It represents all the stages and types
+/// necessary for a KEM, from `KeyGen() -> (DecapsKey, PublicKey)`, `Encaps(EncapsulatingKey) ->
+/// (EncappedKey, SharedSecret)`, and `Decaps(EncappedKey) -> SharedSecret`. Promotion from
+/// [`PublicKey`](FullKEM::PublicKey) to [`EncapsulatingKey`](FullKEM::EncapsulatingKey) is context
+/// dependent.
+pub trait FullKEM {
+    /// The type that will implement [`Decapsulate`]
+    type DecapsulatingKey: Decapsulate<Self::EncapsulatedKey, Self::SharedSecret>;
+
+    /// The public key produced by [`random_keypair`](FullKEM::random_keypair)
     type PublicKey;
 
     /// The type that will implement [`Encapsulate`]
@@ -55,4 +78,16 @@ pub trait KEM {
 
     /// Generates a new (decapsulating key, encapsulating key) keypair for the KEM model
     fn random_keypair(rng: &mut impl CryptoRngCore) -> (Self::DecapsulatingKey, Self::PublicKey);
+}
+
+impl<K: SimpleKEM> FullKEM for K {
+    type DecapsulatingKey = K::DecapsulatingKey;
+    type PublicKey = K::EncapsulatingKey;
+    type EncapsulatingKey = K::EncapsulatingKey;
+    type EncapsulatedKey = K::EncapsulatedKey;
+    type SharedSecret = K::SharedSecret;
+
+    fn random_keypair(rng: &mut impl CryptoRngCore) -> (Self::DecapsulatingKey, Self::PublicKey) {
+        Self::random_keypair(rng)
+    }
 }

--- a/kem/src/lib.rs
+++ b/kem/src/lib.rs
@@ -33,3 +33,23 @@ pub trait Decapsulate<EK, SS> {
     /// Decapsulates the given encapsulated key
     fn decapsulate(&self, encapsulated_key: &EK) -> Result<SS, Self::Error>;
 }
+
+/// This is a trait that all KEM models should implement, and should probably be promoted to the kem
+/// crate itself. It specifies the types of encapsulating and decapsulating keys created by key
+/// generation, the shared secret type, and the encapsulated key type
+pub trait KEM {
+    /// The type that will implement [`Decapsulate`]
+    type DecapsulatingKey: Decapsulate<Self::EncapsulatedKey, Self::SharedSecret>;
+
+    /// The type that will implement [`Encapsulate`]
+    type EncapsulatingKey: Encapsulate<Self::EncapsulatedKey, Self::SharedSecret>;
+
+    /// The type of the encapsulated key
+    type EncapsulatedKey;
+
+    /// The type of the shared secret
+    type SharedSecret;
+
+    /// Generates a new (decapsulating key, encapsulating key) keypair for the KEM model
+    fn random_keypair(rng: &mut impl CryptoRngCore) -> (Self::DecapsulatingKey, Self::EncapsulatingKey);
+}

--- a/kem/src/lib.rs
+++ b/kem/src/lib.rs
@@ -34,6 +34,18 @@ pub trait Decapsulate<EK, SS> {
     fn decapsulate(&self, encapsulated_key: &EK) -> Result<SS, Self::Error>;
 }
 
+// Helper type alias for SimpleKEM encapsulate errors
+type SimpleEncapError<X> = <<X as SimpleKEM>::EncapsulatingKey as Encapsulate<
+    <X as SimpleKEM>::EncapsulatedKey,
+    <X as SimpleKEM>::SharedSecret,
+>>::Error;
+
+// Helper type alias for SimpleKEM decapsulate errors
+type SimpleDecapError<X> = <<X as SimpleKEM>::DecapsulatingKey as Decapsulate<
+    <X as SimpleKEM>::EncapsulatedKey,
+    <X as SimpleKEM>::SharedSecret,
+>>::Error;
+
 /// This trait represents a simplified KEM model, where the encapsulating key and public key are the
 /// same type.
 pub trait SimpleKEM {
@@ -58,10 +70,7 @@ pub trait SimpleKEM {
     fn encapsulate(
         ek: &Self::EncapsulatingKey,
         rng: &mut impl CryptoRngCore,
-    ) -> Result<
-        (Self::EncapsulatedKey, Self::SharedSecret),
-        <Self::EncapsulatingKey as Encapsulate<Self::EncapsulatedKey, Self::SharedSecret>>::Error,
-    > {
+    ) -> Result<(Self::EncapsulatedKey, Self::SharedSecret), SimpleEncapError<Self>> {
         ek.encapsulate(rng)
     }
 
@@ -69,13 +78,22 @@ pub trait SimpleKEM {
     fn decapsulate(
         dk: &Self::DecapsulatingKey,
         ek: &Self::EncapsulatedKey,
-    ) -> Result<
-        Self::SharedSecret,
-        <Self::DecapsulatingKey as Decapsulate<Self::EncapsulatedKey, Self::SharedSecret>>::Error,
-    > {
+    ) -> Result<Self::SharedSecret, SimpleDecapError<Self>> {
         dk.decapsulate(ek)
     }
 }
+
+// Helper type alias for FullKEM encapsulate errors
+type FullEncapError<X> = <<X as FullKEM>::EncapsulatingKey as Encapsulate<
+    <X as FullKEM>::EncapsulatedKey,
+    <X as FullKEM>::SharedSecret,
+>>::Error;
+
+// Helper type alias for FullKEM decapsulate errors
+type FullDecapError<X> = <<X as FullKEM>::DecapsulatingKey as Decapsulate<
+    <X as FullKEM>::EncapsulatedKey,
+    <X as FullKEM>::SharedSecret,
+>>::Error;
 
 /// This is a trait that all KEM models should implement. It represents all the stages and types
 /// necessary for a KEM.
@@ -116,10 +134,7 @@ pub trait FullKEM {
     fn encapsulate(
         ek: &Self::EncapsulatingKey,
         rng: &mut impl CryptoRngCore,
-    ) -> Result<
-        (Self::EncapsulatedKey, Self::SharedSecret),
-        <Self::EncapsulatingKey as Encapsulate<Self::EncapsulatedKey, Self::SharedSecret>>::Error,
-    > {
+    ) -> Result<(Self::EncapsulatedKey, Self::SharedSecret), FullEncapError<Self>> {
         ek.encapsulate(rng)
     }
 
@@ -127,10 +142,7 @@ pub trait FullKEM {
     fn decapsulate(
         dk: &Self::DecapsulatingKey,
         ek: &Self::EncapsulatedKey,
-    ) -> Result<
-        Self::SharedSecret,
-        <Self::DecapsulatingKey as Decapsulate<Self::EncapsulatedKey, Self::SharedSecret>>::Error,
-    > {
+    ) -> Result<Self::SharedSecret, FullDecapError<Self>> {
         dk.decapsulate(ek)
     }
 }

--- a/kem/tests/kemtrait_p256.rs
+++ b/kem/tests/kemtrait_p256.rs
@@ -1,0 +1,69 @@
+use kem::{Decapsulate, Encapsulate, KEM};
+use p256::{ecdh::{EphemeralSecret, SharedSecret}, PublicKey};
+use rand_core::CryptoRngCore;
+
+struct KemNistP256;
+struct DecapsulatorP256(EphemeralSecret);
+struct EncapsulatorP256(PublicKey);
+struct Secret(SharedSecret);
+
+impl Decapsulate<PublicKey, Secret> for DecapsulatorP256 {
+    type Error = ();
+
+    fn decapsulate(&self, encapsulated_key: &PublicKey) -> Result<Secret, Self::Error> {
+        Ok(Secret(self.0.diffie_hellman(encapsulated_key)))
+    }
+}
+
+impl Encapsulate<PublicKey, Secret> for EncapsulatorP256 {
+    type Error = ();
+
+    fn encapsulate(&self, rng: &mut impl CryptoRngCore) -> Result<(PublicKey, Secret), Self::Error> {
+        let sk = EphemeralSecret::random(rng);
+        let pk = sk.public_key();
+
+        Ok((pk, Secret(sk.diffie_hellman(&self.0))))
+    }
+}
+
+impl KEM for KemNistP256 {
+    type DecapsulatingKey = DecapsulatorP256;
+    type EncapsulatingKey = EncapsulatorP256;
+    type EncapsulatedKey = PublicKey;
+    type SharedSecret = Secret;
+
+    fn random_keypair(rng: &mut impl CryptoRngCore) -> (Self::DecapsulatingKey, Self::EncapsulatingKey) {
+        let sk = EphemeralSecret::random(rng);
+        let pk = sk.public_key();
+
+        (DecapsulatorP256(sk), EncapsulatorP256(pk))
+    }
+}
+
+// Helper trait so that shared secrets can be more easily tested for equality during testing
+pub trait SecretBytes {
+    fn as_slice(&self) -> &[u8];
+}
+
+impl SecretBytes for Secret {
+    fn as_slice(&self) -> &[u8] {
+        self.0.as_bytes().as_slice()
+    }
+}
+
+fn test_kemtrait<K: KEM>()
+where
+    <K as KEM>::SharedSecret: SecretBytes,
+{
+    let mut rng = rand::thread_rng();
+    let (sk, pk) = K::random_keypair(&mut rng);
+    let (ek, ss1) = pk.encapsulate(&mut rng).expect("never fails");
+    let ss2 = sk.decapsulate(&ek).expect("never fails");
+
+    assert_eq!(ss1.as_slice(), ss2.as_slice());
+}
+
+#[test]
+fn test_kemtrait_p256() {
+    test_kemtrait::<KemNistP256>();
+}

--- a/kem/tests/kemtrait_p256.rs
+++ b/kem/tests/kemtrait_p256.rs
@@ -59,14 +59,15 @@ impl SecretBytes for Secret {
     }
 }
 
+// use a generic SimpleKEM function to ensure correctness
 fn test_kemtrait_basic<K: SimpleKEM>()
 where
     <K as SimpleKEM>::SharedSecret: SecretBytes,
 {
     let mut rng = rand::thread_rng();
     let (sk, pk) = K::random_keypair(&mut rng);
-    let (ek, ss1) = pk.encapsulate(&mut rng).expect("never fails");
-    let ss2 = sk.decapsulate(&ek).expect("never fails");
+    let (ek, ss1) = K::encapsulate(&pk, &mut rng).expect("never fails");
+    let ss2 = K::decapsulate(&sk, &ek).expect("never fails");
 
     assert_eq!(ss1.as_slice(), ss2.as_slice());
 }


### PR DESCRIPTION
This adds a `SimpleKEM` trait, representing KEM models where the public and private keys from key generation are equivalent to the encapsulating and decapsulating keys. We also add a `FullKEM` trait, which is more general, which allows for KEM models where this is not the case, such as when trying to model authenticated X3DH as a KEM.

Motivation for this PR is mostly just promoting the `DhKem` trait from RustCrypto/KEMs#16 into the kem crate itself.

I think it is also good to have some code that forwards the calls from `SimpleKEM::encapsulate` and `FullKEM::encapsulate` to the actual `Encapsulate<EK, SS>` implementation. That way, a user can directly write `KemModel::encapsulate` and ensure that the types are correct, in the case that there are separate models that use very similar setups. e.g. unauthenticated vs authenticated modes of key exchange.