### PR TITLE
Partial migration to `rand_core` v0.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,15 +166,15 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
+checksum = "f61dac84819c6588b558454b194026eb1f09c293b9036ae9b159e74e73ab6cf9"
 
 [[package]]
 name = "cc"
-version = "1.2.10"
+version = "1.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13208fcbb66eaeffe09b99fffbe1af420f00a7b35aa99ad683dfc1aa76145229"
+checksum = "c7777341816418c02e033934a09f20dc0ccaf65a5201ef8a450ae0105a573fda"
 dependencies = [
  "jobserver",
  "libc",
@@ -280,7 +280,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8658c15c5d921ddf980f7fe25b1e82f4b7a4083b2c4985fea4922edb8e43e07d"
 dependencies = [
  "generic-array",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
  "zeroize",
 ]
@@ -292,7 +292,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
  "zeroize",
 ]
@@ -305,7 +305,7 @@ checksum = "4919aa33c410cb537c1b2a8458a896f9e47ed4349a2002e5b240f358f7bf6ffc"
 dependencies = [
  "hybrid-array",
  "num-traits",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
  "zeroize",
 ]
@@ -317,7 +317,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
- "rand_core",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -325,9 +325,8 @@ dependencies = [
 name = "crypto-common"
 version = "0.2.0-rc.1"
 dependencies = [
- "getrandom 0.3.1",
  "hybrid-array",
- "rand_core",
+ "rand_core 0.9.0",
 ]
 
 [[package]]
@@ -465,7 +464,7 @@ dependencies = [
  "generic-array",
  "group 0.10.0",
  "pkcs8 0.7.6",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
  "zeroize",
 ]
@@ -484,7 +483,7 @@ dependencies = [
  "group 0.13.0",
  "hkdf 0.12.4",
  "pkcs8 0.10.2",
- "rand_core",
+ "rand_core 0.6.4",
  "sec1 0.7.3",
  "subtle",
  "zeroize",
@@ -505,7 +504,7 @@ dependencies = [
  "hybrid-array",
  "pem-rfc7468 1.0.0-rc.2",
  "pkcs8 0.11.0-rc.1",
- "rand_core",
+ "rand_core 0.6.4",
  "sec1 0.8.0-rc.3",
  "serde_json",
  "serdect",
@@ -522,7 +521,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0f40b2dcd8bc322217a5f6559ae5f9e9d1de202a2ecee2e9eafcbece7562a4f"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -533,7 +532,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
 dependencies = [
  "bitvec",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -606,7 +605,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c363a5301b8f153d80747126a04b3c82073b9fe3130571a9d170cacdeaf7912"
 dependencies = [
  "ff 0.10.1",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -617,7 +616,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff 0.13.0",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -716,7 +715,7 @@ dependencies = [
  "hkdf 0.12.4",
  "hmac 0.12.1",
  "p256 0.13.2",
- "rand_core",
+ "rand_core 0.6.4",
  "sha2 0.10.8",
  "subtle",
  "x25519-dalek",
@@ -786,7 +785,7 @@ dependencies = [
  "pqcrypto",
  "pqcrypto-traits",
  "rand",
- "rand_core",
+ "rand_core 0.6.4",
  "x3dh-ke",
  "zeroize",
 ]
@@ -846,7 +845,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
 dependencies = [
  "base64ct",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -855,7 +854,7 @@ name = "password-hash"
 version = "0.6.0-rc.0"
 dependencies = [
  "base64ct",
- "rand_core",
+ "rand_core 0.9.0",
  "subtle",
 ]
 
@@ -938,7 +937,7 @@ version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -953,9 +952,9 @@ dependencies = [
 
 [[package]]
 name = "pqcrypto-internals"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62cd8ebf02b43967cda06e6a3f54d0bd9659459c3003d16aeedd07b44c6db06c"
+checksum = "9cc3518d9ec325ec95d89749d4f5c111776b97c5bbd26e3ffe523aa300f1e27e"
 dependencies = [
  "cc",
  "dunce",
@@ -1023,7 +1022,7 @@ checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1033,7 +1032,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1043,6 +1042,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.15",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b08f3c9802962f7e1b25113931d94f43ed9725bebc59db9d0c3e9a23b67e15ff"
+dependencies = [
+ "getrandom 0.3.1",
+ "zerocopy 0.8.17",
 ]
 
 [[package]]
@@ -1204,7 +1213,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2807892cfa58e081aa1f1111391c7a0649d4fa127a4ffbe34bcbfb35a1171a4"
 dependencies = [
  "digest 0.9.0",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1213,7 +1222,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1222,7 +1231,7 @@ version = "2.3.0-pre.4"
 dependencies = [
  "digest 0.11.0-pre.9",
  "hex-literal",
- "rand_core",
+ "rand_core 0.9.0",
  "sha2 0.11.0-pre.4",
  "signature_derive",
 ]
@@ -1279,9 +1288,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.96"
+version = "2.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5d0adab1ae378d7f53bdebc67a39f1f151407ef230f0ce2883572f5d8985c80"
+checksum = "36147f1a48ae0ec2b5b3bc5b537d267457555a10dc06f3dbc8cb11ba3006d3b1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1434,7 +1443,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
 dependencies = [
  "curve25519-dalek",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1449,7 +1458,7 @@ dependencies = [
  "getrandom 0.2.15",
  "hkdf 0.11.0",
  "p256 0.9.0",
- "rand_core",
+ "rand_core 0.6.4",
  "serde",
  "serde_bytes",
  "sha2 0.9.9",
@@ -1462,7 +1471,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
  "byteorder",
- "zerocopy-derive",
+ "zerocopy-derive 0.7.35",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa91407dacce3a68c56de03abe2760159582b846c6a4acd2f456618087f12713"
+dependencies = [
+ "zerocopy-derive 0.8.17",
 ]
 
 [[package]]
@@ -1470,6 +1488,17 @@ name = "zerocopy-derive"
 version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06718a168365cad3d5ff0bb133aad346959a2074bd4a85c121255a11304a8626"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/aead/Cargo.toml
+++ b/aead/Cargo.toml
@@ -16,7 +16,7 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.81"
 
 [dependencies]
-crypto-common = "0.2.0-rc.0"
+crypto-common = "0.2.0-rc.1"
 
 # optional dependencies
 arrayvec = { version = "0.7", optional = true, default-features = false }
@@ -28,7 +28,7 @@ heapless = { version = "0.8", optional = true, default-features = false }
 default = ["rand_core"]
 alloc = []
 dev = ["blobby"]
-getrandom = ["crypto-common/getrandom"]
+os_rng = ["crypto-common/os_rng", "rand_core"]
 rand_core = ["crypto-common/rand_core"]
 
 [package.metadata.docs.rs]

--- a/aead/src/lib.rs
+++ b/aead/src/lib.rs
@@ -30,8 +30,6 @@ pub use crypto_common::{
 pub use arrayvec;
 #[cfg(feature = "bytes")]
 pub use bytes;
-#[cfg(feature = "getrandom")]
-pub use crypto_common::rand_core::OsRng;
 #[cfg(feature = "heapless")]
 pub use heapless;
 
@@ -45,10 +43,10 @@ use crypto_common::array::{typenum::Unsigned, Array, ArraySize};
 use alloc::vec::Vec;
 #[cfg(feature = "bytes")]
 use bytes::BytesMut;
-#[cfg(feature = "getrandom")]
-use crypto_common::getrandom;
+#[cfg(feature = "os_rng")]
+use crypto_common::rand_core::{OsError, OsRng, TryRngCore};
 #[cfg(feature = "rand_core")]
-use rand_core::CryptoRngCore;
+use rand_core::{CryptoRng, TryCryptoRng};
 
 /// Error type.
 ///
@@ -120,13 +118,10 @@ pub trait AeadCore {
     /// See the [`stream`] module for a ready-made implementation of the latter.
     ///
     /// [NIST SP 800-38D]: https://csrc.nist.gov/publications/detail/sp/800-38d/final
-    #[cfg(feature = "getrandom")]
-    fn generate_nonce() -> core::result::Result<Nonce<Self>, getrandom::Error>
-    where
-        Nonce<Self>: Default,
-    {
+    #[cfg(feature = "os_rng")]
+    fn generate_nonce() -> core::result::Result<Nonce<Self>, OsError> {
         let mut nonce = Nonce::<Self>::default();
-        getrandom::fill(&mut nonce)?;
+        OsRng.try_fill_bytes(&mut nonce)?;
         Ok(nonce)
     }
 
@@ -136,12 +131,21 @@ pub trait AeadCore {
     /// See [`AeadCore::generate_nonce`] documentation for requirements for
     /// random nonces.
     #[cfg(feature = "rand_core")]
-    fn generate_nonce_with_rng(
-        rng: &mut impl CryptoRngCore,
-    ) -> core::result::Result<Nonce<Self>, rand_core::Error>
-    where
-        Nonce<Self>: Default,
-    {
+    fn generate_nonce_with_rng<R: CryptoRng>(rng: &mut R) -> Nonce<Self> {
+        let mut nonce = Nonce::<Self>::default();
+        rng.fill_bytes(&mut nonce);
+        nonce
+    }
+
+    /// Generate a random nonce for this AEAD algorithm using the specified
+    /// [`CryptoRngCore`].
+    ///
+    /// See [`AeadCore::generate_nonce`] documentation for requirements for
+    /// random nonces.
+    #[cfg(feature = "rand_core")]
+    fn try_generate_nonce_with_rng<R: TryCryptoRng>(
+        rng: &mut R,
+    ) -> core::result::Result<Nonce<Self>, R::Error> {
         let mut nonce = Nonce::<Self>::default();
         rng.try_fill_bytes(&mut nonce)?;
         Ok(nonce)

--- a/aead/src/lib.rs
+++ b/aead/src/lib.rs
@@ -125,8 +125,7 @@ pub trait AeadCore {
         Ok(nonce)
     }
 
-    /// Generate a random nonce for this AEAD algorithm using the specified
-    /// [`CryptoRngCore`].
+    /// Generate a random nonce for this AEAD algorithm using the specified [`CryptoRng`].
     ///
     /// See [`AeadCore::generate_nonce`] documentation for requirements for
     /// random nonces.
@@ -137,8 +136,7 @@ pub trait AeadCore {
         nonce
     }
 
-    /// Generate a random nonce for this AEAD algorithm using the specified
-    /// [`CryptoRngCore`].
+    /// Generate a random nonce for this AEAD algorithm using the specified [`TryCryptoRng`].
     ///
     /// See [`AeadCore::generate_nonce`] documentation for requirements for
     /// random nonces.

--- a/async-signature/tests/mock_impl.rs
+++ b/async-signature/tests/mock_impl.rs
@@ -28,9 +28,9 @@ where
 
 #[cfg(feature = "rand_core")]
 impl async_signature::AsyncRandomizedSigner<Signature> for MockSigner {
-    async fn try_sign_with_rng_async(
+    async fn try_sign_with_rng_async<R: async_signature::signature::rand_core::TryCryptoRng>(
         &self,
-        _rng: &mut impl async_signature::signature::rand_core::CryptoRngCore,
+        _rng: &mut R,
         _msg: &[u8],
     ) -> Result<Signature, Error> {
         unimplemented!("just meant to check compilation")

--- a/cipher/Cargo.toml
+++ b/cipher/Cargo.toml
@@ -25,6 +25,7 @@ alloc = []
 block-padding = ["inout/block-padding"]
 # Enable random key and IV generation methods
 rand_core = ["crypto-common/rand_core"]
+os_rng = ["crypto-common/os_rng", "rand_core"]
 dev = ["blobby"]
 
 [package.metadata.docs.rs]

--- a/crypto-common/Cargo.toml
+++ b/crypto-common/Cargo.toml
@@ -16,11 +16,11 @@ categories = ["cryptography", "no-std"]
 hybrid-array = "0.2"
 
 # optional dependencies
-rand_core = { version = "0.6.4", optional = true }
-getrandom = { version = "0.3", optional = true }
+rand_core = { version = "0.9", optional = true }
 
 [features]
-getrandom = ["dep:getrandom", "rand_core?/getrandom"]
+os_rng = ["rand_core/os_rng", "rand_core"]
+rand_core = ["dep:rand_core"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crypto-common/src/lib.rs
+++ b/crypto-common/src/lib.rs
@@ -12,8 +12,6 @@
 /// Hazardous materials.
 pub mod hazmat;
 
-#[cfg(feature = "getrandom")]
-pub use getrandom;
 #[cfg(feature = "rand_core")]
 pub use rand_core;
 
@@ -27,7 +25,9 @@ use hybrid_array::{
 };
 
 #[cfg(feature = "rand_core")]
-use rand_core::CryptoRngCore;
+use rand_core::{CryptoRng, TryCryptoRng};
+#[cfg(feature = "os_rng")]
+use rand_core::{OsError, OsRng, TryRngCore};
 
 /// Block on which [`BlockSizeUser`] implementors operate.
 pub type Block<B> = Array<u8, <B as BlockSizeUser>::BlockSize>;
@@ -185,18 +185,27 @@ pub trait KeyInit: KeySizeUser + Sized {
     }
 
     /// Generate random key using the operating system's secure RNG.
-    #[cfg(feature = "getrandom")]
+    #[cfg(feature = "os_rng")]
     #[inline]
-    fn generate_key() -> Result<Key<Self>, getrandom::Error> {
+    fn generate_key() -> Result<Key<Self>, OsError> {
         let mut key = Key::<Self>::default();
-        getrandom::fill(&mut key)?;
+        OsRng.try_fill_bytes(&mut key)?;
         Ok(key)
     }
 
-    /// Generate random key using the provided [`CryptoRngCore`].
+    /// Generate random key using the provided [`CryptoRng`].
     #[cfg(feature = "rand_core")]
     #[inline]
-    fn generate_key_with_rng(rng: &mut impl CryptoRngCore) -> Result<Key<Self>, rand_core::Error> {
+    fn generate_key_with_rng<R: CryptoRng>(rng: &mut R) -> Key<Self> {
+        let mut key = Key::<Self>::default();
+        rng.fill_bytes(&mut key);
+        key
+    }
+
+    /// Generate random key using the provided [`TryCryptoRng`].
+    #[cfg(feature = "rand_core")]
+    #[inline]
+    fn try_generate_key_with_rng<R: TryCryptoRng>(rng: &mut R) -> Result<Key<Self>, R::Error> {
         let mut key = Key::<Self>::default();
         rng.try_fill_bytes(&mut key)?;
         Ok(key)
@@ -230,58 +239,85 @@ pub trait KeyIvInit: KeySizeUser + IvSizeUser + Sized {
     }
 
     /// Generate random key using the operating system's secure RNG.
-    #[cfg(feature = "getrandom")]
+    #[cfg(feature = "os_rng")]
     #[inline]
-    fn generate_key() -> Result<Key<Self>, getrandom::Error> {
+    fn generate_key() -> Result<Key<Self>, OsError> {
         let mut key = Key::<Self>::default();
-        getrandom::fill(&mut key)?;
+        OsRng.try_fill_bytes(&mut key)?;
         Ok(key)
     }
 
-    /// Generate random key using the provided [`CryptoRngCore`].
+    /// Generate random key using the provided [`CryptoRng`].
     #[cfg(feature = "rand_core")]
     #[inline]
-    fn generate_key_with_rng(rng: &mut impl CryptoRngCore) -> Result<Key<Self>, rand_core::Error> {
+    fn generate_key_with_rng<R: CryptoRng>(rng: &mut R) -> Key<Self> {
+        let mut key = Key::<Self>::default();
+        rng.fill_bytes(&mut key);
+        key
+    }
+
+    /// Generate random key using the provided [`TryCryptoRng`].
+    #[cfg(feature = "rand_core")]
+    #[inline]
+    fn try_generate_key_with_rng<R: TryCryptoRng>(rng: &mut R) -> Result<Key<Self>, R::Error> {
         let mut key = Key::<Self>::default();
         rng.try_fill_bytes(&mut key)?;
         Ok(key)
     }
 
     /// Generate random IV using the operating system's secure RNG.
-    #[cfg(feature = "getrandom")]
+    #[cfg(feature = "os_rng")]
     #[inline]
-    fn generate_iv() -> Result<Iv<Self>, getrandom::Error> {
+    fn generate_iv() -> Result<Iv<Self>, OsError> {
         let mut iv = Iv::<Self>::default();
-        getrandom::fill(&mut iv)?;
+        OsRng.try_fill_bytes(&mut iv)?;
         Ok(iv)
     }
 
-    /// Generate random IV using the provided [`CryptoRngCore`].
+    /// Generate random IV using the provided [`CryptoRng`].
     #[cfg(feature = "rand_core")]
     #[inline]
-    fn generate_iv_with_rng(rng: &mut impl CryptoRngCore) -> Result<Iv<Self>, rand_core::Error> {
+    fn generate_iv_with_rng<R: CryptoRng>(rng: &mut R) -> Iv<Self> {
+        let mut iv = Iv::<Self>::default();
+        rng.fill_bytes(&mut iv);
+        iv
+    }
+
+    /// Generate random IV using the provided [`TryCryptoRng`].
+    #[cfg(feature = "rand_core")]
+    #[inline]
+    fn try_generate_iv_with_rng<R: TryCryptoRng>(rng: &mut R) -> Result<Iv<Self>, R::Error> {
         let mut iv = Iv::<Self>::default();
         rng.try_fill_bytes(&mut iv)?;
         Ok(iv)
     }
 
     /// Generate random key and IV using the operating system's secure RNG.
-    #[cfg(feature = "getrandom")]
+    #[cfg(feature = "os_rng")]
     #[inline]
-    fn generate_key_iv() -> Result<(Key<Self>, Iv<Self>), getrandom::Error> {
+    fn generate_key_iv() -> Result<(Key<Self>, Iv<Self>), OsError> {
         let key = Self::generate_key()?;
         let iv = Self::generate_iv()?;
         Ok((key, iv))
     }
 
-    /// Generate random key and IV using the provided [`CryptoRngCore`].
+    /// Generate random key and IV using the provided [`CryptoRng`].
     #[cfg(feature = "rand_core")]
     #[inline]
-    fn generate_key_iv_with_rng(
-        rng: &mut impl CryptoRngCore,
-    ) -> Result<(Key<Self>, Iv<Self>), rand_core::Error> {
-        let key = Self::generate_key_with_rng(rng)?;
-        let iv = Self::generate_iv_with_rng(rng)?;
+    fn generate_key_iv_with_rng<R: CryptoRng>(rng: &mut R) -> (Key<Self>, Iv<Self>) {
+        let key = Self::generate_key_with_rng(rng);
+        let iv = Self::generate_iv_with_rng(rng);
+        (key, iv)
+    }
+
+    /// Generate random key and IV using the provided [`TryCryptoRng`].
+    #[cfg(feature = "rand_core")]
+    #[inline]
+    fn try_generate_key_iv_with_rng<R: TryCryptoRng>(
+        rng: &mut R,
+    ) -> Result<(Key<Self>, Iv<Self>), R::Error> {
+        let key = Self::try_generate_key_with_rng(rng)?;
+        let iv = Self::try_generate_iv_with_rng(rng)?;
         Ok((key, iv))
     }
 }
@@ -310,18 +346,27 @@ pub trait InnerIvInit: InnerUser + IvSizeUser + Sized {
     }
 
     /// Generate random IV using the operating system's secure RNG.
-    #[cfg(feature = "getrandom")]
+    #[cfg(feature = "os_rng")]
     #[inline]
-    fn generate_iv() -> Result<Iv<Self>, getrandom::Error> {
+    fn generate_iv() -> Result<Iv<Self>, OsError> {
         let mut iv = Iv::<Self>::default();
-        getrandom::fill(&mut iv)?;
+        OsRng.try_fill_bytes(&mut iv)?;
         Ok(iv)
     }
 
-    /// Generate random IV using the provided [`CryptoRngCore`].
+    /// Generate random IV using the provided [`CryptoRng`].
     #[cfg(feature = "rand_core")]
     #[inline]
-    fn generate_iv_with_rng(rng: &mut impl CryptoRngCore) -> Result<Iv<Self>, rand_core::Error> {
+    fn generate_iv_with_rng<R: CryptoRng>(rng: &mut R) -> Iv<Self> {
+        let mut iv = Iv::<Self>::default();
+        rng.fill_bytes(&mut iv);
+        iv
+    }
+
+    /// Generate random IV using the provided [`TryCryptoRng`].
+    #[cfg(feature = "rand_core")]
+    #[inline]
+    fn try_generate_iv_with_rng<R: TryCryptoRng>(rng: &mut R) -> Result<Iv<Self>, R::Error> {
         let mut iv = Iv::<Self>::default();
         rng.try_fill_bytes(&mut iv)?;
         Ok(iv)

--- a/digest/Cargo.toml
+++ b/digest/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["digest", "crypto", "hash"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-crypto-common = "0.2.0-rc.0"
+crypto-common = "0.2.0-rc.1"
 
 # optional dependencies
 block-buffer = { version = "0.11.0-rc.2", optional = true }
@@ -27,6 +27,7 @@ default = ["core-api"]
 core-api = ["block-buffer"] # Enable Core API traits
 mac = ["subtle"] # Enable MAC traits
 rand_core = ["crypto-common/rand_core"] # Enable random key generation methods
+os_rng = ["crypto-common/rand_core", "rand_core"]
 oid = ["const-oid"]
 zeroize = ["dep:zeroize", "block-buffer?/zeroize"]
 alloc = []

--- a/password-hash/Cargo.toml
+++ b/password-hash/Cargo.toml
@@ -22,13 +22,13 @@ base64ct = "1.6"
 subtle = { version = "2", default-features = false }
 
 # optional dependencies
-rand_core = { version = "0.6.4", optional = true, default-features = false }
+rand_core = { version = "0.9", optional = true, default-features = false }
 
 [features]
 default = ["rand_core"]
+rand_core = ["dep:rand_core"]
+os_rng = ["rand_core", "rand_core/os_rng"]
 alloc = ["base64ct/alloc"]
-
-getrandom = ["rand_core/getrandom"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/password-hash/src/output.rs
+++ b/password-hash/src/output.rs
@@ -88,7 +88,8 @@ use subtle::{Choice, ConstantTimeEq};
 /// time, we would also suggest preventing such attacks by using randomly
 /// generated salts and keeping those salts secret.
 ///
-/// The [`SaltString::generate`][`crate::SaltString::generate`] function can be
+/// The [`SaltString::from_rng`][`crate::SaltString::from_rng`] and
+/// [`SaltString::try_from_rng`][`crate::SaltString::try_from_rng`] functions can be
 /// used to generate random high-entropy salt values.
 ///
 /// [1]: https://github.com/P-H-C/phc-string-format/blob/master/phc-sf-spec.md#function-duties

--- a/signature/Cargo.toml
+++ b/signature/Cargo.toml
@@ -16,7 +16,7 @@ rust-version = "1.81"
 [dependencies]
 derive = { package = "signature_derive", version = "2", optional = true, path = "../signature_derive" }
 digest = { version = "=0.11.0-pre.9", optional = true, default-features = false }
-rand_core = { version = "0.6.4", optional = true, default-features = false }
+rand_core = { version = "0.9", optional = true, default-features = false }
 
 [dev-dependencies]
 hex-literal = "0.4"
@@ -26,6 +26,7 @@ sha2 = { version = "=0.11.0-pre.4", default-features = false }
 alloc = []
 # TODO: remove this feature in the next breaking release
 std = ["alloc", "rand_core?/std"]
+rand_core = ["dep:rand_core"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/signature/src/error.rs
+++ b/signature/src/error.rs
@@ -83,19 +83,6 @@ impl From<Box<dyn core::error::Error + Send + Sync + 'static>> for Error {
     }
 }
 
-// #[cfg(feature = "rand_core")]
-// impl From<rand_core::OsError> for Error {
-//     #[cfg(not(feature = "alloc"))]
-//     fn from(_source: rand_core::Error) -> Error {
-//         Error::new()
-//     }
-
-//     #[cfg(feature = "alloc")]
-//     fn from(source: rand_core::OsError) -> Error {
-//         Error::from_source(source)
-//     }
-// }
-
 impl core::error::Error for Error {
     fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
         #[cfg(not(feature = "alloc"))]

--- a/signature/src/error.rs
+++ b/signature/src/error.rs
@@ -83,18 +83,18 @@ impl From<Box<dyn core::error::Error + Send + Sync + 'static>> for Error {
     }
 }
 
-#[cfg(feature = "rand_core")]
-impl From<rand_core::Error> for Error {
-    #[cfg(not(feature = "alloc"))]
-    fn from(_source: rand_core::Error) -> Error {
-        Error::new()
-    }
+// #[cfg(feature = "rand_core")]
+// impl From<rand_core::OsError> for Error {
+//     #[cfg(not(feature = "alloc"))]
+//     fn from(_source: rand_core::Error) -> Error {
+//         Error::new()
+//     }
 
-    #[cfg(feature = "alloc")]
-    fn from(source: rand_core::Error) -> Error {
-        Error::from_source(source)
-    }
-}
+//     #[cfg(feature = "alloc")]
+//     fn from(source: rand_core::OsError) -> Error {
+//         Error::from_source(source)
+//     }
+// }
 
 impl core::error::Error for Error {
     fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {

--- a/signature/src/hazmat.rs
+++ b/signature/src/hazmat.rs
@@ -9,7 +9,7 @@
 use crate::Error;
 
 #[cfg(feature = "rand_core")]
-use crate::rand_core::CryptoRngCore;
+use crate::rand_core::CryptoRng;
 
 /// Sign the provided message prehash, returning a digital signature.
 pub trait PrehashSigner<S> {
@@ -43,11 +43,7 @@ pub trait RandomizedPrehashSigner<S> {
     ///
     /// Allowed lengths are algorithm-dependent and up to a particular
     /// implementation to decide.
-    fn sign_prehash_with_rng(
-        &self,
-        rng: &mut impl CryptoRngCore,
-        prehash: &[u8],
-    ) -> Result<S, Error>;
+    fn sign_prehash_with_rng<R: CryptoRng>(&self, rng: &mut R, prehash: &[u8]) -> Result<S, Error>;
 }
 
 /// Verify the provided message prehash using `Self` (e.g. a public key)

--- a/signature/src/signer.rs
+++ b/signature/src/signer.rs
@@ -6,7 +6,7 @@ use crate::error::Error;
 use crate::digest::Digest;
 
 #[cfg(feature = "rand_core")]
-use crate::rand_core::CryptoRngCore;
+use crate::rand_core::{CryptoRng, TryCryptoRng};
 
 /// Sign the provided message bytestring using `Self` (e.g. a cryptographic key
 /// or connection to an HSM), returning a digital signature.
@@ -86,7 +86,7 @@ pub trait DigestSigner<D: Digest, S> {
 #[cfg(feature = "rand_core")]
 pub trait RandomizedSigner<S> {
     /// Sign the given message and return a digital signature
-    fn sign_with_rng(&self, rng: &mut impl CryptoRngCore, msg: &[u8]) -> S {
+    fn sign_with_rng<R: CryptoRng>(&self, rng: &mut R, msg: &[u8]) -> S {
         self.try_sign_with_rng(rng, msg)
             .expect("signature operation failed")
     }
@@ -96,7 +96,7 @@ pub trait RandomizedSigner<S> {
     ///
     /// The main intended use case for signing errors is when communicating
     /// with external signers, e.g. cloud KMS, HSMs, or other hardware tokens.
-    fn try_sign_with_rng(&self, rng: &mut impl CryptoRngCore, msg: &[u8]) -> Result<S, Error>;
+    fn try_sign_with_rng<R: TryCryptoRng>(&self, rng: &mut R, msg: &[u8]) -> Result<S, Error>;
 }
 
 /// Combination of [`DigestSigner`] and [`RandomizedSigner`] with support for
@@ -106,14 +106,14 @@ pub trait RandomizedDigestSigner<D: Digest, S> {
     /// Sign the given prehashed message `Digest`, returning a signature.
     ///
     /// Panics in the event of a signing error.
-    fn sign_digest_with_rng(&self, rng: &mut impl CryptoRngCore, digest: D) -> S {
+    fn sign_digest_with_rng<R: CryptoRng>(&self, rng: &mut R, digest: D) -> S {
         self.try_sign_digest_with_rng(rng, digest)
             .expect("signature operation failed")
     }
 
     /// Attempt to sign the given prehashed message `Digest`, returning a
     /// digital signature on success, or an error if something went wrong.
-    fn try_sign_digest_with_rng(&self, rng: &mut impl CryptoRngCore, digest: D)
+    fn try_sign_digest_with_rng<R: TryCryptoRng>(&self, rng: &mut R, digest: D)
         -> Result<S, Error>;
 }
 
@@ -123,7 +123,7 @@ pub trait RandomizedDigestSigner<D: Digest, S> {
 #[cfg(feature = "rand_core")]
 pub trait RandomizedSignerMut<S> {
     /// Sign the given message, update the state, and return a digital signature.
-    fn sign_with_rng(&mut self, rng: &mut impl CryptoRngCore, msg: &[u8]) -> S {
+    fn sign_with_rng<R: CryptoRng>(&mut self, rng: &mut R, msg: &[u8]) -> S {
         self.try_sign_with_rng(rng, msg)
             .expect("signature operation failed")
     }
@@ -133,13 +133,13 @@ pub trait RandomizedSignerMut<S> {
     ///
     /// Signing can fail, e.g., if the number of time periods allowed by the
     /// current key is exceeded.
-    fn try_sign_with_rng(&mut self, rng: &mut impl CryptoRngCore, msg: &[u8]) -> Result<S, Error>;
+    fn try_sign_with_rng<R: TryCryptoRng>(&mut self, rng: &mut R, msg: &[u8]) -> Result<S, Error>;
 }
 
 /// Blanket impl of [`RandomizedSignerMut`] for all [`RandomizedSigner`] types.
 #[cfg(feature = "rand_core")]
 impl<S, T: RandomizedSigner<S>> RandomizedSignerMut<S> for T {
-    fn try_sign_with_rng(&mut self, rng: &mut impl CryptoRngCore, msg: &[u8]) -> Result<S, Error> {
+    fn try_sign_with_rng<R: TryCryptoRng>(&mut self, rng: &mut R, msg: &[u8]) -> Result<S, Error> {
         T::try_sign_with_rng(self, rng, msg)
     }
 }

--- a/universal-hash/Cargo.toml
+++ b/universal-hash/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["crypto", "mac"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-crypto-common = "0.2.0-rc.0"
+crypto-common = "0.2.0-rc.1"
 subtle = { version = "2.4", default-features = false }
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
`kem` and `elliptic-curve` can not be migrated because of upstream dependencies which still use `rand_core` v0.6 and expose it in their public API.

`getrandom` crate features are renamed to `os_rng` following the similar change in `rand_core`.

Relevant issue: #1642 