### PR TITLE
CI: add `typos` job

### DIFF
--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -47,3 +47,9 @@ jobs:
           toolchain: stable
           components: rustfmt
       - run: cargo fmt --all -- --check
+
+  typos:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: crate-ci/typos@v1.29.4

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,10 @@
+[files]
+extend-exclude = [
+    ".git/",
+    "elliptic-curve/src/jwk.rs",
+    "signature/tests/derive.rs"
+]
+
+[default.extend-words]
+# Authenticated Key Exchange
+"AKE" = "AKE"

--- a/elliptic-curve/CHANGELOG.md
+++ b/elliptic-curve/CHANGELOG.md
@@ -198,7 +198,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Move `hash2field` into `hash2curve` module ([#903])
 - Bump `ff` and `group` dependencies to v0.12 ([#994])
 - Use `serdect` crate ([#996])
-- Replace `AlgorithmParamters` with `AssociatedOid` ([#1001])
+- Replace `AlgorithmParameters` with `AssociatedOid` ([#1001])
 - Bump `crypto-bigint` dependency to v0.4 ([#1005])
 - Bump `der` dependency to v0.6 ([#1006])
 - Bump `pkcs8` dependency to v0.9 ([#1006])


### PR DESCRIPTION
This should hopefully cut down on the number of typo-fixing PRs we receive by automatically checking for them in CI:

https://github.com/crate-ci/typos