### PR TITLE
signature: Relax `Sized` requirements on async signer traits

### DIFF
--- a/signature/src/hazmat.rs
+++ b/signature/src/hazmat.rs
@@ -43,7 +43,7 @@ pub trait RandomizedPrehashSigner<S> {
     ///
     /// Allowed lengths are algorithm-dependent and up to a particular
     /// implementation to decide.
-    fn sign_prehash_with_rng<R: TryCryptoRng>(
+    fn sign_prehash_with_rng<R: TryCryptoRng + ?Sized>(
         &self,
         rng: &mut R,
         prehash: &[u8],
@@ -103,7 +103,7 @@ pub trait AsyncRandomizedPrehashSigner<S> {
     ///
     /// Allowed lengths are algorithm-dependent and up to a particular
     /// implementation to decide.
-    async fn sign_prehash_with_rng_async<R: TryCryptoRng>(
+    async fn sign_prehash_with_rng_async<R: TryCryptoRng + ?Sized>(
         &self,
         rng: &mut R,
         prehash: &[u8],

--- a/signature/src/signer.rs
+++ b/signature/src/signer.rs
@@ -201,7 +201,7 @@ where
 #[allow(async_fn_in_trait)]
 pub trait AsyncRandomizedSigner<S> {
     /// Sign the given message and return a digital signature
-    async fn sign_with_rng_async<R: CryptoRng>(&self, rng: &mut R, msg: &[u8]) -> S {
+    async fn sign_with_rng_async<R: CryptoRng + ?Sized>(&self, rng: &mut R, msg: &[u8]) -> S {
         self.try_sign_with_rng_async(rng, msg)
             .await
             .expect("signature operation failed")
@@ -212,7 +212,7 @@ pub trait AsyncRandomizedSigner<S> {
     ///
     /// The main intended use case for signing errors is when communicating
     /// with external signers, e.g. cloud KMS, HSMs, or other hardware tokens.
-    async fn try_sign_with_rng_async<R: CryptoRng>(
+    async fn try_sign_with_rng_async<R: TryCryptoRng + ?Sized>(
         &self,
         rng: &mut R,
         msg: &[u8],
@@ -224,7 +224,7 @@ impl<S, T> AsyncRandomizedSigner<S> for T
 where
     T: RandomizedSigner<S>,
 {
-    async fn try_sign_with_rng_async<R: CryptoRng>(
+    async fn try_sign_with_rng_async<R: TryCryptoRng + ?Sized>(
         &self,
         rng: &mut R,
         msg: &[u8],


### PR DESCRIPTION
Follow up on https://github.com/RustCrypto/traits/pull/1765