### PR TITLE
cipher: use `core::error`; remove `std` feature

### DIFF
--- a/.github/workflows/cipher.yml
+++ b/.github/workflows/cipher.yml
@@ -69,5 +69,4 @@ jobs:
       - run: cargo test
       - run: cargo test --features block-padding
       - run: cargo test --features dev
-      - run: cargo test --features std
       - run: cargo test --all-features

--- a/cipher/Cargo.toml
+++ b/cipher/Cargo.toml
@@ -22,7 +22,6 @@ zeroize = { version = "1.8", optional = true, default-features = false }
 
 [features]
 alloc = []
-std = ["alloc"]
 block-padding = ["inout/block-padding"]
 # Enable random key and IV generation methods
 rand_core = ["crypto-common/rand_core"]

--- a/cipher/src/lib.rs
+++ b/cipher/src/lib.rs
@@ -20,8 +20,6 @@
 
 #[cfg(all(feature = "block-padding", feature = "alloc"))]
 extern crate alloc;
-#[cfg(feature = "std")]
-extern crate std;
 
 #[cfg(feature = "dev")]
 pub use blobby;

--- a/cipher/src/stream/errors.rs
+++ b/cipher/src/stream/errors.rs
@@ -17,8 +17,7 @@ impl fmt::Display for StreamCipherError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for StreamCipherError {}
+impl core::error::Error for StreamCipherError {}
 
 /// The error type returned when a cipher position can not be represented
 /// by the requested type.
@@ -37,5 +36,4 @@ impl From<OverflowError> for StreamCipherError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for OverflowError {}
+impl core::error::Error for OverflowError {}


### PR DESCRIPTION
Switches from `std::error::Error` to `core::error::Error` which was stabilized in Rust 1.81, which is already the `cipher` crate's current MSRV.

Since this was the only usage of `std`, also removes the `std` feature.