### PR TITLE
signature: merge types from async-signature

### DIFF
--- a/async-signature/README.md
+++ b/async-signature/README.md
@@ -7,6 +7,10 @@
 [![Project Chat][chat-image]][chat-link]
 [![Build Status][build-image]][build-link]
 
+## Deprecated
+
+This crate is now deprecated, all the types are available in [`signature`][signature-crate]
+
 ## Minimum Supported Rust Version
 
 Rust **1.81** or higher.
@@ -41,3 +45,4 @@ dual licensed as above, without any additional terms or conditions.
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260048-signatures
 [build-image]: https://github.com/RustCrypto/traits/workflows/async-signature/badge.svg?branch=master&event=push
 [build-link]: https://github.com/RustCrypto/traits/actions?query=workflow:async-signature
+[signature-crate]: https://crates.io/crates/signature

--- a/async-signature/src/hazmat.rs
+++ b/async-signature/src/hazmat.rs
@@ -6,48 +6,15 @@
 //! Using them incorrectly can introduce security vulnerabilities. Please
 //! carefully read the documentation before attempting to use them.
 
-use signature::Error;
+#[deprecated(
+    since = "0.6.0",
+    note = "use `signature::hazmat::AsyncPrehashSigner` instead"
+)]
+pub use signature::hazmat::AsyncPrehashSigner;
 
 #[cfg(feature = "rand_core")]
-use signature::rand_core::CryptoRngCore;
-
-/// Asynchronously sign the provided message prehash, returning a digital signature.
-#[allow(async_fn_in_trait)]
-pub trait AsyncPrehashSigner<S> {
-    /// Attempt to sign the given message digest, returning a digital signature
-    /// on success, or an error if something went wrong.
-    ///
-    /// The `prehash` parameter should be the output of a secure cryptographic
-    /// hash function.
-    ///
-    /// This API takes a `prehash` byte slice as there can potentially be many
-    /// compatible lengths for the message digest for a given concrete signature
-    /// algorithm.
-    ///
-    /// Allowed lengths are algorithm-dependent and up to a particular
-    /// implementation to decide.
-    async fn sign_prehash_async(&self, prehash: &[u8]) -> Result<S, Error>;
-}
-
-/// Asynchronously sign the provided message prehash using the provided external randomness source, returning a digital signature.
-#[cfg(feature = "rand_core")]
-#[allow(async_fn_in_trait)]
-pub trait AsyncRandomizedPrehashSigner<S> {
-    /// Attempt to sign the given message digest, returning a digital signature
-    /// on success, or an error if something went wrong.
-    ///
-    /// The `prehash` parameter should be the output of a secure cryptographic
-    /// hash function.
-    ///
-    /// This API takes a `prehash` byte slice as there can potentially be many
-    /// compatible lengths for the message digest for a given concrete signature
-    /// algorithm.
-    ///
-    /// Allowed lengths are algorithm-dependent and up to a particular
-    /// implementation to decide.
-    async fn sign_prehash_with_rng_async(
-        &self,
-        rng: &mut impl CryptoRngCore,
-        prehash: &[u8],
-    ) -> Result<S, Error>;
-}
+#[deprecated(
+    since = "0.6.0",
+    note = "use `signature::hazmat::AsyncRandomizedPrehashSigner` instead"
+)]
+pub use signature::hazmat::AsyncRandomizedPrehashSigner;

--- a/async-signature/src/hazmat.rs
+++ b/async-signature/src/hazmat.rs
@@ -1,0 +1,53 @@
+//! Hazardous Materials: low-level APIs which can be insecure if misused.
+//!
+//! The traits in this module are not generally recommended, and should only be
+//! used in special cases where they are specifically needed.
+//!
+//! Using them incorrectly can introduce security vulnerabilities. Please
+//! carefully read the documentation before attempting to use them.
+
+use signature::Error;
+
+#[cfg(feature = "rand_core")]
+use signature::rand_core::CryptoRngCore;
+
+/// Asynchronously sign the provided message prehash, returning a digital signature.
+#[allow(async_fn_in_trait)]
+pub trait AsyncPrehashSigner<S> {
+    /// Attempt to sign the given message digest, returning a digital signature
+    /// on success, or an error if something went wrong.
+    ///
+    /// The `prehash` parameter should be the output of a secure cryptographic
+    /// hash function.
+    ///
+    /// This API takes a `prehash` byte slice as there can potentially be many
+    /// compatible lengths for the message digest for a given concrete signature
+    /// algorithm.
+    ///
+    /// Allowed lengths are algorithm-dependent and up to a particular
+    /// implementation to decide.
+    async fn sign_prehash_async(&self, prehash: &[u8]) -> Result<S, Error>;
+}
+
+/// Asynchronously sign the provided message prehash using the provided external randomness source, returning a digital signature.
+#[cfg(feature = "rand_core")]
+#[allow(async_fn_in_trait)]
+pub trait AsyncRandomizedPrehashSigner<S> {
+    /// Attempt to sign the given message digest, returning a digital signature
+    /// on success, or an error if something went wrong.
+    ///
+    /// The `prehash` parameter should be the output of a secure cryptographic
+    /// hash function.
+    ///
+    /// This API takes a `prehash` byte slice as there can potentially be many
+    /// compatible lengths for the message digest for a given concrete signature
+    /// algorithm.
+    ///
+    /// Allowed lengths are algorithm-dependent and up to a particular
+    /// implementation to decide.
+    async fn sign_prehash_with_rng_async(
+        &self,
+        rng: &mut impl CryptoRngCore,
+        prehash: &[u8],
+    ) -> Result<S, Error>;
+}

--- a/async-signature/src/lib.rs
+++ b/async-signature/src/lib.rs
@@ -13,6 +13,8 @@
     missing_debug_implementations
 )]
 
+pub mod hazmat;
+
 pub use signature::{self, Error};
 
 #[cfg(feature = "digest")]

--- a/async-signature/src/lib.rs
+++ b/async-signature/src/lib.rs
@@ -20,79 +20,16 @@ pub use signature::{self, Error};
 #[cfg(feature = "digest")]
 pub use signature::digest::{self, Digest};
 
-#[cfg(feature = "rand_core")]
-use signature::rand_core::CryptoRngCore;
+#[deprecated(since = "0.6.0", note = "use `signature::AsyncSigner` instead")]
+pub use signature::AsyncSigner;
 
-/// Asynchronously sign the provided message bytestring using `Self`
-/// (e.g. client for a Cloud KMS or HSM), returning a digital signature.
-///
-/// This trait is an async equivalent of the [`signature::Signer`] trait.
-#[allow(async_fn_in_trait)]
-pub trait AsyncSigner<S> {
-    /// Attempt to sign the given message, returning a digital signature on
-    /// success, or an error if something went wrong.
-    ///
-    /// The main intended use case for signing errors is when communicating
-    /// with external signers, e.g. cloud KMS, HSMs, or other hardware tokens.
-    async fn sign_async(&self, msg: &[u8]) -> Result<S, Error>;
-}
-
-impl<S, T> AsyncSigner<S> for T
-where
-    T: signature::Signer<S>,
-{
-    async fn sign_async(&self, msg: &[u8]) -> Result<S, Error> {
-        self.try_sign(msg)
-    }
-}
-
-/// Asynchronously sign the given prehashed message [`Digest`] using `Self`.
-///
-/// This trait is an async equivalent of the [`signature::DigestSigner`] trait.
 #[cfg(feature = "digest")]
-#[allow(async_fn_in_trait)]
-pub trait AsyncDigestSigner<D, S>
-where
-    D: Digest,
-{
-    /// Attempt to sign the given prehashed message [`Digest`], returning a
-    /// digital signature on success, or an error if something went wrong.
-    async fn sign_digest_async(&self, digest: D) -> Result<S, Error>;
-}
-
-/// Sign the given message using the provided external randomness source.
-#[cfg(feature = "rand_core")]
-#[allow(async_fn_in_trait)]
-pub trait AsyncRandomizedSigner<S> {
-    /// Sign the given message and return a digital signature
-    async fn sign_with_rng_async(&self, rng: &mut impl CryptoRngCore, msg: &[u8]) -> S {
-        self.try_sign_with_rng_async(rng, msg)
-            .await
-            .expect("signature operation failed")
-    }
-
-    /// Attempt to sign the given message, returning a digital signature on
-    /// success, or an error if something went wrong.
-    ///
-    /// The main intended use case for signing errors is when communicating
-    /// with external signers, e.g. cloud KMS, HSMs, or other hardware tokens.
-    async fn try_sign_with_rng_async(
-        &self,
-        rng: &mut impl CryptoRngCore,
-        msg: &[u8],
-    ) -> Result<S, Error>;
-}
+#[deprecated(since = "0.6.0", note = "use `signature::AsyncDigestSigner` instead")]
+pub use signature::AsyncDigestSigner;
 
 #[cfg(feature = "rand_core")]
-impl<S, T> AsyncRandomizedSigner<S> for T
-where
-    T: signature::RandomizedSigner<S>,
-{
-    async fn try_sign_with_rng_async(
-        &self,
-        rng: &mut impl CryptoRngCore,
-        msg: &[u8],
-    ) -> Result<S, Error> {
-        self.try_sign_with_rng(rng, msg)
-    }
-}
+#[deprecated(
+    since = "0.6.0",
+    note = "use `signature::AsyncRandomizedSigner` instead"
+)]
+pub use signature::AsyncRandomizedSigner;

--- a/signature/src/hazmat.rs
+++ b/signature/src/hazmat.rs
@@ -68,3 +68,44 @@ pub trait PrehashVerifier<S> {
     /// solving a system of linear equations.
     fn verify_prehash(&self, prehash: &[u8], signature: &S) -> Result<(), Error>;
 }
+
+/// Asynchronously sign the provided message prehash, returning a digital signature.
+#[allow(async_fn_in_trait)]
+pub trait AsyncPrehashSigner<S> {
+    /// Attempt to sign the given message digest, returning a digital signature
+    /// on success, or an error if something went wrong.
+    ///
+    /// The `prehash` parameter should be the output of a secure cryptographic
+    /// hash function.
+    ///
+    /// This API takes a `prehash` byte slice as there can potentially be many
+    /// compatible lengths for the message digest for a given concrete signature
+    /// algorithm.
+    ///
+    /// Allowed lengths are algorithm-dependent and up to a particular
+    /// implementation to decide.
+    async fn sign_prehash_async(&self, prehash: &[u8]) -> Result<S, Error>;
+}
+
+/// Asynchronously sign the provided message prehash using the provided external randomness source, returning a digital signature.
+#[cfg(feature = "rand_core")]
+#[allow(async_fn_in_trait)]
+pub trait AsyncRandomizedPrehashSigner<S> {
+    /// Attempt to sign the given message digest, returning a digital signature
+    /// on success, or an error if something went wrong.
+    ///
+    /// The `prehash` parameter should be the output of a secure cryptographic
+    /// hash function.
+    ///
+    /// This API takes a `prehash` byte slice as there can potentially be many
+    /// compatible lengths for the message digest for a given concrete signature
+    /// algorithm.
+    ///
+    /// Allowed lengths are algorithm-dependent and up to a particular
+    /// implementation to decide.
+    async fn sign_prehash_with_rng_async(
+        &self,
+        rng: &mut impl CryptoRngCore,
+        prehash: &[u8],
+    ) -> Result<S, Error>;
+}

--- a/signature/src/signer.rs
+++ b/signature/src/signer.rs
@@ -143,3 +143,77 @@ impl<S, T: RandomizedSigner<S>> RandomizedSignerMut<S> for T {
         T::try_sign_with_rng(self, rng, msg)
     }
 }
+
+/// Asynchronously sign the provided message bytestring using `Self`
+/// (e.g. client for a Cloud KMS or HSM), returning a digital signature.
+///
+/// This trait is an async equivalent of the [`Signer`] trait.
+#[allow(async_fn_in_trait)]
+pub trait AsyncSigner<S> {
+    /// Attempt to sign the given message, returning a digital signature on
+    /// success, or an error if something went wrong.
+    ///
+    /// The main intended use case for signing errors is when communicating
+    /// with external signers, e.g. cloud KMS, HSMs, or other hardware tokens.
+    async fn sign_async(&self, msg: &[u8]) -> Result<S, Error>;
+}
+
+impl<S, T> AsyncSigner<S> for T
+where
+    T: Signer<S>,
+{
+    async fn sign_async(&self, msg: &[u8]) -> Result<S, Error> {
+        self.try_sign(msg)
+    }
+}
+
+/// Asynchronously sign the given prehashed message [`Digest`] using `Self`.
+///
+/// This trait is an async equivalent of the [`DigestSigner`] trait.
+#[cfg(feature = "digest")]
+#[allow(async_fn_in_trait)]
+pub trait AsyncDigestSigner<D, S>
+where
+    D: Digest,
+{
+    /// Attempt to sign the given prehashed message [`Digest`], returning a
+    /// digital signature on success, or an error if something went wrong.
+    async fn sign_digest_async(&self, digest: D) -> Result<S, Error>;
+}
+
+/// Sign the given message using the provided external randomness source.
+#[cfg(feature = "rand_core")]
+#[allow(async_fn_in_trait)]
+pub trait AsyncRandomizedSigner<S> {
+    /// Sign the given message and return a digital signature
+    async fn sign_with_rng_async(&self, rng: &mut impl CryptoRngCore, msg: &[u8]) -> S {
+        self.try_sign_with_rng_async(rng, msg)
+            .await
+            .expect("signature operation failed")
+    }
+
+    /// Attempt to sign the given message, returning a digital signature on
+    /// success, or an error if something went wrong.
+    ///
+    /// The main intended use case for signing errors is when communicating
+    /// with external signers, e.g. cloud KMS, HSMs, or other hardware tokens.
+    async fn try_sign_with_rng_async(
+        &self,
+        rng: &mut impl CryptoRngCore,
+        msg: &[u8],
+    ) -> Result<S, Error>;
+}
+
+#[cfg(feature = "rand_core")]
+impl<S, T> AsyncRandomizedSigner<S> for T
+where
+    T: RandomizedSigner<S>,
+{
+    async fn try_sign_with_rng_async(
+        &self,
+        rng: &mut impl CryptoRngCore,
+        msg: &[u8],
+    ) -> Result<S, Error> {
+        self.try_sign_with_rng(rng, msg)
+    }
+}


### PR DESCRIPTION
Fixes #1677

This merge types defined in `async-signature` back into `signature` and effectively deprecates `async-signature`