### PR TITLE
Require `From<NonIdentity>` for `Projective/AffinePoint`

### DIFF
--- a/elliptic-curve/src/arithmetic.rs
+++ b/elliptic-curve/src/arithmetic.rs
@@ -3,7 +3,7 @@
 use crate::{
     Curve, FieldBytes, PrimeCurve, ScalarPrimitive,
     ops::{Invert, LinearCombination, Reduce, ShrAssign},
-    point::AffineCoordinates,
+    point::{AffineCoordinates, NonIdentity},
     scalar::{FromUintUnchecked, IsHigh},
 };
 use core::fmt::Debug;
@@ -22,6 +22,7 @@ pub trait CurveArithmetic: Curve {
         + Default
         + DefaultIsZeroes
         + Eq
+        + From<NonIdentity<Self::AffinePoint>>
         + PartialEq
         + Sized
         + Send
@@ -43,6 +44,7 @@ pub trait CurveArithmetic: Curve {
         + Default
         + DefaultIsZeroes
         + From<Self::AffinePoint>
+        + From<NonIdentity<Self::ProjectivePoint>>
         + Into<Self::AffinePoint>
         + LinearCombination<[(Self::ProjectivePoint, Self::Scalar)]>
         + LinearCombination<[(Self::ProjectivePoint, Self::Scalar); 2]>

--- a/elliptic-curve/src/dev.rs
+++ b/elliptic-curve/src/dev.rs
@@ -9,7 +9,7 @@ use crate::{
     bigint::{Limb, U256},
     error::{Error, Result},
     ops::{Invert, LinearCombination, Reduce, ShrAssign},
-    point::AffineCoordinates,
+    point::{AffineCoordinates, NonIdentity},
     rand_core::TryRngCore,
     scalar::{FromUintUnchecked, IsHigh},
     sec1::{CompressedPoint, FromEncodedPoint, ToEncodedPoint},
@@ -460,6 +460,12 @@ impl Default for AffinePoint {
 
 impl DefaultIsZeroes for AffinePoint {}
 
+impl From<NonIdentity<AffinePoint>> for AffinePoint {
+    fn from(affine: NonIdentity<AffinePoint>) -> Self {
+        affine.to_point()
+    }
+}
+
 impl FromEncodedPoint<MockCurve> for AffinePoint {
     fn from_encoded_point(encoded_point: &EncodedPoint) -> CtOption<Self> {
         let point = if encoded_point.is_identity() {
@@ -551,6 +557,12 @@ impl From<AffinePoint> for ProjectivePoint {
             AffinePoint::Generator => ProjectivePoint::Generator,
             other => ProjectivePoint::Other(other),
         }
+    }
+}
+
+impl From<NonIdentity<ProjectivePoint>> for ProjectivePoint {
+    fn from(point: NonIdentity<ProjectivePoint>) -> Self {
+        point.to_point()
     }
 }
 


### PR DESCRIPTION
Equivalent of #1847 for `Projective/AffinePoint`.

Companion PR to https://github.com/RustCrypto/elliptic-curves/pull/1190.