### PR TITLE
cipher v0.5.0-pre.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -217,7 +217,7 @@ dependencies = [
 
 [[package]]
 name = "cipher"
-version = "0.5.0-pre.4"
+version = "0.5.0-pre.5"
 dependencies = [
  "blobby",
  "crypto-common 0.2.0-rc.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1294,7 +1294,7 @@ dependencies = [
 
 [[package]]
 name = "universal-hash"
-version = "0.6.0-pre.0"
+version = "0.6.0-rc.0"
 dependencies = [
  "crypto-common 0.2.0-rc.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "subtle",

--- a/cipher/Cargo.toml
+++ b/cipher/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cipher"
 description = "Traits for describing block ciphers and stream ciphers"
-version = "0.5.0-pre.4"
+version = "0.5.0-pre.5"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
Note: leaving this as a `.pre` instead of an `.rc` so we can experiment with newtypes first before doing an `.rc`