### PR TITLE
Add lifetime to CustomizedExtArg

### DIFF
--- a/digest/src/core_api/wrapper.rs
+++ b/digest/src/core_api/wrapper.rs
@@ -165,7 +165,7 @@ impl<T> CustomizedInit for CoreWrapper<T>
 where
     T: BufferKindUser + CustomizedInit,
 {
-    type CustomizedExtArg = T::CustomizedExtArg;
+    type CustomizedExtArg<'a> = T::CustomizedExtArg<'a>;
 
     #[inline]
     fn new_customized(customization: &[u8]) -> Self {
@@ -173,7 +173,7 @@ where
     }
 
     #[inline]
-    fn new_ext_customized(customization_ext: &Self::CustomizedExtArg) -> Self {
+    fn new_ext_customized(customization_ext: &Self::CustomizedExtArg<'_>) -> Self {
         Self::from_core(T::new_ext_customized(customization_ext))
     }
 }

--- a/digest/src/lib.rs
+++ b/digest/src/lib.rs
@@ -274,13 +274,13 @@ pub trait CustomizedInit: Sized {
     // associated type defaults are currently unstable
 
     /// Extended customization
-    type CustomizedExtArg;
+    type CustomizedExtArg<'a>;
 
     /// Create new hasher instance with the given customization string.
     fn new_customized(customization: &[u8]) -> Self;
 
     /// Create new hasher instance with the given extended customization.
-    fn new_ext_customized(customization_ext: &Self::CustomizedExtArg) -> Self;
+    fn new_ext_customized(customization_ext: &Self::CustomizedExtArg<'_>) -> Self;
 }
 
 /// The error type used in variable hash traits.


### PR DESCRIPTION
Add a explicit lifetime for `CustomizedExtArg`. It seems to be needed. See https://github.com/RustCrypto/hashes/pull/573.