### PR TITLE
aead: use `core::error`; remove `std` feature

### DIFF
--- a/aead/Cargo.toml
+++ b/aead/Cargo.toml
@@ -27,7 +27,6 @@ heapless = { version = "0.8", optional = true, default-features = false }
 [features]
 default = ["rand_core"]
 alloc = []
-std = ["alloc"]
 dev = ["blobby"]
 getrandom = ["crypto-common/getrandom"]
 rand_core = ["crypto-common/rand_core"]

--- a/aead/src/lib.rs
+++ b/aead/src/lib.rs
@@ -16,9 +16,6 @@
 #[cfg(feature = "alloc")]
 extern crate alloc;
 
-#[cfg(feature = "std")]
-extern crate std;
-
 #[cfg(feature = "dev")]
 pub mod dev;
 
@@ -69,8 +66,7 @@ impl fmt::Display for Error {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for Error {}
+impl core::error::Error for Error {}
 
 /// Nonce: single-use value for ensuring ciphertexts are unique
 pub type Nonce<A> = Array<u8, <A as AeadCore>::NonceSize>;


### PR DESCRIPTION
Switches from `std::error::Error` to `core::error::Error` which was stabilized in Rust 1.81, which is already the `aead` crate's current MSRV.

Since this was the only usage of `std`, also removes the `std` feature.