### PR TITLE
Use full range of the stream message counter for StreamLE31

### DIFF
--- a/aead/src/stream.rs
+++ b/aead/src/stream.rs
@@ -490,7 +490,7 @@ where
     type NonceOverhead = U4;
     type Counter = u32;
     const COUNTER_INCR: u32 = 1;
-    const COUNTER_MAX: u32 = 0xfff_ffff;
+    const COUNTER_MAX: u32 = 0x7fff_ffff;
 
     fn encrypt_in_place(
         &self,


### PR DESCRIPTION
I believe that we the `StreamPrimitive` for `StreamLE31` in the library is not using the correct value for `COUNTER_MAX`, choosing `0x0FFF_FFFF` rather than `0x7FFF_FFFF`, resulting in a reduced space for the message counter. This commit changes the value to use the full range.

I do not believe this is a security issue, but it does reduce the functionality of the library.

I have just committed this off the tag of the 0.5.2 release of AEAD, rather than master, as this is currently released version.

Let me know if my understanding of the problem is incorrect or if I'm attempting to commit this to the wrong library.