### PR TITLE
elliptic-curve: adds Scalar::try_from_rng method

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -237,7 +237,6 @@ dependencies = [
 [[package]]
 name = "ff"
 version = "0.13.0"
-source = "git+https://github.com/baloo/ff.git?branch=baloo%2Frelax-sized-rng#4ae604c5af58d047de06ea42197ef44f3f7d7834"
 dependencies = [
  "bitvec",
  "rand_core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -237,7 +237,7 @@ dependencies = [
 [[package]]
 name = "ff"
 version = "0.13.0"
-source = "git+https://github.com/pinkforest/ff.git?branch=bump-rand-core#c734f7f21d6639bc6494dde538209d0770207c49"
+source = "git+https://github.com/baloo/ff.git?branch=baloo%2Frelax-sized-rng#4ae604c5af58d047de06ea42197ef44f3f7d7834"
 dependencies = [
  "bitvec",
  "rand_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,8 @@ crypto-bigint = { git = "https://github.com/RustCrypto/crypto-bigint.git" }
 
 # https://github.com/zkcrypto/ff/pull/122
 # https://github.com/zkcrypto/ff/pull/126
-ff = { git = "https://github.com/baloo/ff.git", branch = "baloo/relax-sized-rng" }
+# https://github.com/zkcrypto/ff/pull/127
+ff = { git = "https://github.com/baloo/ff.git", branch = "baloo/try_from_rng" }
 
 # https://github.com/zkcrypto/group/pull/56
 group = { git = "https://github.com/pinkforest/group.git", branch = "bump-rand-0.9" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,8 @@ hmac = { git = "https://github.com/RustCrypto/MACs.git" }
 crypto-bigint = { git = "https://github.com/RustCrypto/crypto-bigint.git" }
 
 # https://github.com/zkcrypto/ff/pull/122
-ff = { git = "https://github.com/pinkforest/ff.git", branch = "bump-rand-core" }
+# https://github.com/zkcrypto/ff/pull/126
+ff = { git = "https://github.com/baloo/ff.git", branch = "baloo/relax-sized-rng" }
 
 # https://github.com/zkcrypto/group/pull/56
 group = { git = "https://github.com/pinkforest/group.git", branch = "bump-rand-0.9" }

--- a/elliptic-curve/src/dev.rs
+++ b/elliptic-curve/src/dev.rs
@@ -99,7 +99,7 @@ impl Field for Scalar {
     const ZERO: Self = Self(ScalarPrimitive::ZERO);
     const ONE: Self = Self(ScalarPrimitive::ONE);
 
-    fn random(mut rng: impl RngCore) -> Self {
+    fn random<R: RngCore + ?Sized>(rng: &mut R) -> Self {
         let mut bytes = FieldBytes::default();
 
         loop {

--- a/elliptic-curve/src/dev.rs
+++ b/elliptic-curve/src/dev.rs
@@ -10,7 +10,7 @@ use crate::{
     error::{Error, Result},
     ops::{Invert, LinearCombination, MulByGenerator, Reduce, ShrAssign},
     point::AffineCoordinates,
-    rand_core::RngCore,
+    rand_core::{RngCore, TryRngCore},
     scalar::{FromUintUnchecked, IsHigh},
     sec1::{CompressedPoint, FromEncodedPoint, ToEncodedPoint},
     subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption},
@@ -106,6 +106,17 @@ impl Field for Scalar {
             rng.fill_bytes(&mut bytes);
             if let Some(scalar) = Self::from_repr(bytes).into() {
                 return scalar;
+            }
+        }
+    }
+
+    fn try_from_rng<R: TryRngCore + ?Sized>(rng: &mut R) -> core::result::Result<Self, R::Error> {
+        let mut bytes = FieldBytes::default();
+
+        loop {
+            rng.try_fill_bytes(&mut bytes)?;
+            if let Some(scalar) = Self::from_repr(bytes).into() {
+                return Ok(scalar);
             }
         }
     }

--- a/elliptic-curve/src/scalar/nonzero.rs
+++ b/elliptic-curve/src/scalar/nonzero.rs
@@ -13,7 +13,7 @@ use core::{
 };
 use crypto_bigint::{ArrayEncoding, Integer};
 use ff::{Field, PrimeField};
-use rand_core::CryptoRng;
+use rand_core::{CryptoRng, TryCryptoRng};
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 use zeroize::Zeroize;
 
@@ -55,6 +55,19 @@ where
             // TODO: remove after `Field::random` switches to `&mut impl RngCore`
             if let Some(result) = Self::new(Field::random(rng)).into() {
                 break result;
+            }
+        }
+    }
+
+    /// Generate a random `NonZeroScalar`.
+    pub fn try_from_rng<R: TryCryptoRng + ?Sized>(rng: &mut R) -> Result<Self, R::Error> {
+        // Use rejection sampling to eliminate zero values.
+        // While this method isn't constant-time, the attacker shouldn't learn
+        // anything about unrelated outputs so long as `rng` is a secure `CryptoRng`.
+        loop {
+            // TODO: remove after `Field::random` switches to `&mut impl RngCore`
+            if let Some(result) = Self::new(Scalar::<C>::try_from_rng(rng)?).into() {
+                break Ok(result);
             }
         }
     }

--- a/elliptic-curve/src/scalar/nonzero.rs
+++ b/elliptic-curve/src/scalar/nonzero.rs
@@ -47,14 +47,13 @@ where
     C: CurveArithmetic,
 {
     /// Generate a random `NonZeroScalar`.
-    pub fn random<R: CryptoRng + ?Sized>(mut rng: &mut R) -> Self {
+    pub fn random<R: CryptoRng + ?Sized>(rng: &mut R) -> Self {
         // Use rejection sampling to eliminate zero values.
         // While this method isn't constant-time, the attacker shouldn't learn
         // anything about unrelated outputs so long as `rng` is a secure `CryptoRng`.
         loop {
             // TODO: remove after `Field::random` switches to `&mut impl RngCore`
-            #[allow(clippy::needless_borrows_for_generic_args)]
-            if let Some(result) = Self::new(Field::random(&mut rng)).into() {
+            if let Some(result) = Self::new(Field::random(rng)).into() {
                 break result;
             }
         }


### PR DESCRIPTION
Depends:
 - https://github.com/zkcrypto/ff/pull/126
 - https://github.com/zkcrypto/ff/pull/127
 
 This is to provide an `ecdsa::SigningKey::try_from_rng` API (https://github.com/RustCrypto/signatures/pull/915)