### PR TITLE
elliptic-curve: remove `tap` hack

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -243,7 +243,6 @@ dependencies = [
  "sha2",
  "sha3",
  "subtle",
- "tap",
  "zeroize",
 ]
 

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -36,7 +36,6 @@ pkcs8 = { version = "0.11.0-rc.1", optional = true, default-features = false }
 sec1 = { version = "0.8.0-rc.4", optional = true, features = ["subtle", "zeroize"] }
 serdect = { version = "0.3", optional = true, default-features = false, features = ["alloc"] }
 serde_json = { version = "1.0.121", optional = true, default-features = false, features = ["alloc"] }
-tap = { version = "1.0.1", optional = true, default-features = false } # hack for minimal-versions support for `bits`
 
 [dev-dependencies]
 hex-literal = "1"
@@ -61,7 +60,7 @@ std = [
 ]
 
 arithmetic = ["group"]
-bits = ["arithmetic", "ff/bits", "dep:tap"]
+bits = ["arithmetic", "ff/bits"]
 dev = ["arithmetic", "dep:hex-literal", "pem", "pkcs8"]
 hash2curve = ["arithmetic", "digest"]
 ecdh = ["arithmetic", "digest", "dep:hkdf"]


### PR DESCRIPTION
This is hopefully no longer relevant