### PR TITLE
elliptic-curve: use `crypto_bigint::Invert` trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,9 +158,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-bigint"
-version = "0.7.0-pre.1"
+version = "0.7.0-pre.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6957fb7344601c8271b03e9d4c7efb46f1dee86553eee20f99e54db0cf53f36e"
+checksum = "87a5061ea0870b06f7fdd5a0f7268e30c04de1932c148cca0ce5c79a88d18bed"
 dependencies = [
  "hybrid-array",
  "num-traits",

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -18,7 +18,7 @@ and public/secret keys composed thereof.
 
 [dependencies]
 base16ct = "0.2"
-crypto-bigint = { version = "=0.7.0-pre.1", default-features = false, features = ["rand_core", "hybrid-array", "zeroize"] }
+crypto-bigint = { version = "=0.7.0-pre.2", default-features = false, features = ["rand_core", "hybrid-array", "zeroize"] }
 hybrid-array = { version = "0.3", default-features = false, features = ["zeroize"] }
 rand_core = { version = "0.9.0", default-features = false }
 subtle = { version = "2.6", default-features = false }

--- a/elliptic-curve/src/ops.rs
+++ b/elliptic-curve/src/ops.rs
@@ -1,32 +1,13 @@
 //! Traits for arithmetic operations on elliptic curve field elements.
 
 pub use core::ops::{Add, AddAssign, Mul, Neg, Shr, ShrAssign, Sub, SubAssign};
+pub use crypto_bigint::Invert;
 
 use crypto_bigint::Integer;
 use subtle::{Choice, ConditionallySelectable, CtOption};
 
 #[cfg(feature = "alloc")]
 use alloc::vec::Vec;
-
-/// Perform an inversion on a field element (i.e. base field element or scalar)
-pub trait Invert {
-    /// Field element type
-    type Output;
-
-    /// Invert a field element.
-    fn invert(&self) -> Self::Output;
-
-    /// Invert a field element in variable time.
-    ///
-    /// ⚠️ WARNING!
-    ///
-    /// This method should not be used with secret values, as its variable-time
-    /// operation can potentially leak secrets through sidechannels.
-    fn invert_vartime(&self) -> Self::Output {
-        // Fall back on constant-time implementation by default.
-        self.invert()
-    }
-}
 
 /// Perform a batched inversion on a sequence of field elements (i.e. base field elements or scalars)
 /// at an amortized cost that should be practically as efficient as a single inversion.


### PR DESCRIPTION
Replaces `elliptic_curve::ops::Invert` which has an identical shape