### PR TITLE
Various fixes and improvements to hash2curve

### DIFF
--- a/elliptic-curve/src/hash2curve/group_digest.rs
+++ b/elliptic-curve/src/hash2curve/group_digest.rs
@@ -13,7 +13,7 @@ where
     /// The field element representation for a group value with multiple elements
     type FieldElement: FromOkm + MapToCurve<Output = ProjectivePoint<Self>> + Default + Copy;
 
-    /// The target security level in bits:
+    /// The target security level in bytes:
     /// <https://www.rfc-editor.org/rfc/rfc9380.html#section-8.9-2.2>
     /// <https://www.rfc-editor.org/rfc/rfc9380.html#name-target-security-levels>
     type K: Unsigned;

--- a/elliptic-curve/src/hash2curve/group_digest.rs
+++ b/elliptic-curve/src/hash2curve/group_digest.rs
@@ -3,6 +3,7 @@
 use super::{ExpandMsg, FromOkm, MapToCurve, hash_to_field};
 use crate::{CurveArithmetic, ProjectivePoint, Result};
 use group::cofactor::CofactorGroup;
+use hybrid_array::typenum::Unsigned;
 
 /// Adds hashing arbitrary byte sequences to a valid group element
 pub trait GroupDigest: CurveArithmetic
@@ -11,6 +12,11 @@ where
 {
     /// The field element representation for a group value with multiple elements
     type FieldElement: FromOkm + MapToCurve<Output = ProjectivePoint<Self>> + Default + Copy;
+
+    /// The target security level in bits:
+    /// <https://www.rfc-editor.org/rfc/rfc9380.html#section-8.9-2.2>
+    /// <https://www.rfc-editor.org/rfc/rfc9380.html#name-target-security-levels>
+    type K: Unsigned;
 
     /// Computes the hash to curve routine.
     ///

--- a/elliptic-curve/src/hash2curve/hash2field/expand_msg.rs
+++ b/elliptic-curve/src/hash2curve/hash2field/expand_msg.rs
@@ -3,6 +3,8 @@
 pub(super) mod xmd;
 pub(super) mod xof;
 
+use core::num::NonZero;
+
 use crate::{Error, Result};
 use digest::{Digest, ExtendableOutput, Update, XofReader};
 use hybrid_array::typenum::{IsLess, U256};
@@ -28,7 +30,7 @@ pub trait ExpandMsg<'a> {
     fn expand_message(
         msgs: &[&[u8]],
         dsts: &'a [&'a [u8]],
-        len_in_bytes: usize,
+        len_in_bytes: NonZero<usize>,
     ) -> Result<Self::Expander>;
 }
 

--- a/elliptic-curve/src/hash2curve/hash2field/expand_msg/xmd.rs
+++ b/elliptic-curve/src/hash2curve/hash2field/expand_msg/xmd.rs
@@ -1,6 +1,6 @@
 //! `expand_message_xmd` based on a hash function.
 
-use core::marker::PhantomData;
+use core::{marker::PhantomData, num::NonZero, ops::Mul};
 
 use super::{Domain, ExpandMsg, Expander};
 use crate::{Error, Result};
@@ -8,52 +8,64 @@ use digest::{
     FixedOutput, HashMarker,
     array::{
         Array,
-        typenum::{IsLess, IsLessOrEqual, U256, Unsigned},
+        typenum::{IsGreaterOrEqual, IsLess, IsLessOrEqual, U2, U8, U256, Unsigned},
     },
     core_api::BlockSizeUser,
 };
 
-/// Placeholder type for implementing `expand_message_xmd` based on a hash function
+/// Implements `expand_message_xof` via the [`ExpandMsg`] trait:
+/// <https://www.rfc-editor.org/rfc/rfc9380.html#name-expand_message_xmd>
+///
+/// `K` is the target security level in bits:
+/// <https://www.rfc-editor.org/rfc/rfc9380.html#section-8.9-2.2>
+/// <https://www.rfc-editor.org/rfc/rfc9380.html#name-target-security-levels>
 ///
 /// # Errors
 /// - `dst.is_empty()`
-/// - `len_in_bytes == 0`
 /// - `len_in_bytes > u16::MAX`
 /// - `len_in_bytes > 255 * HashT::OutputSize`
 #[derive(Debug)]
-pub struct ExpandMsgXmd<HashT>(PhantomData<HashT>)
+pub struct ExpandMsgXmd<HashT, K>(PhantomData<(HashT, K)>)
 where
     HashT: BlockSizeUser + Default + FixedOutput + HashMarker,
     HashT::OutputSize: IsLess<U256>,
-    HashT::OutputSize: IsLessOrEqual<HashT::BlockSize>;
+    HashT::OutputSize: IsLessOrEqual<HashT::BlockSize>,
+    HashT::OutputSize: Mul<U8>,
+    U2: Mul<K>,
+    <HashT::OutputSize as Mul<U8>>::Output: IsGreaterOrEqual<<U2 as Mul<K>>::Output>;
 
-/// ExpandMsgXmd implements expand_message_xmd for the ExpandMsg trait
-impl<'a, HashT> ExpandMsg<'a> for ExpandMsgXmd<HashT>
+impl<'a, HashT, K> ExpandMsg<'a> for ExpandMsgXmd<HashT, K>
 where
     HashT: BlockSizeUser + Default + FixedOutput + HashMarker,
-    // If `len_in_bytes` is bigger then 256, length of the `DST` will depend on
-    // the output size of the hash, which is still not allowed to be bigger then 256:
+    // If DST is larger than 255 bytes, the length of the computed DST will depend on the output
+    // size of the hash, which is still not allowed to be larger than 256:
     // https://www.ietf.org/archive/id/draft-irtf-cfrg-hash-to-curve-13.html#section-5.4.1-6
     HashT::OutputSize: IsLess<U256>,
     // Constraint set by `expand_message_xmd`:
     // https://www.ietf.org/archive/id/draft-irtf-cfrg-hash-to-curve-13.html#section-5.4.1-4
     HashT::OutputSize: IsLessOrEqual<HashT::BlockSize>,
+    // The number of bits output by `HashT` MUST be larger or equal to `2 * K`:
+    // https://www.rfc-editor.org/rfc/rfc9380.html#section-5.3.1-2.1
+    HashT::OutputSize: Mul<U8>,
+    U2: Mul<K>,
+    <HashT::OutputSize as Mul<U8>>::Output: IsGreaterOrEqual<<U2 as Mul<K>>::Output>,
 {
     type Expander = ExpanderXmd<'a, HashT>;
 
     fn expand_message(
         msgs: &[&[u8]],
         dsts: &'a [&'a [u8]],
-        len_in_bytes: usize,
+        len_in_bytes: NonZero<usize>,
     ) -> Result<Self::Expander> {
-        if len_in_bytes == 0 {
+        let len_in_bytes_u16 = u16::try_from(len_in_bytes.get()).map_err(|_| Error)?;
+
+        // `255 * <b_in_bytes>` can not exceed `u16::MAX`
+        if len_in_bytes_u16 > 255 * HashT::OutputSize::to_u16() {
             return Err(Error);
         }
 
-        let len_in_bytes_u16 = u16::try_from(len_in_bytes).map_err(|_| Error)?;
-
         let b_in_bytes = HashT::OutputSize::to_usize();
-        let ell = u8::try_from(len_in_bytes.div_ceil(b_in_bytes)).map_err(|_| Error)?;
+        let ell = u8::try_from(len_in_bytes.get().div_ceil(b_in_bytes)).map_err(|_| Error)?;
 
         let domain = Domain::xmd::<HashT>(dsts)?;
         let mut b_0 = HashT::default();
@@ -157,7 +169,7 @@ mod test {
     use hex_literal::hex;
     use hybrid_array::{
         ArraySize,
-        typenum::{U32, U128},
+        typenum::{U8, U32, U128},
     };
     use sha2::Sha256;
 
@@ -209,13 +221,18 @@ mod test {
         ) -> Result<()>
         where
             HashT: BlockSizeUser + Default + FixedOutput + HashMarker,
-            HashT::OutputSize: IsLess<U256> + IsLessOrEqual<HashT::BlockSize>,
+            HashT::OutputSize: IsLess<U256> + IsLessOrEqual<HashT::BlockSize> + Mul<U8>,
+            U2: Mul<U32>,
+            <HashT::OutputSize as Mul<U8>>::Output: IsGreaterOrEqual<<U2 as Mul<U32>>::Output>,
         {
             assert_message::<HashT>(self.msg, domain, L::to_u16(), self.msg_prime);
 
             let dst = [dst];
-            let mut expander =
-                ExpandMsgXmd::<HashT>::expand_message(&[self.msg], &dst, L::to_usize())?;
+            let mut expander = ExpandMsgXmd::<HashT, U32>::expand_message(
+                &[self.msg],
+                &dst,
+                NonZero::new(L::to_usize()).ok_or(Error)?,
+            )?;
 
             let mut uniform_bytes = Array::<u8, L>::default();
             expander.fill_bytes(&mut uniform_bytes);


### PR DESCRIPTION
This was mainly to fix a bug in handling large DSTs for `expand_message_xof`.

- `ExpandMsg::expand_message()`s `len_in_bytes` parameter is now a `NonZero`, moving one run-time error to the type system.
- In tandem `FromOkm::Length` now requires `typenum::NonZero`.
- Added generic `K` parameter to `ExpandMsg` implementers.
  - `ExpandMsgXmd` only uses it to follow constraints set by the specification more closely. See https://www.rfc-editor.org/rfc/rfc9380.html#section-5.3.1-2.1.
  - More importantly, `ExpandMsgXof`, requires `K` to calculate the size for the computed DST if the given DST is larger than 255 bytes. This was previously not implemented correctly in that it always used a 32-byte long computed DST.
- Added `type K` to the `GroupDigest` trait. This allows blanket implementations to use the right `K` for `ExpandMsgXmd` and `ExpandMsgXof`.
- Added `HashMarker` to the constraints of `HashT` for `ExpandMsgXof`.
- Moved documentation from `ExpandMsg` trait implementations to the actual type and added links to the specification.

Cc @mikelodder7.