### PR TITLE
Add `NonIdentity::mul_by_generator()`

### DIFF
--- a/elliptic-curve/src/point/non_identity.rs
+++ b/elliptic-curve/src/point/non_identity.rs
@@ -214,7 +214,7 @@ impl<P: group::Group> Zeroize for NonIdentity<P> {
 #[cfg(all(test, feature = "dev"))]
 mod tests {
     use super::NonIdentity;
-    use crate::dev::{AffinePoint, ProjectivePoint};
+    use crate::dev::{AffinePoint, NonZeroScalar, ProjectivePoint, SecretKey};
     use group::GroupEncoding;
     use hex_literal::hex;
     use zeroize::Zeroize;
@@ -264,5 +264,19 @@ mod tests {
         point.zeroize();
 
         assert_eq!(point.to_point(), ProjectivePoint::Generator);
+    }
+
+    #[test]
+    fn mul_by_generator() {
+        let scalar = NonZeroScalar::from_repr(
+            hex!("c9afa9d845ba75166b5c215767b1d6934e50c3db36e89b127b8a622b120f6721").into(),
+        )
+        .unwrap();
+        let point = NonIdentity::<ProjectivePoint>::mul_by_generator(scalar);
+
+        let sk = SecretKey::from(scalar);
+        let pk = sk.public_key();
+
+        assert_eq!(point.to_point(), pk.to_projective());
     }
 }

--- a/elliptic-curve/src/point/non_identity.rs
+++ b/elliptic-curve/src/point/non_identity.rs
@@ -2,7 +2,7 @@
 
 use core::ops::{Deref, Mul};
 
-use group::{Curve, GroupEncoding, prime::PrimeCurveAffine};
+use group::{Curve, Group, GroupEncoding, prime::PrimeCurveAffine};
 use rand_core::CryptoRng;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 
@@ -75,12 +75,12 @@ where
     }
 
     /// Multiply by the generator of the prime-order subgroup.
-    pub fn mul_by_generator<C: CurveArithmetic>(scalar: NonZeroScalar<C>) -> Self
+    pub fn mul_by_generator<C: CurveArithmetic>(scalar: &NonZeroScalar<C>) -> Self
     where
-        P: Copy + Mul<Scalar<C>, Output = P>,
+        P: Group<Scalar = C::Scalar>,
     {
         Self {
-            point: P::generator() * *scalar.as_ref(),
+            point: P::mul_by_generator(scalar),
         }
     }
 }
@@ -205,7 +205,7 @@ where
     }
 }
 
-impl<P: group::Group> Zeroize for NonIdentity<P> {
+impl<P: Group> Zeroize for NonIdentity<P> {
     fn zeroize(&mut self) {
         self.point = P::generator();
     }
@@ -272,7 +272,7 @@ mod tests {
             hex!("c9afa9d845ba75166b5c215767b1d6934e50c3db36e89b127b8a622b120f6721").into(),
         )
         .unwrap();
-        let point = NonIdentity::<ProjectivePoint>::mul_by_generator(scalar);
+        let point = NonIdentity::<ProjectivePoint>::mul_by_generator(&scalar);
 
         let sk = SecretKey::from(scalar);
         let pk = sk.public_key();

--- a/elliptic-curve/src/point/non_identity.rs
+++ b/elliptic-curve/src/point/non_identity.rs
@@ -73,6 +73,16 @@ where
             point: self.point.to_affine(),
         }
     }
+
+    /// Multiply by the generator of the prime-order subgroup.
+    pub fn mul_by_generator<C: CurveArithmetic>(scalar: NonZeroScalar<C>) -> Self
+    where
+        P: Copy + Mul<Scalar<C>, Output = P>,
+    {
+        Self {
+            point: P::generator() * *scalar.as_ref(),
+        }
+    }
 }
 
 impl<P> NonIdentity<P>


### PR DESCRIPTION
This PR adds `NonIdentity::mul_by_generator()`, which is similar to the `MulByGenerator` trait, but returns a `NonIdentity` instead of a `ProjectivePoint`. This is quite useful for getting the public key from a `NonZeroScalar` without having to go through the whole conversion dance.