### PR TITLE
Bump `hybrid-array` to v0.2.0-rc.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -731,9 +731,9 @@ dependencies = [
 
 [[package]]
 name = "hybrid-array"
-version = "0.2.0-rc.8"
+version = "0.2.0-rc.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53668f5da5a41d9eaf4bf7064be46d1ebe6a4e1ceed817f387587b18f2b51047"
+checksum = "4d306b679262030ad8813a82d4915fc04efff97776e4db7f8eb5137039d56400"
 dependencies = [
  "typenum",
  "zeroize",

--- a/digest/src/core_api/ct_variable.rs
+++ b/digest/src/core_api/ct_variable.rs
@@ -221,7 +221,7 @@ where
 
     fn serialize(&self) -> SerializedState<Self> {
         let serialized_inner = self.inner.serialize();
-        let serialized_outsize = Array::<u8, U1>::clone_from_slice(&[OutSize::U8]);
+        let serialized_outsize = Array([OutSize::U8]);
 
         serialized_inner.concat(serialized_outsize)
     }

--- a/digest/src/core_api/rt_variable.rs
+++ b/digest/src/core_api/rt_variable.rs
@@ -157,10 +157,9 @@ where
 
     fn serialize(&self) -> SerializedState<Self> {
         let serialized_core = self.core.serialize();
-        let serialized_pos =
-            Array::<u8, U1>::clone_from_slice(&[self.buffer.get_pos().try_into().unwrap()]);
+        let serialized_pos = Array([self.buffer.get_pos().try_into().unwrap()]);
         let serialized_data = self.buffer.clone().pad_with_zeros();
-        let serialized_output_size = Array::<u8, U1>::clone_from_slice(&[self.output_size]);
+        let serialized_output_size = Array([self.output_size]);
 
         serialized_core
             .concat(serialized_pos)

--- a/digest/src/core_api/wrapper.rs
+++ b/digest/src/core_api/wrapper.rs
@@ -197,8 +197,7 @@ where
 
     fn serialize(&self) -> SerializedState<Self> {
         let serialized_core = self.core.serialize();
-        let serialized_pos =
-            Array::<u8, U1>::clone_from_slice(&[self.buffer.get_pos().try_into().unwrap()]);
+        let serialized_pos = Array([self.buffer.get_pos().try_into().unwrap()]);
         let serialized_data = self.buffer.clone().pad_with_zeros();
 
         serialized_core

--- a/elliptic-curve/src/public_key.rs
+++ b/elliptic-curve/src/public_key.rs
@@ -269,7 +269,11 @@ where
     FieldBytesSize<C>: ModulusSize,
 {
     fn from(public_key: &PublicKey<C>) -> CompressedPoint<C> {
-        CompressedPoint::<C>::clone_from_slice(public_key.to_encoded_point(true).as_bytes())
+        public_key
+            .to_encoded_point(true)
+            .as_bytes()
+            .try_into()
+            .expect("wrong compressed point size")
     }
 }
 

--- a/elliptic-curve/src/secret_key.rs
+++ b/elliptic-curve/src/secret_key.rs
@@ -163,8 +163,8 @@ where
     /// NOTE: this function is variable-time with respect to the input length. To avoid a timing
     /// sidechannel, always ensure that the input has been pre-padded to `C::FieldBytesSize`.
     pub fn from_slice(slice: &[u8]) -> Result<Self> {
-        if slice.len() == C::FieldBytesSize::USIZE {
-            Self::from_bytes(FieldBytes::<C>::from_slice(slice))
+        if let Ok(field_bytes) = <&FieldBytes<C>>::try_from(slice) {
+            Self::from_bytes(field_bytes)
         } else if (Self::MIN_SIZE..C::FieldBytesSize::USIZE).contains(&slice.len()) {
             let mut bytes = Zeroizing::new(FieldBytes::<C>::default());
             let offset = C::FieldBytesSize::USIZE.saturating_sub(slice.len());

--- a/signature/tests/derive.rs
+++ b/signature/tests/derive.rs
@@ -35,7 +35,10 @@ impl TryFrom<&[u8]> for DummySignature {
     type Error = Error;
 
     fn try_from(bytes: &[u8]) -> Result<Self, Error> {
-        Ok(DummySignature(Array::clone_from_slice(bytes)))
+        bytes
+            .try_into()
+            .map(DummySignature)
+            .map_err(|_| Error::new())
     }
 }
 


### PR DESCRIPTION
Also fixes the deprecation warnings