### PR TITLE
aead: add `inout` support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,6 +22,7 @@ dependencies = [
  "bytes",
  "crypto-common 0.2.0-rc.2",
  "heapless",
+ "inout",
 ]
 
 [[package]]

--- a/aead/Cargo.toml
+++ b/aead/Cargo.toml
@@ -23,9 +23,10 @@ arrayvec = { version = "0.7", optional = true, default-features = false }
 blobby = { version = "0.4.0-pre.0", optional = true }
 bytes = { version = "1", optional = true, default-features = false }
 heapless = { version = "0.8", optional = true, default-features = false }
+inout = { version = "0.2.0-rc.4", optional = true, default-features = false }
 
 [features]
-default = ["rand_core"]
+default = ["inout", "rand_core"]
 alloc = []
 dev = ["blobby"]
 os_rng = ["crypto-common/os_rng", "rand_core"]

--- a/aead/src/lib.rs
+++ b/aead/src/lib.rs
@@ -30,11 +30,12 @@ pub use crypto_common::{
 pub use arrayvec;
 #[cfg(feature = "bytes")]
 pub use bytes;
-#[cfg(feature = "heapless")]
-pub use heapless;
-
 #[cfg(feature = "rand_core")]
 pub use crypto_common::rand_core;
+#[cfg(feature = "heapless")]
+pub use heapless;
+#[cfg(feature = "inout")]
+pub use inout;
 
 use core::fmt;
 use crypto_common::array::{Array, ArraySize};


### PR DESCRIPTION
Renames `AeadInPlaceDetached` to `AeadInOut`, and changes the type signature so the provided `buffer` is now an `InOutBuf`