### PR TITLE
signature: remove `std` feature

### DIFF
--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -25,10 +25,7 @@ signature = { version = "3.0.0-pre", path = "../signature", optional = true, def
 universal-hash = { version = "0.6.0-rc.0", path = "../universal-hash", optional = true }
 
 [features]
-std = [
-    "elliptic-curve/std",
-    "signature/std",
-]
+std = ["elliptic-curve/std"]
 os_rng = ["crypto-common/os_rng"]
 rand_core = ["crypto-common/rand_core"]
 

--- a/signature/CHANGELOG.md
+++ b/signature/CHANGELOG.md
@@ -4,15 +4,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 2.3.0 (UNRELEASED)
+## 3.0.0 (UNRELEASED)
 ### Added
 - `RandomizedSignerMut` trait ([#1448])
 
 ### Changed
+- Replace `signature_derive` with blanket impls ([#1827])
 - Edition changed to 2024 and MSRV bumped to 1.85 ([#1759])
+
+### Removed
+- `std` feature - replaced with `core::error::Error`
 
 [#1448]: https://github.com/RustCrypto/traits/pull/1448
 [#1759]: https://github.com/RustCrypto/traits/pull/1759
+[#1827]: https://github.com/RustCrypto/traits/pull/1827
 
 ## 2.2.0 (2023-11-12)
 ### Changed

--- a/signature/Cargo.toml
+++ b/signature/Cargo.toml
@@ -22,8 +22,6 @@ sha2 = { version = "=0.11.0-pre.5", default-features = false }
 
 [features]
 alloc = []
-# TODO: remove this feature in the next breaking release
-std = ["alloc", "rand_core?/std"]
 rand_core = ["dep:rand_core"]
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
We've since migrated to `core::error::Error` (#1711)