### PR TITLE
Implement `Mul<&NonZeroScalar>` for `NonIdentity`

### DIFF
--- a/elliptic-curve/src/point/non_identity.rs
+++ b/elliptic-curve/src/point/non_identity.rs
@@ -163,6 +163,18 @@ where
     }
 }
 
+impl<C, P> Mul<&NonZeroScalar<C>> for NonIdentity<P>
+where
+    C: CurveArithmetic,
+    P: Copy + Mul<Scalar<C>, Output = P>,
+{
+    type Output = NonIdentity<P>;
+
+    fn mul(self, rhs: &NonZeroScalar<C>) -> Self::Output {
+        self * *rhs
+    }
+}
+
 impl<C, P> Mul<&NonZeroScalar<C>> for &NonIdentity<P>
 where
     C: CurveArithmetic,


### PR DESCRIPTION
For context: setting `where` bounds on traits can in some situations be "poisonous", meaning that they have to be repeated everywhere you use the trait.

E.g.:
```rust
trait Protocol {
    type NonZeroScalar;
    type NonIdentity: Mul<&Self::NonZeroScalar>;
    ...
}
```
As opposed to:
```rust
trait Protocol
where
    &Self::NonIdentity: Mul<&Self::NonZeroScalar>
{
    type NonZeroScalar;
    type NonIdentity;
    ...
}
```