### PR TITLE
Add hash customization trait for varibale output hash

### DIFF
--- a/digest/src/core_api/ct_variable.rs
+++ b/digest/src/core_api/ct_variable.rs
@@ -2,9 +2,9 @@ use super::{
     AlgorithmName, Buffer, BufferKindUser, FixedOutputCore, Reset, TruncSide, UpdateCore,
     VariableOutputCore,
 };
-use crate::HashMarker;
 #[cfg(feature = "mac")]
 use crate::MacMarker;
+use crate::{CustomizedInit, HashMarker, VarOutputCustomized};
 #[cfg(feature = "oid")]
 use const_oid::{AssociatedOid, ObjectIdentifier};
 use core::{
@@ -126,6 +126,21 @@ where
     fn default() -> Self {
         Self {
             inner: T::new(OutSize::USIZE).unwrap(),
+            _out: PhantomData,
+        }
+    }
+}
+
+impl<T, OutSize, O> CustomizedInit for CtVariableCoreWrapper<T, OutSize, O>
+where
+    T: VariableOutputCore + VarOutputCustomized,
+    OutSize: ArraySize + IsLessOrEqual<T::OutputSize>,
+    LeEq<OutSize, T::OutputSize>: NonZero,
+{
+    #[inline]
+    fn new_customized(customization: &[u8]) -> Self {
+        Self {
+            inner: T::new_customized(customization, OutSize::USIZE),
             _out: PhantomData,
         }
     }

--- a/digest/src/lib.rs
+++ b/digest/src/lib.rs
@@ -274,6 +274,12 @@ pub trait CustomizedInit: Sized {
     fn new_customized(customization: &[u8]) -> Self;
 }
 
+/// Trait adding customization string to hash functions with variable output.
+pub trait VarOutputCustomized: Sized {
+    /// Create new hasher instance with the given customization string and output size.
+    fn new_customized(customization: &[u8], output_size: usize) -> Self;
+}
+
 /// The error type used in variable hash traits.
 #[derive(Clone, Copy, Debug, Default)]
 pub struct InvalidOutputSize;


### PR DESCRIPTION
New trait for customized hash function with variable output `CtVariableCoreWrapper` like Blake2 to implement the `CustomizedInit` trait.