### PR TITLE
elliptic-curve: remove `ToString` and `FromStr` impls

### DIFF
--- a/elliptic-curve/src/public_key.rs
+++ b/elliptic-curve/src/public_key.rs
@@ -29,13 +29,13 @@ use pkcs8::EncodePublicKey;
 #[cfg(all(feature = "alloc", feature = "sec1"))]
 use alloc::boxed::Box;
 
-#[cfg(any(feature = "jwk", feature = "pem"))]
+#[cfg(feature = "jwk")]
 use alloc::string::String;
 
 #[cfg(feature = "serde")]
 use serdect::serde::{de, ser, Deserialize, Serialize};
 
-#[cfg(any(feature = "pem", feature = "serde"))]
+#[cfg(feature = "serde")]
 use pkcs8::DecodePublicKey;
 
 #[cfg(all(feature = "sec1", feature = "pkcs8"))]

--- a/elliptic-curve/src/secret_key.rs
+++ b/elliptic-curve/src/secret_key.rs
@@ -45,11 +45,8 @@ use {
 #[cfg(all(feature = "arithmetic", any(feature = "jwk", feature = "pem")))]
 use alloc::string::String;
 
-#[cfg(all(feature = "arithmetic", feature = "jwk"))]
-use alloc::string::ToString;
-
 #[cfg(all(doc, feature = "pkcs8"))]
-use {crate::pkcs8::DecodePrivateKey, core::str::FromStr};
+use crate::pkcs8::DecodePrivateKey;
 
 /// Elliptic curve secret keys.
 ///
@@ -71,9 +68,6 @@ use {crate::pkcs8::DecodePrivateKey, core::str::FromStr};
 /// To decode an elliptic curve private key from PKCS#8, enable the `pkcs8`
 /// feature of this crate (or the `pkcs8` feature of a specific RustCrypto
 /// elliptic curve crate) and use the [`DecodePrivateKey`]  trait to parse it.
-///
-/// When the `pem` feature of this crate (or a specific RustCrypto elliptic
-/// curve crate) is enabled, a [`FromStr`] impl is also available.
 #[derive(Clone)]
 pub struct SecretKey<C: Curve> {
     /// Scalar value
@@ -273,7 +267,7 @@ where
         C: JwkParameters + ValidatePublicKey,
         FieldBytesSize<C>: ModulusSize,
     {
-        jwk.parse::<JwkEcKey>().and_then(|jwk| Self::from_jwk(&jwk))
+        JwkEcKey::from_json(jwk).and_then(|jwk| Self::from_jwk(&jwk))
     }
 
     /// Serialize this secret key as [`JwkEcKey`] JSON Web Key (JWK).
@@ -295,7 +289,7 @@ where
         AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
         FieldBytesSize<C>: ModulusSize,
     {
-        Zeroizing::new(self.to_jwk().to_string())
+        Zeroizing::new(self.to_jwk().to_json().expect("JWK encoding error"))
     }
 }
 

--- a/elliptic-curve/src/secret_key/pkcs8.rs
+++ b/elliptic-curve/src/secret_key/pkcs8.rs
@@ -19,14 +19,6 @@ use {
     pkcs8::{der, EncodePrivateKey},
 };
 
-// Imports for actual PEM support
-#[cfg(feature = "pem")]
-use {
-    crate::{error::Error, Result},
-    core::str::FromStr,
-    pkcs8::DecodePrivateKey,
-};
-
 impl<C> AssociatedAlgorithmIdentifier for SecretKey<C>
 where
     C: AssociatedOid + Curve,
@@ -73,18 +65,5 @@ where
         let ec_private_key = self.to_sec1_der()?;
         let pkcs8_key = pkcs8::PrivateKeyInfo::new(algorithm_identifier, &ec_private_key);
         Ok(der::SecretDocument::encode_msg(&pkcs8_key)?)
-    }
-}
-
-#[cfg(feature = "pem")]
-impl<C> FromStr for SecretKey<C>
-where
-    C: Curve + AssociatedOid + ValidatePublicKey,
-    FieldBytesSize<C>: ModulusSize,
-{
-    type Err = Error;
-
-    fn from_str(s: &str) -> Result<Self> {
-        Self::from_pkcs8_pem(s).map_err(|_| Error)
     }
 }

--- a/elliptic-curve/tests/pkcs8.rs
+++ b/elliptic-curve/tests/pkcs8.rs
@@ -49,7 +49,7 @@ fn decode_pkcs8_public_key_from_der() {
 #[test]
 #[cfg(feature = "pem")]
 fn decode_pkcs8_public_key_from_pem() {
-    let public_key = PKCS8_PUBLIC_KEY_PEM.parse::<PublicKey>().unwrap();
+    let public_key = PublicKey::from_public_key_pem(PKCS8_PUBLIC_KEY_PEM).unwrap();
 
     // Ensure key parses equivalently to DER
     let der_key = PublicKey::from_public_key_der(&PKCS8_PUBLIC_KEY_DER[..]).unwrap();


### PR DESCRIPTION
As discussed in #1598 users probably should prefer explicit serialization/deserialziation methods instead of using `FromStr`/`ToString` trait implementations.

`FromStr` implementations for `ScalarPrimitive` and `NonZeroScalar` are left unchanged since they have a symmetric `Display` impl. But note that the current `FromStr` impls for these types may be potentially confusing, since they decodes from hex, while `FromStr` impls for primitive numeric types decode from decimal encoding.