### PR TITLE
digest: fixup clippy, add missing `Debug` impl

### DIFF
--- a/digest/src/hashreader.rs
+++ b/digest/src/hashreader.rs
@@ -3,6 +3,7 @@ use super::{Digest, FixedOutputReset, Output, Reset};
 use std::io;
 
 /// Abstraction over a reader which hashes the data being read
+#[derive(Debug)]
 pub struct HashReader<D: Digest, R: io::Read> {
     reader: R,
     hasher: D,

--- a/digest/src/hashwriter.rs
+++ b/digest/src/hashwriter.rs
@@ -3,6 +3,7 @@ use super::{Digest, FixedOutputReset, Output, Reset};
 use std::io;
 
 /// Abstraction over a writer which hashes the data being written.
+#[derive(Debug)]
 pub struct HashWriter<D: Digest, W: io::Write> {
     writer: W,
     hasher: D,


### PR DESCRIPTION
CI on master branch is currently broken because of a missing `Debug` implementation.

fixup #1159