### PR TITLE
aead: remove `AeadCore::CiphertextOverhead`

### DIFF
--- a/aead/src/lib.rs
+++ b/aead/src/lib.rs
@@ -85,10 +85,6 @@ pub trait AeadCore {
     /// The maximum length of the tag.
     type TagSize: ArraySize;
 
-    /// The upper bound amount of additional space required to support a
-    /// ciphertext vs. a plaintext.
-    type CiphertextOverhead: ArraySize + Unsigned;
-
     /// Generate a random nonce for this AEAD algorithm.
     ///
     /// AEAD algorithms accept a parameter to encryption/decryption called
@@ -575,11 +571,9 @@ mod tests {
 
     /// Ensure that `AeadInPlace` is object-safe
     #[allow(dead_code)]
-    type DynAeadInPlace<N, T, O> =
-        dyn AeadInPlace<NonceSize = N, TagSize = T, CiphertextOverhead = O>;
+    type DynAeadInPlace<N, T> = dyn AeadInPlace<NonceSize = N, TagSize = T>;
 
     /// Ensure that `AeadMutInPlace` is object-safe
     #[allow(dead_code)]
-    type DynAeadMutInPlace<N, T, O> =
-        dyn AeadMutInPlace<NonceSize = N, TagSize = T, CiphertextOverhead = O>;
+    type DynAeadMutInPlace<N, T> = dyn AeadMutInPlace<NonceSize = N, TagSize = T>;
 }


### PR DESCRIPTION
This size was intended for AEADs based on padded block cipher modes such as CBC in order to express the underlying cipher's block size and therefore the maximum amount of possible padding overhead beyond the original plaintext, which is a full block (in the case a sentinel block is added to a block-aligned plaintext input).

However, every AEAD we implement uses counter mode, i.e. a stream cipher instead of a block cipher, which has no overhead, and as such `CiphertextOverhead` is set to `U0` in every AEAD implementation we currently maintain.

Furthermore, to my knowledge there are no standard AEADs which use CBC or other padded block cipher modes of operation. The original goal was to support an expired draft specification of a CBC+HMAC AEAD.

Since it doesn't appear to be of use, this PR removes it.