### PR TITLE
elliptic-curve: deprecate `MulByGenerator`

### DIFF
--- a/elliptic-curve/src/arithmetic.rs
+++ b/elliptic-curve/src/arithmetic.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     Curve, FieldBytes, PrimeCurve, ScalarPrimitive,
-    ops::{Invert, LinearCombination, MulByGenerator, Reduce, ShrAssign},
+    ops::{Invert, LinearCombination, Reduce, ShrAssign},
     point::AffineCoordinates,
     scalar::{FromUintUnchecked, IsHigh},
 };
@@ -46,7 +46,6 @@ pub trait CurveArithmetic: Curve {
         + Into<Self::AffinePoint>
         + LinearCombination<[(Self::ProjectivePoint, Self::Scalar)]>
         + LinearCombination<[(Self::ProjectivePoint, Self::Scalar); 2]>
-        + MulByGenerator
         + group::Curve<AffineRepr = Self::AffinePoint>
         + group::Group<Scalar = Self::Scalar>;
 

--- a/elliptic-curve/src/dev.rs
+++ b/elliptic-curve/src/dev.rs
@@ -8,7 +8,7 @@ use crate::{
     array::typenum::U32,
     bigint::{Limb, U256},
     error::{Error, Result},
-    ops::{Invert, LinearCombination, MulByGenerator, Reduce, ShrAssign},
+    ops::{Invert, LinearCombination, Reduce, ShrAssign},
     point::AffineCoordinates,
     rand_core::TryRngCore,
     scalar::{FromUintUnchecked, IsHigh},
@@ -806,8 +806,6 @@ impl MulAssign<&Scalar> for ProjectivePoint {
         unimplemented!();
     }
 }
-
-impl MulByGenerator for ProjectivePoint {}
 
 impl Neg for ProjectivePoint {
     type Output = ProjectivePoint;

--- a/elliptic-curve/src/ops.rs
+++ b/elliptic-curve/src/ops.rs
@@ -3,7 +3,6 @@
 pub use core::ops::{Add, AddAssign, Mul, Neg, Shr, ShrAssign, Sub, SubAssign};
 
 use crypto_bigint::Integer;
-use group::Group;
 use subtle::{Choice, ConditionallySelectable, CtOption};
 
 #[cfg(feature = "alloc")]
@@ -165,18 +164,6 @@ where
             .copied()
             .map(|(point, scalar)| point * scalar)
             .sum()
-    }
-}
-
-/// Multiplication by the generator.
-///
-/// May use optimizations (e.g. precomputed tables) when available.
-// TODO(tarcieri): replace this with `Group::mul_by_generator``? (see zkcrypto/group#44)
-pub trait MulByGenerator: Group {
-    /// Multiply by the generator of the prime-order subgroup.
-    #[must_use]
-    fn mul_by_generator(scalar: &Self::Scalar) -> Self {
-        Self::generator() * scalar
     }
 }
 


### PR DESCRIPTION
This now should use `group::Group` directly.

Followup to #1821 