### PR TITLE
fix: confusing commment on `Curve` trait

### DIFF
--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -191,8 +191,7 @@ pub trait Curve: 'static + Copy + Clone + Debug + Default + Eq + Ord + Send + Sy
         + FieldBytesEncoding<Self>
         + ShrAssign<usize>;
 
-    /// Order of this elliptic curve, i.e. number of elements in the scalar
-    /// field.
+    /// Order of the group formed by the elliptic curves points.
     const ORDER: Self::Uint;
 }
 


### PR DESCRIPTION
In the actual implementations (ie. p256, k256) the order is of the elliptic curve group, not the scalar field.