### PR TITLE
elliptic-curve:: adds `try_from_rng` method to `SecretKey` and `EphemeralSecret`

### DIFF
--- a/elliptic-curve/src/dev.rs
+++ b/elliptic-curve/src/dev.rs
@@ -99,17 +99,6 @@ impl Field for Scalar {
     const ZERO: Self = Self(ScalarPrimitive::ZERO);
     const ONE: Self = Self(ScalarPrimitive::ONE);
 
-    fn random<R: RngCore + ?Sized>(rng: &mut R) -> Self {
-        let mut bytes = FieldBytes::default();
-
-        loop {
-            rng.fill_bytes(&mut bytes);
-            if let Some(scalar) = Self::from_repr(bytes).into() {
-                return scalar;
-            }
-        }
-    }
-
     fn try_from_rng<R: TryRngCore + ?Sized>(rng: &mut R) -> core::result::Result<Self, R::Error> {
         let mut bytes = FieldBytes::default();
 

--- a/elliptic-curve/src/ecdh.rs
+++ b/elliptic-curve/src/ecdh.rs
@@ -34,7 +34,7 @@ use core::{borrow::Borrow, fmt};
 use digest::{Digest, crypto_common::BlockSizeUser};
 use group::Curve as _;
 use hkdf::{Hkdf, hmac::SimpleHmac};
-use rand_core::CryptoRng;
+use rand_core::{CryptoRng, TryCryptoRng};
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
 /// Low-level Elliptic Curve Diffie-Hellman (ECDH) function.
@@ -112,6 +112,13 @@ where
         Self {
             scalar: NonZeroScalar::random(rng),
         }
+    }
+
+    /// Generate a cryptographically random [`EphemeralSecret`].
+    pub fn try_from_rng<R: TryCryptoRng + ?Sized>(rng: &mut R) -> Result<Self, R::Error> {
+        Ok(Self {
+            scalar: NonZeroScalar::try_from_rng(rng)?,
+        })
     }
 
     /// Get the public key associated with this ephemeral secret.

--- a/elliptic-curve/src/secret_key.rs
+++ b/elliptic-curve/src/secret_key.rs
@@ -15,7 +15,10 @@ use subtle::{Choice, ConstantTimeEq};
 use zeroize::{Zeroize, ZeroizeOnDrop, Zeroizing};
 
 #[cfg(feature = "arithmetic")]
-use crate::{CurveArithmetic, NonZeroScalar, PublicKey, rand_core::CryptoRng};
+use crate::{
+    CurveArithmetic, NonZeroScalar, PublicKey,
+    rand_core::{CryptoRng, TryCryptoRng},
+};
 
 #[cfg(feature = "jwk")]
 use crate::jwk::{JwkEcKey, JwkParameters};
@@ -98,6 +101,19 @@ where
         Self {
             inner: NonZeroScalar::<C>::random(rng).into(),
         }
+    }
+
+    /// Generate a random [`SecretKey`].
+    #[cfg(feature = "arithmetic")]
+    pub fn try_from_rng<R: TryCryptoRng + ?Sized>(
+        rng: &mut R,
+    ) -> core::result::Result<Self, R::Error>
+    where
+        C: CurveArithmetic,
+    {
+        Ok(Self {
+            inner: NonZeroScalar::<C>::try_from_rng(rng)?.into(),
+        })
     }
 
     /// Create a new secret key from a scalar value.


### PR DESCRIPTION
Follow up to https://github.com/RustCrypto/traits/pull/1774