### PR TITLE
VRF crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -664,6 +664,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "vrf"
+version = "0.1.0"
+dependencies = [
+ "digest 0.11.0-pre.10 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "wasi"
 version = "0.13.3+wasi-0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "signature_derive",
     "universal-hash",
     "signature",
+    "vrf",
 ]
 
 [patch.crates-io]

--- a/vrf/Cargo.toml
+++ b/vrf/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "vrf"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+digest = "=0.11.0-pre.10"

--- a/vrf/src/lib.rs
+++ b/vrf/src/lib.rs
@@ -1,0 +1,26 @@
+use digest::{Output, OutputSizeUser};
+
+pub trait Proof<H>
+where 
+    H: OutputSizeUser,
+{
+    fn to_hash(&self) -> Output<H>;
+}
+
+pub trait Prover<H>
+where
+    H: OutputSizeUser,
+{
+    type Proof: Proof<H>;
+    
+    fn prove(&self, alpha: &[u8]) -> Self::Proof;
+}
+
+pub trait Verifier<H>
+where
+    H: OutputSizeUser,
+{
+    type Proof: Proof<H>;
+    
+    fn verify(&self, alpha: &[u8], proof: Self::Proof) -> bool;
+}


### PR DESCRIPTION
Adding traits for Verifiable Random Functions. See #1728.

The `vrf` name on `crates.io` is taken. The [current crate](https://github.com/witnet/vrf-rs) under this name seems unmaintained, the last commit being 3 years ago.

The exact structure of the traits is not defined yet, I'm mostly looking for some input until we resolve the crate name and have some confidence that we have a good interface.


