### PR TITLE
elliptic-curve: fix Nightly compiler warnings

### DIFF
--- a/elliptic-curve/src/dev.rs
+++ b/elliptic-curve/src/dev.rs
@@ -114,12 +114,10 @@ impl Field for Scalar {
         self.0.is_zero()
     }
 
-    #[must_use]
     fn square(&self) -> Self {
         unimplemented!();
     }
 
-    #[must_use]
     fn double(&self) -> Self {
         self.add(self)
     }
@@ -601,7 +599,6 @@ impl group::Group for ProjectivePoint {
         Choice::from(u8::from(self == &Self::Identity))
     }
 
-    #[must_use]
     fn double(&self) -> Self {
         unimplemented!();
     }


### PR DESCRIPTION
`#[must_use]` annotations have no effect on trait methods.

See this CI job:
https://github.com/RustCrypto/traits/actions/runs/13452612496/job/37589720185