### PR TITLE
digest v0.11.0-pre.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,12 +62,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "autocfg"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
-
-[[package]]
 name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -86,18 +80,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "bitvec"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
-dependencies = [
- "funty",
- "radium",
- "tap",
- "wyz",
 ]
 
 [[package]]
@@ -291,19 +273,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crypto-bigint"
-version = "0.6.0-rc.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf4d6fbc60a5516ff886af2c5994fb2bdfa6fbe2168468100bd87e6c09caf08c"
-dependencies = [
- "hybrid-array",
- "num-traits",
- "rand_core",
- "subtle",
- "zeroize",
-]
-
-[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -398,17 +367,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "der"
-version = "0.8.0-rc.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05d9c07d3bd80cf0935ce478d07edf7e7a5b158446757f988f3e62082227b700"
-dependencies = [
- "const-oid 0.10.0-rc.0",
- "pem-rfc7468 1.0.0-rc.0",
- "zeroize",
-]
-
-[[package]]
 name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -430,7 +388,7 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.11.0-pre.8"
+version = "0.11.0-pre.9"
 dependencies = [
  "blobby",
  "block-buffer 0.11.0-rc.0",
@@ -489,34 +447,8 @@ dependencies = [
  "hkdf 0.12.4",
  "pkcs8 0.10.2",
  "rand_core",
- "sec1 0.7.3",
+ "sec1",
  "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "elliptic-curve"
-version = "0.14.0-pre.5"
-dependencies = [
- "base16ct",
- "base64ct",
- "crypto-bigint 0.6.0-rc.0",
- "digest 0.11.0-pre.8",
- "ff 0.13.0",
- "group 0.13.0",
- "hex-literal",
- "hkdf 0.13.0-pre.3",
- "hybrid-array",
- "pem-rfc7468 1.0.0-rc.0",
- "pkcs8 0.11.0-rc.0",
- "rand_core",
- "sec1 0.8.0-rc.0",
- "serde_json",
- "serdect",
- "sha2 0.11.0-pre.3",
- "sha3",
- "subtle",
- "tap",
  "zeroize",
 ]
 
@@ -536,7 +468,6 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
 dependencies = [
- "bitvec",
  "rand_core",
  "subtle",
 ]
@@ -546,12 +477,6 @@ name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
-
-[[package]]
-name = "funty"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "generic-array"
@@ -658,15 +583,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hkdf"
-version = "0.13.0-pre.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd5d615ab5c462f96c309b3a00b19f373025a4981312f717f9df5bbd0201530c"
-dependencies = [
- "hmac 0.13.0-pre.3",
-]
-
-[[package]]
 name = "hmac"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -683,15 +599,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest 0.10.7",
-]
-
-[[package]]
-name = "hmac"
-version = "0.13.0-pre.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffd790a0795ee332ed3e8959e5b177beb70d7112eb7d345428ec17427897d5ce"
-dependencies = [
- "digest 0.11.0-pre.8",
 ]
 
 [[package]]
@@ -722,7 +629,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d306b679262030ad8813a82d4915fc04efff97776e4db7f8eb5137039d56400"
 dependencies = [
  "typenum",
- "zeroize",
 ]
 
 [[package]]
@@ -746,27 +652,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "itoa"
-version = "1.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
-
-[[package]]
 name = "jobserver"
 version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "keccak"
-version = "0.2.0-pre.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7cdd4f0dc5807b9a2b25dd48a3f58e862606fe7bd47f41ecde36e97422d7e90"
-dependencies = [
- "cpufeatures",
 ]
 
 [[package]]
@@ -788,15 +679,6 @@ name = "libc"
 version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
-
-[[package]]
-name = "num-traits"
-version = "0.2.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
-dependencies = [
- "autocfg",
-]
 
 [[package]]
 name = "opaque-debug"
@@ -855,22 +737,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "pem-rfc7468"
-version = "1.0.0-rc.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2b24c1c4a3b352d47de5ec824193e68317dc0ce041f6279a4771eb550ab7f8c"
-dependencies = [
- "base64ct",
-]
-
-[[package]]
 name = "pkcs8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee3ef9b64d26bad0536099c816c6734379e45bbd5f14798def6809e5cc350447"
 dependencies = [
  "der 0.4.5",
- "pem-rfc7468 0.2.3",
+ "pem-rfc7468",
  "spki 0.4.1",
  "zeroize",
 ]
@@ -883,16 +756,6 @@ checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
  "der 0.7.9",
  "spki 0.7.3",
-]
-
-[[package]]
-name = "pkcs8"
-version = "0.11.0-rc.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66180445f1dce533620a7743467ef85fe1c5e80cdaf7c7053609d7a2fbcdae20"
-dependencies = [
- "der 0.8.0-rc.0",
- "spki 0.8.0-rc.0",
 ]
 
 [[package]]
@@ -993,12 +856,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "radium"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
-
-[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1038,12 +895,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ryu"
-version = "1.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
-
-[[package]]
 name = "sec1"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1053,21 +904,6 @@ dependencies = [
  "der 0.7.9",
  "generic-array",
  "pkcs8 0.10.2",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "sec1"
-version = "0.8.0-rc.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32c98827dc6ed0ea1707286a3d14b4ad4e25e2643169cbf111568a46ff5b09f5"
-dependencies = [
- "base16ct",
- "der 0.8.0-rc.0",
- "hybrid-array",
- "pkcs8 0.11.0-rc.0",
- "serdect",
  "subtle",
  "zeroize",
 ]
@@ -1108,27 +944,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_json"
-version = "1.0.120"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e0d21c9a8cae1235ad58a00c11cb40d4b1e5c784f1ef2c537876ed6ffd8b7c5"
-dependencies = [
- "itoa",
- "ryu",
- "serde",
-]
-
-[[package]]
-name = "serdect"
-version = "0.3.0-pre.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "791ef964bfaba6be28a5c3f0c56836e17cb711ac009ca1074b9c735a3ebf240a"
-dependencies = [
- "base16ct",
- "serde",
-]
-
-[[package]]
 name = "sha2"
 version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1150,27 +965,6 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest 0.10.7",
-]
-
-[[package]]
-name = "sha2"
-version = "0.11.0-pre.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f33549bf3064b62478926aa89cbfc7c109aab66ae8f0d5d2ef839e482cc30d6"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest 0.11.0-pre.8",
-]
-
-[[package]]
-name = "sha3"
-version = "0.11.0-pre.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f32c02b9987a647a3d6af14c3e88df86594e4283050d9d8ee3a035df247785b9"
-dependencies = [
- "digest 0.11.0-pre.8",
- "keccak",
 ]
 
 [[package]]
@@ -1196,10 +990,9 @@ dependencies = [
 name = "signature"
 version = "2.3.0-pre.3"
 dependencies = [
- "digest 0.11.0-pre.8",
+ "digest 0.11.0-pre.9",
  "hex-literal",
  "rand_core",
- "sha2 0.11.0-pre.3",
  "signature_derive",
 ]
 
@@ -1232,16 +1025,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "spki"
-version = "0.8.0-rc.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee3fb1c675852398475928637b3ebbdd7e1d0cc24d27b3bbc81788b4eb51e310"
-dependencies = [
- "base64ct",
- "der 0.8.0-rc.0",
-]
-
-[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1263,12 +1046,6 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
-
-[[package]]
-name = "tap"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "typenum"
@@ -1311,15 +1088,6 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
-
-[[package]]
-name = "wyz"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
-dependencies = [
- "tap",
-]
 
 [[package]]
 name = "x25519-dalek"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,13 +7,14 @@ members = [
     "crypto",
     "crypto-common",
     "digest",
-    "elliptic-curve",
+    #"elliptic-curve",
     "kem",
     "password-hash",
     "signature",
     "signature_derive",
     "universal-hash",
 ]
+exclude = ["elliptic-curve"]
 
 [patch.crates-io]
 digest = { path = "./digest" }

--- a/digest/Cargo.toml
+++ b/digest/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "digest"
 description = "Traits for cryptographic hash functions and message authentication codes"
-version = "0.11.0-pre.8"
+version = "0.11.0-pre.9"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/signature/Cargo.toml
+++ b/signature/Cargo.toml
@@ -1,26 +1,26 @@
 [package]
-name          = "signature"
-description   = "Traits for cryptographic signature algorithms (e.g. ECDSA, Ed25519)"
-version       = "2.3.0-pre.3"
-authors       = ["RustCrypto Developers"]
-license       = "Apache-2.0 OR MIT"
+name = "signature"
+description = "Traits for cryptographic signature algorithms (e.g. ECDSA, Ed25519)"
+version = "2.3.0-pre.3"
+authors = ["RustCrypto Developers"]
+license = "Apache-2.0 OR MIT"
 documentation = "https://docs.rs/signature"
-homepage      = "https://github.com/RustCrypto/traits/tree/master/signature"
-repository    = "https://github.com/RustCrypto/traits"
-readme        = "README.md"
-keywords      = ["crypto", "ecdsa", "ed25519", "signature", "signing"]
-categories    = ["cryptography", "no-std"]
-edition       = "2021"
-rust-version  = "1.72"
+homepage = "https://github.com/RustCrypto/traits/tree/master/signature"
+repository = "https://github.com/RustCrypto/traits"
+readme = "README.md"
+keywords = ["crypto", "ecdsa", "ed25519", "signature", "signing"]
+categories = ["cryptography", "no-std"]
+edition = "2021"
+rust-version = "1.72"
 
 [dependencies]
 derive = { package = "signature_derive", version = "2", optional = true, path = "../signature_derive" }
-digest = { version = "=0.11.0-pre.8", optional = true, default-features = false }
+digest = { version = "=0.11.0-pre.9", optional = true, default-features = false }
 rand_core = { version = "0.6.4", optional = true, default-features = false }
 
 [dev-dependencies]
 hex-literal = "0.4"
-sha2 = { version = "=0.11.0-pre.3", default-features = false }
+#sha2 = { version = "=0.11.0-pre.3", default-features = false }
 
 [features]
 alloc = []

--- a/signature/tests/derive.rs
+++ b/signature/tests/derive.rs
@@ -2,84 +2,85 @@
 
 #![cfg(all(feature = "derive", feature = "digest"))]
 
-use digest::{array::Array, Digest, OutputSizeUser};
-use hex_literal::hex;
-use sha2::Sha256;
-use signature::{
-    hazmat::{PrehashSigner, PrehashVerifier},
-    DigestSigner, DigestVerifier, Error, PrehashSignature, SignatureEncoding, Signer, Verifier,
-};
-
-/// Test vector to compute SHA-256 digest of
-const INPUT_STRING: &[u8] = b"abc";
-
-/// Expected SHA-256 digest for the input string
-const INPUT_STRING_DIGEST: [u8; 32] =
-    hex!("ba7816bf 8f01cfea 414140de 5dae2223 b00361a3 96177a9c b410ff61 f20015ad");
-
-type Repr = Array<u8, <Sha256 as OutputSizeUser>::OutputSize>;
-
-/// Dummy signature which just contains a digest output
-#[derive(Clone, Debug)]
-struct DummySignature(Repr);
-
-impl PrehashSignature for DummySignature {
-    type Digest = Sha256;
-}
-
-impl SignatureEncoding for DummySignature {
-    type Repr = Repr;
-}
-
-impl TryFrom<&[u8]> for DummySignature {
-    type Error = Error;
-
-    fn try_from(bytes: &[u8]) -> Result<Self, Error> {
-        bytes
-            .try_into()
-            .map(DummySignature)
-            .map_err(|_| Error::new())
-    }
-}
-
-impl From<DummySignature> for Repr {
-    fn from(sig: DummySignature) -> Repr {
-        sig.0
-    }
-}
-
-/// Dummy signer which just returns the message digest as a `DummySignature`
-#[derive(Signer, DigestSigner, Default)]
-struct DummySigner {}
-
-impl PrehashSigner<DummySignature> for DummySigner {
-    fn sign_prehash(&self, prehash: &[u8]) -> signature::Result<DummySignature> {
-        DummySignature::try_from(prehash)
-    }
-}
-
-/// Dummy verifier which ensures the `DummySignature` digest matches the
-/// expected value.
-///
-/// Panics (via `assert_eq!`) if the value is not what is expected.
-#[derive(Verifier, DigestVerifier, Default)]
-struct DummyVerifier {}
-
-impl PrehashVerifier<DummySignature> for DummyVerifier {
-    fn verify_prehash(&self, prehash: &[u8], signature: &DummySignature) -> signature::Result<()> {
-        assert_eq!(signature.to_bytes().as_slice(), prehash);
-        Ok(())
-    }
-}
-
-#[test]
-fn derived_signer_impl() {
-    let sig: DummySignature = DummySigner::default().sign(INPUT_STRING);
-    assert_eq!(sig.to_bytes().as_slice(), INPUT_STRING_DIGEST)
-}
-
-#[test]
-fn derived_verifier_impl() {
-    let sig: DummySignature = DummySigner::default().sign(INPUT_STRING);
-    assert!(DummyVerifier::default().verify(INPUT_STRING, &sig).is_ok());
-}
+// TODO(tarcieri): re-enable when `sha2` has been updated
+// use digest::{array::Array, Digest, OutputSizeUser};
+// use hex_literal::hex;
+// use sha2::Sha256;
+// use signature::{
+//     hazmat::{PrehashSigner, PrehashVerifier},
+//     DigestSigner, DigestVerifier, Error, PrehashSignature, SignatureEncoding, Signer, Verifier,
+// };
+//
+// /// Test vector to compute SHA-256 digest of
+// const INPUT_STRING: &[u8] = b"abc";
+//
+// /// Expected SHA-256 digest for the input string
+// const INPUT_STRING_DIGEST: [u8; 32] =
+//     hex!("ba7816bf 8f01cfea 414140de 5dae2223 b00361a3 96177a9c b410ff61 f20015ad");
+//
+// type Repr = Array<u8, <Sha256 as OutputSizeUser>::OutputSize>;
+//
+// /// Dummy signature which just contains a digest output
+// #[derive(Clone, Debug)]
+// struct DummySignature(Repr);
+//
+// impl PrehashSignature for DummySignature {
+//     type Digest = Sha256;
+// }
+//
+// impl SignatureEncoding for DummySignature {
+//     type Repr = Repr;
+// }
+//
+// impl TryFrom<&[u8]> for DummySignature {
+//     type Error = Error;
+//
+//     fn try_from(bytes: &[u8]) -> Result<Self, Error> {
+//         bytes
+//             .try_into()
+//             .map(DummySignature)
+//             .map_err(|_| Error::new())
+//     }
+// }
+//
+// impl From<DummySignature> for Repr {
+//     fn from(sig: DummySignature) -> Repr {
+//         sig.0
+//     }
+// }
+//
+// /// Dummy signer which just returns the message digest as a `DummySignature`
+// #[derive(Signer, DigestSigner, Default)]
+// struct DummySigner {}
+//
+// impl PrehashSigner<DummySignature> for DummySigner {
+//     fn sign_prehash(&self, prehash: &[u8]) -> signature::Result<DummySignature> {
+//         DummySignature::try_from(prehash)
+//     }
+// }
+//
+// /// Dummy verifier which ensures the `DummySignature` digest matches the
+// /// expected value.
+// ///
+// /// Panics (via `assert_eq!`) if the value is not what is expected.
+// #[derive(Verifier, DigestVerifier, Default)]
+// struct DummyVerifier {}
+//
+// impl PrehashVerifier<DummySignature> for DummyVerifier {
+//     fn verify_prehash(&self, prehash: &[u8], signature: &DummySignature) -> signature::Result<()> {
+//         assert_eq!(signature.to_bytes().as_slice(), prehash);
+//         Ok(())
+//     }
+// }
+//
+// #[test]
+// fn derived_signer_impl() {
+//     let sig: DummySignature = DummySigner::default().sign(INPUT_STRING);
+//     assert_eq!(sig.to_bytes().as_slice(), INPUT_STRING_DIGEST)
+// }
+//
+// #[test]
+// fn derived_verifier_impl() {
+//     let sig: DummySignature = DummySigner::default().sign(INPUT_STRING);
+//     assert!(DummyVerifier::default().verify(INPUT_STRING, &sig).is_ok());
+// }


### PR DESCRIPTION
Due to circular dependencies, it was necessary to temporarily split `elliptic-curve` out of the workspace. It also can't currently resolve a solution for `elliptic-curve`'s Cargo.lock due to `digest`. Excluding `elliptic-curve`, all of the other crates work.

The main causes of this are crates like `sha2` and `sha3` which are circular `dev-dependencies` (i.e. between traits and hashes).

This will temporarily break the `elliptic-curve` build until we can do new releases of `sha2` and `sha3` as well as crates like `hmac` and `hkdf`. Once these have been released, we can put everything back into a single workspace.