### PR TITLE
Use `Output = True` instead of `NonZero`

### DIFF
--- a/crypto-common/src/lib.rs
+++ b/crypto-common/src/lib.rs
@@ -79,17 +79,11 @@ pub trait BlockSizes: ArraySize + sealed::BlockSizes {}
 impl<T: ArraySize + sealed::BlockSizes> BlockSizes for T {}
 
 mod sealed {
-    use crate::typenum::{Gr, IsGreater, IsLess, Le, NonZero, U0, U256, Unsigned};
+    use crate::typenum::{IsLess, NonZero, True, U256, Unsigned};
 
     pub trait BlockSizes {}
 
-    impl<T: Unsigned> BlockSizes for T
-    where
-        Self: IsLess<U256> + IsGreater<U0>,
-        Le<Self, U256>: NonZero,
-        Gr<Self, U0>: NonZero,
-    {
-    }
+    impl<T: Unsigned> BlockSizes for T where Self: IsLess<U256, Output = True> + NonZero {}
 }
 
 /// Types which can process blocks in parallel.

--- a/elliptic-curve/src/hash2curve/hash2field/expand_msg.rs
+++ b/elliptic-curve/src/hash2curve/hash2field/expand_msg.rs
@@ -7,7 +7,7 @@ use core::num::NonZero;
 
 use crate::{Error, Result};
 use digest::{Digest, ExtendableOutput, Update, XofReader};
-use hybrid_array::typenum::{IsLess, U256};
+use hybrid_array::typenum::{IsLess, True, U256};
 use hybrid_array::{Array, ArraySize};
 
 /// Salt when the DST is too long
@@ -48,7 +48,7 @@ pub trait Expander {
 #[derive(Debug)]
 pub(crate) enum Domain<'a, L>
 where
-    L: ArraySize + IsLess<U256>,
+    L: ArraySize + IsLess<U256, Output = True>,
 {
     /// > 255
     Hashed(Array<u8, L>),
@@ -58,7 +58,7 @@ where
 
 impl<'a, L> Domain<'a, L>
 where
-    L: ArraySize + IsLess<U256>,
+    L: ArraySize + IsLess<U256, Output = True>,
 {
     pub fn xof<X>(dsts: &'a [&'a [u8]]) -> Result<Self>
     where

--- a/elliptic-curve/src/hash2curve/hash2field/expand_msg/xof.rs
+++ b/elliptic-curve/src/hash2curve/hash2field/expand_msg/xof.rs
@@ -6,7 +6,7 @@ use core::{fmt, marker::PhantomData, num::NonZero, ops::Mul};
 use digest::{ExtendableOutput, HashMarker, Update, XofReader};
 use hybrid_array::{
     ArraySize,
-    typenum::{IsLess, U2, U256},
+    typenum::{IsLess, True, U2, U256},
 };
 
 /// Implements `expand_message_xof` via the [`ExpandMsg`] trait:
@@ -23,7 +23,7 @@ pub struct ExpandMsgXof<HashT, K>
 where
     HashT: Default + ExtendableOutput + Update + HashMarker,
     K: Mul<U2>,
-    <K as Mul<U2>>::Output: ArraySize + IsLess<U256>,
+    <K as Mul<U2>>::Output: ArraySize + IsLess<U256, Output = True>,
 {
     reader: <HashT as ExtendableOutput>::Reader,
     _k: PhantomData<K>,
@@ -33,7 +33,7 @@ impl<HashT, K> fmt::Debug for ExpandMsgXof<HashT, K>
 where
     HashT: Default + ExtendableOutput + Update + HashMarker,
     K: Mul<U2>,
-    <K as Mul<U2>>::Output: ArraySize + IsLess<U256>,
+    <K as Mul<U2>>::Output: ArraySize + IsLess<U256, Output = True>,
     <HashT as ExtendableOutput>::Reader: fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -49,7 +49,7 @@ where
     // If DST is larger than 255 bytes, the length of the computed DST is calculated by `K * 2`.
     // https://www.rfc-editor.org/rfc/rfc9380.html#section-5.3.1-2.1
     K: Mul<U2>,
-    <K as Mul<U2>>::Output: ArraySize + IsLess<U256>,
+    <K as Mul<U2>>::Output: ArraySize + IsLess<U256, Output = True>,
 {
     type Expander = Self;
 
@@ -82,7 +82,7 @@ impl<HashT, K> Expander for ExpandMsgXof<HashT, K>
 where
     HashT: Default + ExtendableOutput + Update + HashMarker,
     K: Mul<U2>,
-    <K as Mul<U2>>::Output: ArraySize + IsLess<U256>,
+    <K as Mul<U2>>::Output: ArraySize + IsLess<U256, Output = True>,
 {
     fn fill_bytes(&mut self, okm: &mut [u8]) {
         self.reader.read(okm);


### PR DESCRIPTION
Bounds like `IsLess` aren't actually enforced unless the `IsLess::Output` is checked. This was done by adding `Le<...>: NonZero`. This PR simplifies this check by adding `IsLess<..., Output = True>`.

These checks were entirely missing in the hash2curve implementation, so I added the improved check here as well.