### PR TITLE
avoid duplicate definition of crates when pulling from git

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,25 @@ members = [
 ]
 
 [patch.crates-io]
-signature = { path = "signature" }
+# Use crates.io patch instead of a `path = "../foo"` in each
+# crate of this workspace.
+# This allows to pull a git dependency from outside this workspace
+# without having to also pull all the transitive dependencies from
+# within this workspace.
+# Otherwise, the transitive dependency gets duplicated and you end
+# up with objects not implementing trait error that are hard to debug.
+aead             = { path = "./aead" }
+async-signature  = { path = "./async-signature" }
+cipher           = { path = "./cipher" }
+crypto           = { path = "./crypto" }
+crypto-common    = { path = "./crypto-common" }
+digest           = { path = "./digest" }
+elliptic-curve   = { path = "./elliptic-curve" }
+kem              = { path = "./kem" }
+password-hash    = { path = "./password-hash" }
+signature_derive = { path = "./signature_derive" }
+universal-hash   = { path = "./universal-hash" }
+signature        = { path = "./signature" }
 
 sha2 = { git = "https://github.com/RustCrypto/hashes" }
 sha3 = { git = "https://github.com/RustCrypto/hashes" }

--- a/aead/Cargo.toml
+++ b/aead/Cargo.toml
@@ -16,7 +16,7 @@ keywords = ["crypto", "encryption"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-crypto-common = { version = "0.2.0-rc.1", path = "../crypto-common" }
+crypto-common = "0.2.0-rc.1"
 
 # optional dependencies
 arrayvec = { version = "0.7", optional = true, default-features = false }

--- a/cipher/Cargo.toml
+++ b/cipher/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["crypto", "block-cipher", "stream-cipher", "trait"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-crypto-common = { version = "0.2.0-rc.2", path = "../crypto-common" }
+crypto-common = "0.2.0-rc.2"
 inout = "0.2.0-rc.4"
 
 # optional dependencies

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -13,16 +13,16 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-crypto-common = { version = "0.2.0-rc.1", path = "../crypto-common", default-features = false }
+crypto-common = { version = "0.2.0-rc.1", default-features = false }
 
 # optional dependencies
-aead = { version = "0.6.0-rc.0", path = "../aead", optional = true }
-cipher = { version = "0.5.0-pre.7", path = "../cipher", optional = true }
-digest = { version = "0.11.0-pre.9", path = "../digest", optional = true, features = ["mac"] }
-elliptic-curve = { version = "0.14.0-rc.1", path = "../elliptic-curve", optional = true }
-password-hash = { version = "0.6.0-rc.0", path = "../password-hash", optional = true }
-signature = { version = "2.3.0-pre.6", path = "../signature", optional = true, default-features = false }
-universal-hash = { version = "0.6.0-rc.0", path = "../universal-hash", optional = true }
+aead = { version = "0.6.0-rc.0", optional = true }
+cipher = { version = "0.5.0-pre.7", optional = true }
+digest = { version = "0.11.0-pre.9", optional = true, features = ["mac"] }
+elliptic-curve = { version = "0.14.0-rc.1", optional = true }
+password-hash = { version = "0.6.0-rc.0", optional = true }
+signature = { version = "2.3.0-pre.6", optional = true, default-features = false }
+universal-hash = { version = "0.6.0-rc.0", optional = true }
 
 [features]
 std = [

--- a/digest/Cargo.toml
+++ b/digest/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["digest", "crypto", "hash"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-crypto-common = { version = "0.2.0-rc.2", path = "../crypto-common" }
+crypto-common = "0.2.0-rc.2"
 
 # optional dependencies
 block-buffer = { version = "0.11.0-rc.4", optional = true }

--- a/signature/Cargo.toml
+++ b/signature/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-derive = { package = "signature_derive", version = "2", optional = true, path = "../signature_derive" }
+derive = { package = "signature_derive", version = "2", optional = true }
 digest = { version = "=0.11.0-pre.10", optional = true, default-features = false }
 rand_core = { version = "0.9", optional = true, default-features = false }
 

--- a/universal-hash/Cargo.toml
+++ b/universal-hash/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["crypto", "mac"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-crypto-common = { version = "0.2.0-rc.1", path = "../crypto-common" }
+crypto-common = "0.2.0-rc.1"
 subtle = { version = "2.4", default-features = false }
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
This allows to pull a git dependency from outside this workspace without having to also pull all the transitive dependencies from within this workspace.
Otherwise, the transitive dependency gets duplicated and you end up with objects not implementing trait error that are hard to debug.

For example, if you pull aead = { git = "https://.../traits.git" } you end up with two definitions of crypto-common, one from crates.io and one from git.
This causes issues because the objects you then pass to the aead traits do not implements the required traits from the crypto-common crates.