### PR TITLE
password-hash: Add `Output::with_encoding` method

### DIFF
--- a/password-hash/src/output.rs
+++ b/password-hash/src/output.rs
@@ -182,6 +182,11 @@ impl Output {
         self.encoding
     }
 
+    /// Creates a copy of this [`Output`] with the specified [`Encoding`].
+    pub fn with_encoding(&self, encoding: Encoding) -> Self {
+        Self { encoding, ..*self }
+    }
+
     /// Get the length of the output value as a byte slice.
     pub fn len(&self) -> usize {
         usize::from(self.length)


### PR DESCRIPTION
Allows `Display`/`Debug` printing `Output` with a specific `Encoding` without needing to go through `encode`/`b64_encode`, if e.g. it was created using `init_with`.

Maybe a version of `init_with` that allows specifying an encoding (similar to `new_with_encoding`) would be better, I'm not sure. This is a smaller, more general change.