### PR TITLE
CI: fix workspace doc build

### DIFF
--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           toolchain: stable
       # TODO(tarcieri): remove `--exclude crypto` after new release series
-      - run: cargo doc --all-features --workspace --exclude crypto
+      - run: cargo doc --workspace --all-features --no-deps --exclude crypto
 
   rustfmt:
     runs-on: ubuntu-latest

--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -35,7 +35,8 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
-      - run: cargo doc --all-features
+      # TODO(tarcieri): remove `--exclude crypto` after new release series
+      - run: cargo doc --all-features --workspace --exclude crypto
 
   rustfmt:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The `crypto` crate is linking old versions of the trait crates, and that's causing collisions when building the workspace rustdoc:

https://github.com/RustCrypto/traits/actions/runs/11112631698/job/30875140095

    warning: output filename collision.
    The lib target `aead` in package `aead v0.6.0-rc.0 (/Users/tony/src/RustCrypto/traits/aead)` has the same output filename as the lib target `aead` in package `aead v0.5.2`.
    Colliding filename is: /Users/tony/src/RustCrypto/traits/target/doc/aead/index.html
    The targets should have unique names.
    This is a known bug where multiple crates with the same name use
    the same path; see <https://github.com/rust-lang/cargo/issues/6313>.
    warning: output filename collision.
    The lib target `cipher` in package `cipher v0.5.0-pre.7 (/Users/tony/src/RustCrypto/traits/cipher)` has the same output filename as the lib target `cipher` in package `cipher v0.4.4`.
    Colliding filename is: /Users/tony/src/RustCrypto/traits/target/doc/cipher/index.html
    The targets should have unique names.
    This is a known bug where multiple crates with the same name use
    the same path; see <https://github.com/rust-lang/cargo/issues/6313>.

This changes the CI config to exclude it from the rustdoc build for now, since everything else is on a prerelease series.

We should probably bump `crypto` to link the latest prereleases soon, but for now this gets CI green again.