### PR TITLE
Add `CollisionResistance` trait

### DIFF
--- a/digest/src/core_api/ct_variable.rs
+++ b/digest/src/core_api/ct_variable.rs
@@ -4,7 +4,7 @@ use super::{
 };
 #[cfg(feature = "mac")]
 use crate::MacMarker;
-use crate::{CustomizedInit, HashMarker, VarOutputCustomized};
+use crate::{CollisionResistance, CustomizedInit, HashMarker, VarOutputCustomized};
 use core::{
     fmt,
     marker::PhantomData,
@@ -44,6 +44,15 @@ where
     OutSize: ArraySize + IsLessOrEqual<T::OutputSize>,
     LeEq<OutSize, T::OutputSize>: NonZero,
 {
+}
+
+impl<T, OutSize> CollisionResistance for CtVariableCoreWrapper<T, OutSize>
+where
+    T: VariableOutputCore + CollisionResistance,
+    OutSize: ArraySize + IsLessOrEqual<T::OutputSize>,
+    LeEq<OutSize, T::OutputSize>: NonZero,
+{
+    type CollisionResistance = T::CollisionResistance;
 }
 
 impl<T, OutSize> BlockSizeUser for CtVariableCoreWrapper<T, OutSize>

--- a/digest/src/core_api/rt_variable.rs
+++ b/digest/src/core_api/rt_variable.rs
@@ -1,7 +1,7 @@
 use super::{AlgorithmName, BlockSizeUser, TruncSide, VariableOutputCore};
 #[cfg(feature = "mac")]
 use crate::MacMarker;
-use crate::{HashMarker, InvalidBufferSize};
+use crate::{CollisionResistance, HashMarker, InvalidBufferSize};
 use crate::{InvalidOutputSize, Reset, Update, VariableOutput, VariableOutputReset};
 use block_buffer::BlockBuffer;
 use core::{
@@ -55,6 +55,10 @@ impl<T: VariableOutputCore + HashMarker> HashMarker for RtVariableCoreWrapper<T>
 
 #[cfg(feature = "mac")]
 impl<T: VariableOutputCore + MacMarker> MacMarker for RtVariableCoreWrapper<T> {}
+
+impl<T: VariableOutputCore + CollisionResistance> CollisionResistance for RtVariableCoreWrapper<T> {
+    type CollisionResistance = T::CollisionResistance;
+}
 
 impl<T: VariableOutputCore> BlockSizeUser for RtVariableCoreWrapper<T> {
     type BlockSize = T::BlockSize;

--- a/digest/src/core_api/wrapper.rs
+++ b/digest/src/core_api/wrapper.rs
@@ -3,8 +3,8 @@ use super::{
     UpdateCore, XofReaderCoreWrapper,
 };
 use crate::{
-    CustomizedInit, ExtendableOutput, ExtendableOutputReset, FixedOutput, FixedOutputReset,
-    HashMarker, Update,
+    CollisionResistance, CustomizedInit, ExtendableOutput, ExtendableOutputReset, FixedOutput,
+    FixedOutputReset, HashMarker, Update,
 };
 use block_buffer::BlockBuffer;
 use core::{
@@ -35,6 +35,10 @@ impl<T: BufferKindUser + HashMarker> HashMarker for CoreWrapper<T> {}
 
 #[cfg(feature = "mac")]
 impl<T: BufferKindUser + MacMarker> MacMarker for CoreWrapper<T> {}
+
+impl<T: BufferKindUser + CollisionResistance> CollisionResistance for CoreWrapper<T> {
+    type CollisionResistance = T::CollisionResistance;
+}
 
 // this blanket impl is needed for HMAC
 impl<T: BufferKindUser + HashMarker> BlockSizeUser for CoreWrapper<T> {

--- a/digest/src/lib.rs
+++ b/digest/src/lib.rs
@@ -74,6 +74,7 @@ pub use mac::{CtOutput, Mac, MacError, MacMarker};
 pub use xof_fixed::XofFixedWrapper;
 
 use core::fmt;
+use crypto_common::typenum::Unsigned;
 
 /// Types which consume data with byte granularity.
 pub trait Update {
@@ -280,6 +281,14 @@ pub trait CustomizedInit: Sized {
 pub trait VarOutputCustomized: Sized {
     /// Create new hasher instance with the given customization string and output size.
     fn new_customized(customization: &[u8], output_size: usize) -> Self;
+}
+
+/// Types with a certain collision resistance.
+pub trait CollisionResistance {
+    /// Collision resistance in bytes. This applies to an output size of `CollisionResistance * 2`.
+    /// The collision resistance with a smaller output size is not defined by this trait and is at
+    /// least the given collision resistance with a bigger output.
+    type CollisionResistance: Unsigned;
 }
 
 /// The error type used in variable hash traits.

--- a/digest/src/xof_fixed.rs
+++ b/digest/src/xof_fixed.rs
@@ -6,8 +6,8 @@ use crypto_common::hazmat::SerializableState;
 use crypto_common::{BlockSizeUser, KeyInit, KeySizeUser, OutputSizeUser, Reset};
 
 use crate::{
-    CustomizedInit, ExtendableOutput, ExtendableOutputReset, FixedOutput, FixedOutputReset,
-    HashMarker, Update,
+    CollisionResistance, CustomizedInit, ExtendableOutput, ExtendableOutputReset, FixedOutput,
+    FixedOutputReset, HashMarker, Update,
 };
 
 /// Wrapper around [`ExtendableOutput`] types adding [`OutputSizeUser`] with the given size of `S`.
@@ -49,6 +49,12 @@ impl<T: ExtendableOutput + HashMarker, S: ArraySize> HashMarker for XofFixedWrap
 impl<T: ExtendableOutput + crate::MacMarker, S: ArraySize> crate::MacMarker
     for XofFixedWrapper<T, S>
 {
+}
+
+impl<T: ExtendableOutput + CollisionResistance, S: ArraySize> CollisionResistance
+    for XofFixedWrapper<T, S>
+{
+    type CollisionResistance = T::CollisionResistance;
 }
 
 // this blanket impl is needed for HMAC


### PR DESCRIPTION
This PR adds a new trait called `CollisionResistance` which can be applied to hashes and MACs to signify their collision resistance.

Resolves #1816.