### PR TITLE
Define a `Encapsulate::encapsulate_in_place` method

### DIFF
--- a/kem/src/lib.rs
+++ b/kem/src/lib.rs
@@ -21,6 +21,14 @@ pub trait Encapsulate<EK, SS> {
 
     /// Encapsulates a fresh shared secret
     fn encapsulate(&self, rng: &mut impl CryptoRngCore) -> Result<(EK, SS), Self::Error>;
+
+    /// Encapsulates a fresh shared secret, placing the encapsulated key into the given mut ref.
+    /// If this errors, the final value of `encapsulated_key` MUST equal its original value.
+    fn encapsulate_in_place(
+        &self,
+        rng: &mut impl CryptoRngCore,
+        encapsulated_key: &mut EK,
+    ) -> Result<SS, Self::Error>;
 }
 
 /// A value that can be used to decapsulate an encapsulated key. Often, this will just be a secret

--- a/kem/src/lib.rs
+++ b/kem/src/lib.rs
@@ -12,9 +12,9 @@
 use core::fmt::Debug;
 use rand_core::CryptoRngCore;
 
-/// A value that can be encapsulated to. Often, this will just be a public key. However, it can
-/// also be a bundle of public keys, or it can include a sender's private key for authenticated
-/// encapsulation.
+/// This trait implements encapsulation. Often, the implementer will just be a public key. However,
+/// it can also be a bundle of public keys, or it can include a sender's private key for
+/// authenticated encapsulation.
 pub trait Encapsulate<EK, SS> {
     /// Encapsulation error
     type Error: Debug;
@@ -37,9 +37,9 @@ pub trait Encapsulate<EK, SS> {
     }
 }
 
-/// A value that can be used to decapsulate an encapsulated key. Often, this will just be a secret
-/// key. But, as with [`Encapsulate`], it can be a bundle of secret keys, or it can include a
-/// sender's private key for authenticated encapsulation.
+/// This trait implements decapsulation. Often, the implementer will just be a secret key. But, as
+/// with [`Encapsulate`], it can be a bundle of secret keys, or it can include a sender's private
+/// key for authenticated encapsulation.
 pub trait Decapsulate<EK, SS> {
     /// Decapsulation error
     type Error: Debug;

--- a/kem/src/lib.rs
+++ b/kem/src/lib.rs
@@ -21,6 +21,14 @@ pub trait Encapsulate<EK, SS> {
 
     /// Encapsulates a fresh shared secret
     fn encapsulate(&self, rng: &mut impl CryptoRngCore) -> Result<(EK, SS), Self::Error>;
+}
+
+/// This trait implements in-place encapsulation. Often, the implementer will just be a public key.
+/// However, it can also be a bundle of public keys, or it can include a sender's private key for
+/// authenticated encapsulation.
+pub trait EncapsulateInPlace<EK, SS> {
+    /// Encapsulation error
+    type Error: Debug;
 
     /// Encapsulates a fresh shared secret, placing the encapsulated key into the given mut ref.
     /// If this errors, the final value of `encapsulated_key` MUST equal its original value.
@@ -28,13 +36,7 @@ pub trait Encapsulate<EK, SS> {
         &self,
         rng: &mut impl CryptoRngCore,
         encapsulated_key: &mut EK,
-    ) -> Result<SS, Self::Error> {
-        // Provide a default encapsulate_in_place implementation. If an implementer is
-        // performance-conscious, they can override this.
-        let (ek, ss) = self.encapsulate(rng)?;
-        *encapsulated_key = ek;
-        Ok(ss)
-    }
+    ) -> Result<SS, Self::Error>;
 }
 
 /// This trait implements decapsulation. Often, the implementer will just be a secret key. But, as

--- a/kem/src/lib.rs
+++ b/kem/src/lib.rs
@@ -28,7 +28,13 @@ pub trait Encapsulate<EK, SS> {
         &self,
         rng: &mut impl CryptoRngCore,
         encapsulated_key: &mut EK,
-    ) -> Result<SS, Self::Error>;
+    ) -> Result<SS, Self::Error> {
+        // Provide a default encapsulate_in_place implementation. If an implementer is
+        // performance-conscious, they can override this.
+        let (ek, ss) = self.encapsulate(rng)?;
+        *encapsulated_key = ek;
+        Ok(ss)
+    }
 }
 
 /// A value that can be used to decapsulate an encapsulated key. Often, this will just be a secret

--- a/kem/tests/hpke.rs
+++ b/kem/tests/hpke.rs
@@ -23,16 +23,6 @@ impl Encapsulate<EncappedKey, SharedSecret> for PublicKey {
     ) -> Result<(EncappedKey, SharedSecret), HpkeError> {
         <X25519HkdfSha256 as KemTrait>::encap(&self.0, None, &mut csprng).map(|(ss, ek)| (ek, ss))
     }
-
-    fn encapsulate_in_place(
-        &self,
-        csprng: &mut impl CryptoRngCore,
-        encapsulated_key: &mut EncappedKey,
-    ) -> Result<SharedSecret, HpkeError> {
-        let (ek, ss) = self.encapsulate(csprng)?;
-        *encapsulated_key = ek;
-        Ok(ss)
-    }
 }
 
 impl Decapsulate<EncappedKey, SharedSecret> for PrivateKey {
@@ -60,4 +50,6 @@ fn test_hpke() {
     let (ek, ss1) = pk_recip.encapsulate(&mut rng).unwrap();
     let ss2 = sk_recip.decapsulate(&ek).unwrap();
     assert_eq!(ss1.0, ss2.0);
+
+    // Can't use encapsulate_in_place for this crate, because EncappedKey has no constructor
 }

--- a/kem/tests/hpke.rs
+++ b/kem/tests/hpke.rs
@@ -21,7 +21,17 @@ impl Encapsulate<EncappedKey, SharedSecret> for PublicKey {
         &self,
         mut csprng: &mut impl CryptoRngCore,
     ) -> Result<(EncappedKey, SharedSecret), HpkeError> {
-        <X25519HkdfSha256 as KemTrait>::encap(&self.0, None, &mut csprng).map(|(ek, ss)| (ss, ek))
+        <X25519HkdfSha256 as KemTrait>::encap(&self.0, None, &mut csprng).map(|(ss, ek)| (ek, ss))
+    }
+
+    fn encapsulate_in_place(
+        &self,
+        csprng: &mut impl CryptoRngCore,
+        encapsulated_key: &mut EncappedKey,
+    ) -> Result<SharedSecret, HpkeError> {
+        let (ek, ss) = self.encapsulate(csprng)?;
+        *encapsulated_key = ek;
+        Ok(ss)
     }
 }
 

--- a/kem/tests/saber.rs
+++ b/kem/tests/saber.rs
@@ -1,5 +1,7 @@
 use kem::{Decapsulate, Encapsulate};
 
+use core::convert::Infallible;
+
 use pqcrypto::kem::firesaber::{
     decapsulate, encapsulate, keypair, Ciphertext as SaberEncappedKey, PublicKey, SecretKey,
     SharedSecret as SaberSharedSecret,
@@ -12,15 +14,24 @@ struct SaberPublicKey(PublicKey);
 struct SaberPrivateKey(SecretKey);
 
 impl Encapsulate<SaberEncappedKey, SaberSharedSecret> for SaberPublicKey {
-    // TODO: Encapsulation is infallible. Make this the never type once it's available
-    type Error = ();
+    type Error = Infallible;
 
     fn encapsulate(
         &self,
         _: &mut impl CryptoRngCore,
-    ) -> Result<(SaberEncappedKey, SaberSharedSecret), ()> {
+    ) -> Result<(SaberEncappedKey, SaberSharedSecret), Infallible> {
         let (ss, ek) = encapsulate(&self.0);
         Ok((ek, ss))
+    }
+
+    fn encapsulate_in_place(
+        &self,
+        csprng: &mut impl CryptoRngCore,
+        encapsulated_key: &mut SaberEncappedKey,
+    ) -> Result<SaberSharedSecret, Infallible> {
+        let (ek, ss) = self.encapsulate(csprng)?;
+        *encapsulated_key = ek;
+        Ok(ss)
     }
 }
 

--- a/kem/tests/saber.rs
+++ b/kem/tests/saber.rs
@@ -36,10 +36,9 @@ impl Encapsulate<SaberEncappedKey, SaberSharedSecret> for SaberPublicKey {
 }
 
 impl Decapsulate<SaberEncappedKey, SaberSharedSecret> for SaberPrivateKey {
-    // TODO: Decapsulation is infallible. Make this the never type once it's available
-    type Error = ();
+    type Error = Infallible;
 
-    fn decapsulate(&self, ek: &SaberEncappedKey) -> Result<SaberSharedSecret, ()> {
+    fn decapsulate(&self, ek: &SaberEncappedKey) -> Result<SaberSharedSecret, Infallible> {
         Ok(decapsulate(ek, &self.0))
     }
 }

--- a/kem/tests/saber.rs
+++ b/kem/tests/saber.rs
@@ -23,16 +23,6 @@ impl Encapsulate<SaberEncappedKey, SaberSharedSecret> for SaberPublicKey {
         let (ss, ek) = encapsulate(&self.0);
         Ok((ek, ss))
     }
-
-    fn encapsulate_in_place(
-        &self,
-        csprng: &mut impl CryptoRngCore,
-        encapsulated_key: &mut SaberEncappedKey,
-    ) -> Result<SaberSharedSecret, Infallible> {
-        let (ek, ss) = self.encapsulate(csprng)?;
-        *encapsulated_key = ek;
-        Ok(ss)
-    }
 }
 
 impl Decapsulate<SaberEncappedKey, SaberSharedSecret> for SaberPrivateKey {
@@ -60,4 +50,6 @@ fn test_saber() {
     let (ek, ss1) = pk_recip.encapsulate(&mut rng).unwrap();
     let ss2 = sk_recip.decapsulate(&ek).unwrap();
     assert_eq!(ss1.as_bytes(), ss2.as_bytes());
+
+    // Can't use encapsulate_in_place for this crate, because Ciphertext has no constructor
 }

--- a/kem/tests/x3dh.rs
+++ b/kem/tests/x3dh.rs
@@ -68,16 +68,6 @@ impl Encapsulate<EphemeralKey, SharedSecret> for EncapContext {
 
         Ok((ek, shared_secret))
     }
-
-    fn encapsulate_in_place(
-        &self,
-        rng: &mut impl CryptoRngCore,
-        encapsulated_key: &mut EphemeralKey,
-    ) -> Result<SharedSecret, Self::Error> {
-        let (ek, ss) = self.encapsulate(rng)?;
-        *encapsulated_key = ek;
-        Ok(ss)
-    }
 }
 
 // Define an decapsulator. Since authenticated and unauthenticated encapped keys are represented by
@@ -118,6 +108,14 @@ fn test_x3dh() {
 
     // Now do an authenticated encap
     let (encapped_key, ss1) = encap_context.encapsulate(&mut rng).unwrap();
+    let ss2 = decap_context.decapsulate(&encapped_key).unwrap();
+    assert_eq!(ss1, ss2);
+
+    // Now do the same but with encapsulate_in_place
+    let mut encapped_key = EphemeralKey::default();
+    let ss1 = encap_context
+        .encapsulate_in_place(&mut rng, &mut encapped_key)
+        .unwrap();
     let ss2 = decap_context.decapsulate(&encapped_key).unwrap();
     assert_eq!(ss1, ss2);
 }

--- a/kem/tests/x3dh.rs
+++ b/kem/tests/x3dh.rs
@@ -1,4 +1,4 @@
-use kem::{Decapsulate, Encapsulate};
+use kem::{Decapsulate, Encapsulate, EncapsulateInPlace};
 
 use p256::ecdsa::Signature;
 use rand_core::CryptoRngCore;
@@ -67,6 +67,22 @@ impl Encapsulate<EphemeralKey, SharedSecret> for EncapContext {
         let shared_secret = x3dh_a(sig, my_ik, spk, &ek, ik, opk)?;
 
         Ok((ek, shared_secret))
+    }
+}
+
+// Same thing but in-place
+impl EncapsulateInPlace<EphemeralKey, SharedSecret> for EncapContext {
+    type Error = &'static str;
+
+    // Do the dumb thing and just call encapsulate() and copy the result into the mut ref
+    fn encapsulate_in_place(
+        &self,
+        rng: &mut impl CryptoRngCore,
+        encapsulated_key: &mut EphemeralKey,
+    ) -> Result<SharedSecret, Self::Error> {
+        let (ek, ss) = self.encapsulate(rng)?;
+        *encapsulated_key = ek;
+        Ok(ss)
     }
 }
 

--- a/kem/tests/x3dh.rs
+++ b/kem/tests/x3dh.rs
@@ -68,6 +68,16 @@ impl Encapsulate<EphemeralKey, SharedSecret> for EncapContext {
 
         Ok((ek, shared_secret))
     }
+
+    fn encapsulate_in_place(
+        &self,
+        rng: &mut impl CryptoRngCore,
+        encapsulated_key: &mut EphemeralKey,
+    ) -> Result<SharedSecret, Self::Error> {
+        let (ek, ss) = self.encapsulate(rng)?;
+        *encapsulated_key = ek;
+        Ok(ss)
+    }
 }
 
 // Define an decapsulator. Since authenticated and unauthenticated encapped keys are represented by


### PR DESCRIPTION
I have an issue in my Saber impl https://github.com/rozbb/saber-rs/issues/6 that relates to this. `encapsulate` performs a stack allocation for its encapsulated key. This is not an issue for DH-based KEMs, but it's certainly more of an issue with, e.g., Kyber1024 or Firesaber, whose ciphertexts are ~1.5kB.

So I've added an `encapsulate_in_place` method to `Encapsulate` that lets the user provide their own ciphertext buffer. One nontrivial choice I made is documenting that "If this errors, the final value of `encapsulated_key` MUST equal its original value". I think this is probably fine: if the ciphertext is small then you can just do an allocation anyway, and if the ciphertext is large then it's probably a PQC scheme, and all of those are infallible, so you'll always overwrite anyway. In the absolute worst case, you can make a self-zeroizing copy of the buffer before you start working on it.

Happy to get feedback.
