### PR TITLE
elliptic-curve: use `crypto-bigint` release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,8 +158,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-bigint"
-version = "0.7.0-pre.0"
-source = "git+https://github.com/RustCrypto/crypto-bigint.git#e1065ce5fa73ee15e73f36a2ed0c6d4ca7b8fe8f"
+version = "0.7.0-pre.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6957fb7344601c8271b03e9d4c7efb46f1dee86553eee20f99e54db0cf53f36e"
 dependencies = [
  "hybrid-array",
  "num-traits",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,3 @@ members = [
 
 [patch.crates-io]
 signature = { path = "signature" }
-
-# https://github.com/RustCrypto/crypto-bigint/pull/762
-# https://github.com/RustCrypto/crypto-bigint/pull/765
-crypto-bigint = { git = "https://github.com/RustCrypto/crypto-bigint.git" }

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -18,7 +18,7 @@ and public/secret keys composed thereof.
 
 [dependencies]
 base16ct = "0.2"
-crypto-bigint = { version = "0.7.0-pre", default-features = false, features = ["rand_core", "hybrid-array", "zeroize"] }
+crypto-bigint = { version = "=0.7.0-pre.1", default-features = false, features = ["rand_core", "hybrid-array", "zeroize"] }
 hybrid-array = { version = "0.3", default-features = false, features = ["zeroize"] }
 rand_core = { version = "0.9.0", default-features = false }
 subtle = { version = "2.6", default-features = false }


### PR DESCRIPTION
Switches to the v0.7.0-pre.1 release