### PR TITLE
async-signature: remove `AsyncDigestSigner` blanket implementation

### DIFF
--- a/async-signature/src/lib.rs
+++ b/async-signature/src/lib.rs
@@ -58,17 +58,6 @@ where
     async fn sign_digest_async(&self, digest: D) -> Result<S, Error>;
 }
 
-#[cfg(feature = "digest")]
-impl<D, S, T> AsyncDigestSigner<D, S> for T
-where
-    D: Digest,
-    T: signature::DigestSigner<D, S>,
-{
-    async fn sign_digest_async(&self, digest: D) -> Result<S, Error> {
-        self.try_sign_digest(digest)
-    }
-}
-
 /// Sign the given message using the provided external randomness source.
 #[cfg(feature = "rand_core")]
 #[allow(async_fn_in_trait)]

--- a/async-signature/tests/mock_impl.rs
+++ b/async-signature/tests/mock_impl.rs
@@ -1,0 +1,38 @@
+#![allow(dead_code)]
+//! Check compilation of the various traits exposed by async_signature.
+//!
+//! This is intended to make sure we can implement those traits without conflict from a blanket
+//! implementation.
+
+use async_signature::{AsyncSigner, Error};
+
+struct Signature;
+
+struct MockSigner;
+
+impl AsyncSigner<Signature> for MockSigner {
+    async fn sign_async(&self, _msg: &[u8]) -> Result<Signature, Error> {
+        unimplemented!("just meant to check compilation")
+    }
+}
+
+#[cfg(feature = "digest")]
+impl<D> async_signature::AsyncDigestSigner<D, Signature> for MockSigner
+where
+    D: async_signature::Digest,
+{
+    async fn sign_digest_async(&self, _digest: D) -> Result<Signature, Error> {
+        unimplemented!("just meant to check compilation")
+    }
+}
+
+#[cfg(feature = "rand_core")]
+impl async_signature::AsyncRandomizedSigner<Signature> for MockSigner {
+    async fn try_sign_with_rng_async(
+        &self,
+        _rng: &mut impl async_signature::signature::rand_core::CryptoRngCore,
+        _msg: &[u8],
+    ) -> Result<Signature, Error> {
+        unimplemented!("just meant to check compilation")
+    }
+}


### PR DESCRIPTION
This introduces a basic check to make sure our blanket implementation would not block manual implementation of the traits in this crate.

Before this commit `AsyncDigestSigner` was causing a conflict:
```
  --> async-signature/tests/mock_impl.rs:14:1
   |
14 | / impl<D> async_signature::AsyncDigestSigner<D, Signature> for MockSigner
15 | | where
16 | |     D: async_signature::Digest,
   | |_______________________________^
   |
   = note: conflicting implementation in crate `async_signature`:
           - impl<D, S, T> AsyncDigestSigner<D, S> for T
             where D: Digest, T: DigestSigner<D, S>;
   = note: downstream crates may implement trait `async_signature::signature::DigestSigner<_, Signature>` for type `MockSigner`
```