### PR TITLE
digest: expose `AssociatedAlgorithmIdentifier` through `CoreWrapper`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -451,6 +451,7 @@ dependencies = [
  "block-buffer 0.11.0-pre.5",
  "const-oid 0.10.0-pre.2",
  "crypto-common 0.2.0-pre.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spki 0.8.0-pre.0",
  "subtle",
  "zeroize",
 ]

--- a/digest/Cargo.toml
+++ b/digest/Cargo.toml
@@ -29,7 +29,6 @@ core-api = ["block-buffer"] # Enable Core API traits
 mac = ["subtle"] # Enable MAC traits
 rand_core = ["crypto-common/rand_core"] # Enable random key generation methods
 oid = ["const-oid"]
-spki = ["oid", "dep:spki"]
 zeroize = ["dep:zeroize", "block-buffer?/zeroize"]
 alloc = []
 std = ["alloc", "crypto-common/std"]

--- a/digest/Cargo.toml
+++ b/digest/Cargo.toml
@@ -20,6 +20,7 @@ block-buffer = { version = "=0.11.0-pre.5", optional = true }
 subtle = { version = "2.4", default-features = false, optional = true }
 blobby = { version = "0.3", optional = true }
 const-oid = { version = "=0.10.0-pre.2", optional = true }
+spki = { version = "=0.8.0-pre.0", optional = true }
 zeroize = { version = "1.7", optional = true, default-features = false }
 
 [features]
@@ -28,6 +29,7 @@ core-api = ["block-buffer"] # Enable Core API traits
 mac = ["subtle"] # Enable MAC traits
 rand_core = ["crypto-common/rand_core"] # Enable random key generation methods
 oid = ["const-oid"]
+spki = ["oid", "dep:spki"]
 zeroize = ["dep:zeroize", "block-buffer?/zeroize"]
 alloc = []
 std = ["alloc", "crypto-common/std"]

--- a/digest/src/core_api/ct_variable.rs
+++ b/digest/src/core_api/ct_variable.rs
@@ -18,6 +18,8 @@ use crypto_common::{
     typenum::{IsLess, IsLessOrEqual, Le, LeEq, NonZero, Sum, U1, U256},
     Block, BlockSizeUser, OutputSizeUser,
 };
+#[cfg(feature = "spki")]
+use spki::{AlgorithmIdentifier, AssociatedAlgorithmIdentifier};
 
 /// Dummy type used with [`CtVariableCoreWrapper`] in cases when
 /// resulting hash does not have a known OID.
@@ -165,6 +167,19 @@ where
     LeEq<OutSize, T::OutputSize>: NonZero,
 {
     const OID: ObjectIdentifier = O::OID;
+}
+
+#[cfg(feature = "spki")]
+impl<T, OutSize, O> AssociatedAlgorithmIdentifier for CtVariableCoreWrapper<T, OutSize, O>
+where
+    T: VariableOutputCore,
+    O: AssociatedAlgorithmIdentifier,
+    OutSize: ArraySize + IsLessOrEqual<T::OutputSize>,
+    LeEq<OutSize, T::OutputSize>: NonZero,
+{
+    type Params = O::Params;
+
+    const ALGORITHM_IDENTIFIER: AlgorithmIdentifier<Self::Params> = O::ALGORITHM_IDENTIFIER;
 }
 
 #[cfg(feature = "zeroize")]

--- a/digest/src/core_api/wrapper.rs
+++ b/digest/src/core_api/wrapper.rs
@@ -23,6 +23,8 @@ use crypto_common::{
 use crate::MacMarker;
 #[cfg(feature = "oid")]
 use const_oid::{AssociatedOid, ObjectIdentifier};
+#[cfg(feature = "spki")]
+use spki::{AlgorithmIdentifier, AssociatedAlgorithmIdentifier};
 
 /// Wrapper around [`BufferKindUser`].
 ///
@@ -177,6 +179,16 @@ where
     T: BufferKindUser + AssociatedOid,
 {
     const OID: ObjectIdentifier = T::OID;
+}
+
+#[cfg(feature = "spki")]
+impl<T> AssociatedAlgorithmIdentifier for CoreWrapper<T>
+where
+    T: BufferKindUser + AssociatedAlgorithmIdentifier,
+{
+    type Params = T::Params;
+
+    const ALGORITHM_IDENTIFIER: AlgorithmIdentifier<Self::Params> = T::ALGORITHM_IDENTIFIER;
 }
 
 type CoreWrapperSerializedStateSize<T> =

--- a/digest/src/lib.rs
+++ b/digest/src/lib.rs
@@ -61,6 +61,8 @@ pub use block_buffer;
 #[cfg(feature = "oid")]
 pub use const_oid;
 pub use crypto_common;
+#[cfg(feature = "spki")]
+pub use spki;
 
 #[cfg(feature = "const-oid")]
 pub use crate::digest::DynDigestWithOid;


### PR DESCRIPTION
This allows implementation in consumer crates like:
https://github.com/RustCrypto/hashes/pull/586