### PR TITLE
Add `type ExpandMsg` to `VoprfParameters`

### DIFF
--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -70,7 +70,7 @@ jwk = ["dep:base64ct", "dep:serde_json", "alloc", "serde", "zeroize/alloc"]
 pkcs8 = ["dep:pkcs8", "sec1"]
 pem = ["dep:pem-rfc7468", "alloc", "arithmetic", "pkcs8", "sec1/pem"]
 serde = ["dep:serdect", "alloc", "pkcs8", "sec1/serde"]
-voprf = ["digest"]
+voprf = ["digest", "hash2curve"]
 
 [package.metadata.docs.rs]
 features = ["bits", "ecdh", "hash2curve", "jwk", "pem", "std", "voprf"]

--- a/elliptic-curve/src/voprf.rs
+++ b/elliptic-curve/src/voprf.rs
@@ -3,6 +3,7 @@
 //! <https://datatracker.ietf.org/doc/draft-irtf-cfrg-voprf/>
 
 use crate::PrimeCurve;
+use crate::hash2curve::ExpandMsg;
 
 /// Elliptic curve parameters used by VOPRF.
 pub trait VoprfParameters: PrimeCurve {
@@ -17,4 +18,10 @@ pub trait VoprfParameters: PrimeCurve {
     ///
     /// [voprf]: https://www.ietf.org/archive/id/draft-irtf-cfrg-voprf-19.html#name-ciphersuites-2
     type Hash: digest::Digest;
+
+    /// The `expand_message` parameter which assigns a particular algorithm for `HashToGroup`
+    /// and `HashToScalar` as defined in [section 4 of `draft-irtf-cfrg-voprf-19`][voprf].
+    ///
+    /// [voprf]: https://www.rfc-editor.org/rfc/rfc9497#name-ciphersuites
+    type ExpandMsg: for<'a> ExpandMsg<'a>;
 }


### PR DESCRIPTION
Main motivation was that `decaf448` (https://github.com/RustCrypto/elliptic-curves/pull/1121) requires `ExpandMsgXof` instead of `ExpandMsgXmd`.

I was briefly tempted to add a `type Hash` to the `ExpandMsg` trait to be able to write `type ExpandMsg = ExpandMsg<Hash = Self::Hash>`. Otherwise it is possible to add a different hash in the `ExpandMsg` type:
```rust
impl VoprfParamters for Fun128 {
    type Hash = Sha512;
    type ExpandMsg = ExpandMsgXmd<Sha256>;
    ...
}
```
But I thought its a bit much. Let me know if you want me to add that.