### PR TITLE
Do not explicitly pass `docsrs` configuration flag

### DIFF
--- a/aead/Cargo.toml
+++ b/aead/Cargo.toml
@@ -34,4 +34,3 @@ rand_core = ["crypto-common/rand_core"]
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]

--- a/async-signature/Cargo.toml
+++ b/async-signature/Cargo.toml
@@ -22,4 +22,3 @@ rand_core = ["signature/rand_core"]
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]

--- a/cipher/Cargo.toml
+++ b/cipher/Cargo.toml
@@ -31,4 +31,3 @@ zeroize = ["dep:zeroize", "crypto-common/zeroize"]
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]

--- a/crypto-common/Cargo.toml
+++ b/crypto-common/Cargo.toml
@@ -25,4 +25,3 @@ zeroize = ["hybrid-array/zeroize"]
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -34,4 +34,3 @@ rand_core = ["crypto-common/rand_core"]
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]

--- a/digest/Cargo.toml
+++ b/digest/Cargo.toml
@@ -35,4 +35,3 @@ dev = ["blobby"]
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -74,4 +74,3 @@ voprf = ["digest"]
 
 [package.metadata.docs.rs]
 features = ["bits", "ecdh", "hash2curve", "jwk", "pem", "std", "voprf"]
-rustdoc-args = ["--cfg", "docsrs"]

--- a/kem/Cargo.toml
+++ b/kem/Cargo.toml
@@ -18,7 +18,6 @@ zeroize = { version = "1.7", default-features = false }
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]
 
 [lib]
 doctest = false

--- a/password-hash/Cargo.toml
+++ b/password-hash/Cargo.toml
@@ -31,4 +31,3 @@ alloc = ["base64ct/alloc"]
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]

--- a/signature/Cargo.toml
+++ b/signature/Cargo.toml
@@ -29,4 +29,3 @@ rand_core = ["dep:rand_core"]
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]

--- a/universal-hash/Cargo.toml
+++ b/universal-hash/Cargo.toml
@@ -18,4 +18,3 @@ subtle = { version = "2.4", default-features = false }
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]


### PR DESCRIPTION
The flag is passed automatically by docs.rs.