### PR TITLE
digest: bump `const-oid` dependency to v0.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,9 +117,9 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
-version = "0.10.0-rc.3"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ff6be19477a1bd5441f382916a89bc2a0b2c35db6d41e0f6e8538bf6d6463f"
+checksum = "1cb3c4a0d3776f7535c32793be81d6d5fec0d48ac70955d9834e643aa249a52f"
 
 [[package]]
 name = "cpufeatures"

--- a/digest/Cargo.toml
+++ b/digest/Cargo.toml
@@ -19,7 +19,7 @@ crypto-common = { version = "0.2.0-rc.2", path = "../crypto-common" }
 block-buffer = { version = "0.11.0-rc.4", optional = true }
 subtle = { version = "2.4", default-features = false, optional = true }
 blobby = { version = "0.4.0-pre.0", optional = true }
-const-oid = { version = "0.10.0-rc.3", optional = true }
+const-oid = { version = "0.10", optional = true }
 zeroize = { version = "1.7", optional = true, default-features = false }
 
 [features]


### PR DESCRIPTION
Release notes: https://github.com/RustCrypto/formats/pull/1672