### PR TITLE
Remove CustomizedExtArg

### DIFF
--- a/digest/src/core_api/wrapper.rs
+++ b/digest/src/core_api/wrapper.rs
@@ -165,16 +165,9 @@ impl<T> CustomizedInit for CoreWrapper<T>
 where
     T: BufferKindUser + CustomizedInit,
 {
-    type CustomizedExtArg<'a> = T::CustomizedExtArg<'a>;
-
     #[inline]
     fn new_customized(customization: &[u8]) -> Self {
         Self::from_core(T::new_customized(customization))
-    }
-
-    #[inline]
-    fn new_ext_customized(customization_ext: &Self::CustomizedExtArg<'_>) -> Self {
-        Self::from_core(T::new_ext_customized(customization_ext))
     }
 }
 

--- a/digest/src/lib.rs
+++ b/digest/src/lib.rs
@@ -270,17 +270,8 @@ pub trait VariableOutputReset: VariableOutput + Reset {
 
 /// Trait for hash functions with customization string for domain separation.
 pub trait CustomizedInit: Sized {
-    // TODO: It would be nice to define a default value equal to `[u8]`, but unfortunately
-    // associated type defaults are currently unstable
-
-    /// Extended customization
-    type CustomizedExtArg<'a>;
-
     /// Create new hasher instance with the given customization string.
     fn new_customized(customization: &[u8]) -> Self;
-
-    /// Create new hasher instance with the given extended customization.
-    fn new_ext_customized(customization_ext: &Self::CustomizedExtArg<'_>) -> Self;
 }
 
 /// The error type used in variable hash traits.


### PR DESCRIPTION
As discussed in https://github.com/RustCrypto/traits/pull/1561, it is more generic to have only an interface with simple byte slice customization only.