### PR TITLE
digest: implement `Update` for `Vec<u8>`

### DIFF
--- a/digest/src/lib.rs
+++ b/digest/src/lib.rs
@@ -308,3 +308,10 @@ pub use hashwriter::HashWriter;
 mod hashreader;
 #[cfg(feature = "std")]
 pub use hashreader::HashReader;
+
+#[cfg(feature = "alloc")]
+impl Update for alloc::vec::Vec<u8> {
+    fn update(&mut self, data: &[u8]) {
+        self.extend_from_slice(data)
+    }
+}


### PR DESCRIPTION
In use-cases like https://github.com/RustCrypto/SSH/blob/a6f33709d6a48d82c818a9bdec87fe3a96b027ca/ssh-encoding/src/writer.rs#L19 it is not currently possible to write things like;
``` rust
impl<D> Writer for D
where
    D: digest::Update,
{
    fn write(&mut self, bytes: &[u8]) -> Result<()> {
        self.update(bytes);
        Ok(())
    }
}
```
to get a writer implementation for `T: Digest`.

This isn't currently possible because of the following error:
```
error[E0119]: conflicting implementations of trait `Writer` for type `Vec<u8>`
   |
21 |   impl Writer for Vec<u8> {
   |   ----------------------- first implementation here
...
44 | / impl<D> Writer for D
45 | | where
46 | |     D: Update,
   | |______________^ conflicting implementation for `Vec<u8>`
   |
   = note: upstream crates may add a new impl of trait `digest::Update` for type `alloc::vec::Vec<u8>` in future versions
```

Although this is technically incorrect, as Vec isn't a digest, an `Update` implementation still seems relevant.