### PR TITLE
fix IsHigh trait comment

### DIFF
--- a/elliptic-curve/src/scalar.rs
+++ b/elliptic-curve/src/scalar.rs
@@ -49,6 +49,6 @@ pub trait FromUintUnchecked {
 /// - For scalars 0 through n / 2: `Choice::from(0)`
 /// - For scalars (n / 2) + 1 through n - 1: `Choice::from(1)`
 pub trait IsHigh {
-    /// Is this scalar greater than or equal to n / 2?
+    /// Is this scalar greater than n / 2?
     fn is_high(&self) -> Choice;
 }


### PR DESCRIPTION
The comment was saying that function informs if the scalar is **"greater or equal to"** whereas the implementation informs if the scalar is **"strictly greater than"**