### PR TITLE
CI: add `typos` config for ignoring Base64

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -1,8 +1,14 @@
 [files]
 extend-exclude = [
     ".git/",
-    "elliptic-curve/src/jwk.rs",
     "signature/tests/derive.rs"
+]
+
+[default]
+extend-ignore-re = [
+    # Patterns which appear to be 36 or more characters of Base64/Base64url
+    '\b[0-9A-Za-z+/]{36,}\b',
+    '\b[0-9A-Za-z_-]{36,}\b',
 ]
 
 [default.extend-words]


### PR DESCRIPTION
Uses a regex to detect strings that appear to be sequences of Base64-encoded characters, and re-enables the lint for the JWK implementation in `elliptic-curve`