### PR TITLE
Use `digest` v0.11.0-pre.9 crate releases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,6 +62,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "autocfg"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+
+[[package]]
 name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -80,6 +86,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
 ]
 
 [[package]]
@@ -273,6 +291,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-bigint"
+version = "0.6.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf4d6fbc60a5516ff886af2c5994fb2bdfa6fbe2168468100bd87e6c09caf08c"
+dependencies = [
+ "hybrid-array",
+ "num-traits",
+ "rand_core",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -367,6 +398,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "der"
+version = "0.8.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05d9c07d3bd80cf0935ce478d07edf7e7a5b158446757f988f3e62082227b700"
+dependencies = [
+ "const-oid 0.10.0-rc.0",
+ "pem-rfc7468 1.0.0-rc.0",
+ "zeroize",
+]
+
+[[package]]
 name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -447,8 +489,34 @@ dependencies = [
  "hkdf 0.12.4",
  "pkcs8 0.10.2",
  "rand_core",
- "sec1",
+ "sec1 0.7.3",
  "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.14.0-pre.5"
+dependencies = [
+ "base16ct",
+ "base64ct",
+ "crypto-bigint 0.6.0-rc.0",
+ "digest 0.11.0-pre.9",
+ "ff 0.13.0",
+ "group 0.13.0",
+ "hex-literal",
+ "hkdf 0.13.0-pre.4",
+ "hybrid-array",
+ "pem-rfc7468 1.0.0-rc.0",
+ "pkcs8 0.11.0-rc.0",
+ "rand_core",
+ "sec1 0.8.0-rc.0",
+ "serde_json",
+ "serdect",
+ "sha2 0.11.0-pre.4",
+ "sha3",
+ "subtle",
+ "tap",
  "zeroize",
 ]
 
@@ -468,6 +536,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
 dependencies = [
+ "bitvec",
  "rand_core",
  "subtle",
 ]
@@ -477,6 +546,12 @@ name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "generic-array"
@@ -583,6 +658,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hkdf"
+version = "0.13.0-pre.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00176ff81091018d42ff82e8324f8e5adb0b7e0468d1358f653972562dbff031"
+dependencies = [
+ "hmac 0.13.0-pre.4",
+]
+
+[[package]]
 name = "hmac"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -599,6 +683,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0-pre.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4b1fb14e4df79f9406b434b60acef9f45c26c50062cccf1346c6103b8c47d58"
+dependencies = [
+ "digest 0.11.0-pre.9",
 ]
 
 [[package]]
@@ -629,6 +722,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d306b679262030ad8813a82d4915fc04efff97776e4db7f8eb5137039d56400"
 dependencies = [
  "typenum",
+ "zeroize",
 ]
 
 [[package]]
@@ -652,12 +746,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "itoa"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+
+[[package]]
 name = "jobserver"
 version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "keccak"
+version = "0.2.0-pre.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7cdd4f0dc5807b9a2b25dd48a3f58e862606fe7bd47f41ecde36e97422d7e90"
+dependencies = [
+ "cpufeatures",
 ]
 
 [[package]]
@@ -679,6 +788,15 @@ name = "libc"
 version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "opaque-debug"
@@ -737,13 +855,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem-rfc7468"
+version = "1.0.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2b24c1c4a3b352d47de5ec824193e68317dc0ce041f6279a4771eb550ab7f8c"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
 name = "pkcs8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee3ef9b64d26bad0536099c816c6734379e45bbd5f14798def6809e5cc350447"
 dependencies = [
  "der 0.4.5",
- "pem-rfc7468",
+ "pem-rfc7468 0.2.3",
  "spki 0.4.1",
  "zeroize",
 ]
@@ -756,6 +883,16 @@ checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
  "der 0.7.9",
  "spki 0.7.3",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.11.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66180445f1dce533620a7743467ef85fe1c5e80cdaf7c7053609d7a2fbcdae20"
+dependencies = [
+ "der 0.8.0-rc.0",
+ "spki 0.8.0-rc.0",
 ]
 
 [[package]]
@@ -856,6 +993,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -895,6 +1038,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+
+[[package]]
 name = "sec1"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -904,6 +1053,21 @@ dependencies = [
  "der 0.7.9",
  "generic-array",
  "pkcs8 0.10.2",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "sec1"
+version = "0.8.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32c98827dc6ed0ea1707286a3d14b4ad4e25e2643169cbf111568a46ff5b09f5"
+dependencies = [
+ "base16ct",
+ "der 0.8.0-rc.0",
+ "hybrid-array",
+ "pkcs8 0.11.0-rc.0",
+ "serdect",
  "subtle",
  "zeroize",
 ]
@@ -944,6 +1108,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_json"
+version = "1.0.120"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e0d21c9a8cae1235ad58a00c11cb40d4b1e5c784f1ef2c537876ed6ffd8b7c5"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serdect"
+version = "0.3.0-pre.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "791ef964bfaba6be28a5c3f0c56836e17cb711ac009ca1074b9c735a3ebf240a"
+dependencies = [
+ "base16ct",
+ "serde",
+]
+
+[[package]]
 name = "sha2"
 version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -965,6 +1150,27 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0-pre.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "540c0893cce56cdbcfebcec191ec8e0f470dd1889b6e7a0b503e310a94a168f5"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.11.0-pre.9",
+]
+
+[[package]]
+name = "sha3"
+version = "0.11.0-pre.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e485881f388c2818d709796dc883c1ffcadde9d1f0e054f3a5c14974185261a6"
+dependencies = [
+ "digest 0.11.0-pre.9",
+ "keccak",
 ]
 
 [[package]]
@@ -993,6 +1199,7 @@ dependencies = [
  "digest 0.11.0-pre.9",
  "hex-literal",
  "rand_core",
+ "sha2 0.11.0-pre.4",
  "signature_derive",
 ]
 
@@ -1025,6 +1232,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "spki"
+version = "0.8.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee3fb1c675852398475928637b3ebbdd7e1d0cc24d27b3bbc81788b4eb51e310"
+dependencies = [
+ "base64ct",
+ "der 0.8.0-rc.0",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1046,6 +1263,12 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "typenum"
@@ -1088,6 +1311,15 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
 
 [[package]]
 name = "x25519-dalek"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,14 +7,13 @@ members = [
     "crypto",
     "crypto-common",
     "digest",
-    #"elliptic-curve",
+    "elliptic-curve",
     "kem",
     "password-hash",
     "signature",
     "signature_derive",
     "universal-hash",
 ]
-exclude = ["elliptic-curve"]
 
 [patch.crates-io]
 digest = { path = "./digest" }

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -26,10 +26,10 @@ zeroize = { version = "1.7", default-features = false }
 
 # optional dependencies
 base64ct = { version = "1", optional = true, default-features = false, features = ["alloc"] }
-digest = { version = "=0.11.0-pre.8", optional = true }
+digest = { version = "=0.11.0-pre.9", optional = true }
 ff = { version = "0.13", optional = true, default-features = false }
 group = { version = "0.13", optional = true, default-features = false }
-hkdf = { version = "=0.13.0-pre.3", optional = true, default-features = false }
+hkdf = { version = "=0.13.0-pre.4", optional = true, default-features = false }
 hex-literal = { version = "0.4", optional = true }
 pem-rfc7468 = { version = "1.0.0-rc.0", optional = true, features = ["alloc"] }
 pkcs8 = { version = "0.11.0-rc.0", optional = true, default-features = false }
@@ -40,8 +40,8 @@ tap = { version = "1.0.1", optional = true, default-features = false } # hack fo
 
 [dev-dependencies]
 hex-literal = "0.4"
-sha2 = "=0.11.0-pre.3"
-sha3 = "=0.11.0-pre.3"
+sha2 = "=0.11.0-pre.4"
+sha3 = "=0.11.0-pre.4"
 
 [features]
 default = ["arithmetic"]

--- a/signature/Cargo.toml
+++ b/signature/Cargo.toml
@@ -20,7 +20,7 @@ rand_core = { version = "0.6.4", optional = true, default-features = false }
 
 [dev-dependencies]
 hex-literal = "0.4"
-#sha2 = { version = "=0.11.0-pre.3", default-features = false }
+sha2 = { version = "=0.11.0-pre.4", default-features = false }
 
 [features]
 alloc = []

--- a/signature/tests/derive.rs
+++ b/signature/tests/derive.rs
@@ -2,85 +2,84 @@
 
 #![cfg(all(feature = "derive", feature = "digest"))]
 
-// TODO(tarcieri): re-enable when `sha2` has been updated
-// use digest::{array::Array, Digest, OutputSizeUser};
-// use hex_literal::hex;
-// use sha2::Sha256;
-// use signature::{
-//     hazmat::{PrehashSigner, PrehashVerifier},
-//     DigestSigner, DigestVerifier, Error, PrehashSignature, SignatureEncoding, Signer, Verifier,
-// };
-//
-// /// Test vector to compute SHA-256 digest of
-// const INPUT_STRING: &[u8] = b"abc";
-//
-// /// Expected SHA-256 digest for the input string
-// const INPUT_STRING_DIGEST: [u8; 32] =
-//     hex!("ba7816bf 8f01cfea 414140de 5dae2223 b00361a3 96177a9c b410ff61 f20015ad");
-//
-// type Repr = Array<u8, <Sha256 as OutputSizeUser>::OutputSize>;
-//
-// /// Dummy signature which just contains a digest output
-// #[derive(Clone, Debug)]
-// struct DummySignature(Repr);
-//
-// impl PrehashSignature for DummySignature {
-//     type Digest = Sha256;
-// }
-//
-// impl SignatureEncoding for DummySignature {
-//     type Repr = Repr;
-// }
-//
-// impl TryFrom<&[u8]> for DummySignature {
-//     type Error = Error;
-//
-//     fn try_from(bytes: &[u8]) -> Result<Self, Error> {
-//         bytes
-//             .try_into()
-//             .map(DummySignature)
-//             .map_err(|_| Error::new())
-//     }
-// }
-//
-// impl From<DummySignature> for Repr {
-//     fn from(sig: DummySignature) -> Repr {
-//         sig.0
-//     }
-// }
-//
-// /// Dummy signer which just returns the message digest as a `DummySignature`
-// #[derive(Signer, DigestSigner, Default)]
-// struct DummySigner {}
-//
-// impl PrehashSigner<DummySignature> for DummySigner {
-//     fn sign_prehash(&self, prehash: &[u8]) -> signature::Result<DummySignature> {
-//         DummySignature::try_from(prehash)
-//     }
-// }
-//
-// /// Dummy verifier which ensures the `DummySignature` digest matches the
-// /// expected value.
-// ///
-// /// Panics (via `assert_eq!`) if the value is not what is expected.
-// #[derive(Verifier, DigestVerifier, Default)]
-// struct DummyVerifier {}
-//
-// impl PrehashVerifier<DummySignature> for DummyVerifier {
-//     fn verify_prehash(&self, prehash: &[u8], signature: &DummySignature) -> signature::Result<()> {
-//         assert_eq!(signature.to_bytes().as_slice(), prehash);
-//         Ok(())
-//     }
-// }
-//
-// #[test]
-// fn derived_signer_impl() {
-//     let sig: DummySignature = DummySigner::default().sign(INPUT_STRING);
-//     assert_eq!(sig.to_bytes().as_slice(), INPUT_STRING_DIGEST)
-// }
-//
-// #[test]
-// fn derived_verifier_impl() {
-//     let sig: DummySignature = DummySigner::default().sign(INPUT_STRING);
-//     assert!(DummyVerifier::default().verify(INPUT_STRING, &sig).is_ok());
-// }
+use digest::{array::Array, Digest, OutputSizeUser};
+use hex_literal::hex;
+use sha2::Sha256;
+use signature::{
+    hazmat::{PrehashSigner, PrehashVerifier},
+    DigestSigner, DigestVerifier, Error, PrehashSignature, SignatureEncoding, Signer, Verifier,
+};
+
+/// Test vector to compute SHA-256 digest of
+const INPUT_STRING: &[u8] = b"abc";
+
+/// Expected SHA-256 digest for the input string
+const INPUT_STRING_DIGEST: [u8; 32] =
+    hex!("ba7816bf 8f01cfea 414140de 5dae2223 b00361a3 96177a9c b410ff61 f20015ad");
+
+type Repr = Array<u8, <Sha256 as OutputSizeUser>::OutputSize>;
+
+/// Dummy signature which just contains a digest output
+#[derive(Clone, Debug)]
+struct DummySignature(Repr);
+
+impl PrehashSignature for DummySignature {
+    type Digest = Sha256;
+}
+
+impl SignatureEncoding for DummySignature {
+    type Repr = Repr;
+}
+
+impl TryFrom<&[u8]> for DummySignature {
+    type Error = Error;
+
+    fn try_from(bytes: &[u8]) -> Result<Self, Error> {
+        bytes
+            .try_into()
+            .map(DummySignature)
+            .map_err(|_| Error::new())
+    }
+}
+
+impl From<DummySignature> for Repr {
+    fn from(sig: DummySignature) -> Repr {
+        sig.0
+    }
+}
+
+/// Dummy signer which just returns the message digest as a `DummySignature`
+#[derive(Signer, DigestSigner, Default)]
+struct DummySigner {}
+
+impl PrehashSigner<DummySignature> for DummySigner {
+    fn sign_prehash(&self, prehash: &[u8]) -> signature::Result<DummySignature> {
+        DummySignature::try_from(prehash)
+    }
+}
+
+/// Dummy verifier which ensures the `DummySignature` digest matches the
+/// expected value.
+///
+/// Panics (via `assert_eq!`) if the value is not what is expected.
+#[derive(Verifier, DigestVerifier, Default)]
+struct DummyVerifier {}
+
+impl PrehashVerifier<DummySignature> for DummyVerifier {
+    fn verify_prehash(&self, prehash: &[u8], signature: &DummySignature) -> signature::Result<()> {
+        assert_eq!(signature.to_bytes().as_slice(), prehash);
+        Ok(())
+    }
+}
+
+#[test]
+fn derived_signer_impl() {
+    let sig: DummySignature = DummySigner::default().sign(INPUT_STRING);
+    assert_eq!(sig.to_bytes().as_slice(), INPUT_STRING_DIGEST)
+}
+
+#[test]
+fn derived_verifier_impl() {
+    let sig: DummySignature = DummySigner::default().sign(INPUT_STRING);
+    assert!(DummyVerifier::default().verify(INPUT_STRING, &sig).is_ok());
+}


### PR DESCRIPTION
Re-unifies the workspace now that the circular dev-dependencies have been updated