### PR TITLE
Implement `PartialEq + Eq` for `NonIdentity` and `NonZeroScalar`

### DIFF
--- a/elliptic-curve/src/point/non_identity.rs
+++ b/elliptic-curve/src/point/non_identity.rs
@@ -18,7 +18,7 @@ use crate::{CurveArithmetic, NonZeroScalar, Scalar};
 ///
 /// In the context of ECC, it's useful for ensuring that certain arithmetic
 /// cannot result in the identity point.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct NonIdentity<P> {
     point: P,
 }

--- a/elliptic-curve/src/scalar/nonzero.rs
+++ b/elliptic-curve/src/scalar/nonzero.rs
@@ -128,6 +128,8 @@ where
     }
 }
 
+impl<C> Eq for NonZeroScalar<C> where C: CurveArithmetic {}
+
 impl<C> From<NonZeroScalar<C>> for FieldBytes<C>
 where
     C: CurveArithmetic,
@@ -253,6 +255,15 @@ where
         let scalar = self.scalar * other.scalar;
         debug_assert!(!bool::from(scalar.is_zero()));
         NonZeroScalar { scalar }
+    }
+}
+
+impl<C> PartialEq for NonZeroScalar<C>
+where
+    C: CurveArithmetic,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.scalar.eq(&other.scalar)
     }
 }
 


### PR DESCRIPTION
This is done by the fact that the underlying types implement these traits already.