### PR TITLE
elliptic-curve: leverage `core::error::Error`

### DIFF
--- a/elliptic-curve/src/error.rs
+++ b/elliptic-curve/src/error.rs
@@ -9,6 +9,8 @@ pub type Result<T> = core::result::Result<T, Error>;
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct Error;
 
+impl core::error::Error for Error {}
+
 impl Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("crypto error")
@@ -40,6 +42,3 @@ impl From<sec1::Error> for Error {
         Error
     }
 }
-
-#[cfg(feature = "std")]
-impl std::error::Error for Error {}

--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -17,6 +17,8 @@
     clippy::mod_module_files,
     clippy::panic,
     clippy::panic_in_result_fn,
+    clippy::std_instead_of_alloc,
+    clippy::std_instead_of_core,
     clippy::unwrap_used,
     missing_debug_implementations,
     missing_docs,


### PR DESCRIPTION
This trait is now stable in `core`