### PR TITLE
Remove signature error source from display message

### DIFF
--- a/signature/src/error.rs
+++ b/signature/src/error.rs
@@ -73,16 +73,7 @@ impl Debug for Error {
 
 impl Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str("signature error")?;
-
-        #[cfg(feature = "std")]
-        {
-            if let Some(source) = &self.source {
-                write!(f, ": {}", source)?;
-            }
-        }
-
-        Ok(())
+        f.write_str("signature error")
     }
 }
 


### PR DESCRIPTION
Since errors returned by `std::error::Error::source()` are commonly printed separately, this avoids double-printing the source error message.

Fixes #1685.