### PR TITLE
ci: update all upstream dependencies with Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,10 @@ updates:
   directory: "/"
   allow:
     - dependency-type: "all"
+  groups:
+    all-deps:
+      patterns:
+        - "*"
   schedule:
     interval: daily
   open-pull-requests-limit: 10

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,7 @@
 version: 2
 updates:
 - package-ecosystem: cargo
+  versioning-strategy: lockfile-only
   directory: "/"
   allow:
     - dependency-type: "all"
@@ -9,7 +10,7 @@ updates:
       patterns:
         - "*"
   schedule:
-    interval: daily
+    interval: weekly
   open-pull-requests-limit: 10
 - package-ecosystem: github-actions
   directory: "/"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,8 @@ version: 2
 updates:
 - package-ecosystem: cargo
   directory: "/"
+  allow:
+    - dependency-type: "all"
   schedule:
     interval: daily
   open-pull-requests-limit: 10


### PR DESCRIPTION
This change automates Cargo.lock updates. 