### PR TITLE
async-signature: forward `std` feature

### DIFF
--- a/async-signature/Cargo.toml
+++ b/async-signature/Cargo.toml
@@ -17,6 +17,7 @@ signature = "=2.3.0-pre.3"
 
 [features]
 digest = ["signature/digest"]
+std = ["signature/std"]
 rand_core = ["signature/rand_core"]
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
`std` gates the From<std::error::Error> implementation from signature.

This allows to enable the feature without importing signature directly.