### PR TITLE
signature: Prehash should accept a `TryCryptoRng`

### DIFF
--- a/signature/src/hazmat.rs
+++ b/signature/src/hazmat.rs
@@ -9,7 +9,7 @@
 use crate::Error;
 
 #[cfg(feature = "rand_core")]
-use crate::rand_core::CryptoRng;
+use crate::rand_core::TryCryptoRng;
 
 /// Sign the provided message prehash, returning a digital signature.
 pub trait PrehashSigner<S> {
@@ -43,7 +43,11 @@ pub trait RandomizedPrehashSigner<S> {
     ///
     /// Allowed lengths are algorithm-dependent and up to a particular
     /// implementation to decide.
-    fn sign_prehash_with_rng<R: CryptoRng>(&self, rng: &mut R, prehash: &[u8]) -> Result<S, Error>;
+    fn sign_prehash_with_rng<R: TryCryptoRng>(
+        &self,
+        rng: &mut R,
+        prehash: &[u8],
+    ) -> Result<S, Error>;
 }
 
 /// Verify the provided message prehash using `Self` (e.g. a public key)
@@ -99,7 +103,7 @@ pub trait AsyncRandomizedPrehashSigner<S> {
     ///
     /// Allowed lengths are algorithm-dependent and up to a particular
     /// implementation to decide.
-    async fn sign_prehash_with_rng_async<R: CryptoRng>(
+    async fn sign_prehash_with_rng_async<R: TryCryptoRng>(
         &self,
         rng: &mut R,
         prehash: &[u8],


### PR DESCRIPTION
This is so that a `RandomizedDigestSigner` can call into `hazmat::RandomizedPrehashSigner` directly with the provided rng.

Example use: https://github.com/RustCrypto/signatures/pull/901