### PR TITLE
Require `From<NonZeroScalar<C>>` for `Scalar<C>`

### DIFF
--- a/elliptic-curve/src/arithmetic.rs
+++ b/elliptic-curve/src/arithmetic.rs
@@ -1,7 +1,7 @@
 //! Elliptic curve arithmetic traits.
 
 use crate::{
-    Curve, FieldBytes, PrimeCurve, ScalarPrimitive,
+    Curve, FieldBytes, NonZeroScalar, PrimeCurve, ScalarPrimitive,
     ops::{Invert, LinearCombination, Reduce, ShrAssign},
     point::{AffineCoordinates, NonIdentity},
     scalar::{FromUintUnchecked, IsHigh},
@@ -65,6 +65,7 @@ pub trait CurveArithmetic: Curve {
     /// - [`Sync`]
     type Scalar: AsRef<Self::Scalar>
         + DefaultIsZeroes
+        + From<NonZeroScalar<Self>>
         + From<ScalarPrimitive<Self>>
         + FromUintUnchecked<Uint = Self::Uint>
         + Into<FieldBytes<Self>>

--- a/elliptic-curve/src/dev.rs
+++ b/elliptic-curve/src/dev.rs
@@ -352,6 +352,12 @@ impl From<u64> for Scalar {
     }
 }
 
+impl From<NonZeroScalar> for Scalar {
+    fn from(scalar: NonZeroScalar) -> Self {
+        scalar.0.into()
+    }
+}
+
 impl From<ScalarPrimitive> for Scalar {
     fn from(scalar: ScalarPrimitive) -> Scalar {
         Self(scalar)


### PR DESCRIPTION
This adds a new requirement to `CurveArithmetic::Scalar`: `From<NonZeroScalar<C>>`.

Its currently a bit cumbersome to go through `Deref` or `AsRef` every time and then `Copy`. `Into` seems much more straightforward to me.

Companion PR: https://github.com/RustCrypto/elliptic-curves/pull/1188.