### PR TITLE
Require `TryInto<Non/Identity/ZeroScalar>`

### DIFF
--- a/elliptic-curve/src/arithmetic.rs
+++ b/elliptic-curve/src/arithmetic.rs
@@ -1,7 +1,7 @@
 //! Elliptic curve arithmetic traits.
 
 use crate::{
-    Curve, FieldBytes, NonZeroScalar, PrimeCurve, ScalarPrimitive,
+    Curve, Error, FieldBytes, NonZeroScalar, PrimeCurve, ScalarPrimitive,
     ops::{Invert, LinearCombination, Mul, Reduce, ShrAssign},
     point::{AffineCoordinates, NonIdentity},
     scalar::{FromUintUnchecked, IsHigh},
@@ -27,7 +27,7 @@ pub trait CurveArithmetic: Curve {
         + Sized
         + Send
         + Sync
-        + TryInto<NonIdentity<Self::AffinePoint>>;
+        + TryInto<NonIdentity<Self::AffinePoint>, Error = Error>;
 
     /// Elliptic curve point in projective coordinates.
     ///
@@ -49,7 +49,7 @@ pub trait CurveArithmetic: Curve {
         + Into<Self::AffinePoint>
         + LinearCombination<[(Self::ProjectivePoint, Self::Scalar)]>
         + LinearCombination<[(Self::ProjectivePoint, Self::Scalar); 2]>
-        + TryInto<NonIdentity<Self::ProjectivePoint>>
+        + TryInto<NonIdentity<Self::ProjectivePoint>, Error = Error>
         + group::Curve<AffineRepr = Self::AffinePoint>
         + group::Group<Scalar = Self::Scalar>;
 
@@ -82,7 +82,7 @@ pub trait CurveArithmetic: Curve {
         + PartialOrd
         + Reduce<Self::Uint, Bytes = FieldBytes<Self>>
         + ShrAssign<usize>
-        + TryInto<NonZeroScalar<Self>>
+        + TryInto<NonZeroScalar<Self>, Error = Error>
         + ff::Field
         + ff::PrimeField<Repr = FieldBytes<Self>>;
 }

--- a/elliptic-curve/src/arithmetic.rs
+++ b/elliptic-curve/src/arithmetic.rs
@@ -26,7 +26,8 @@ pub trait CurveArithmetic: Curve {
         + PartialEq
         + Sized
         + Send
-        + Sync;
+        + Sync
+        + TryInto<NonIdentity<Self::AffinePoint>>;
 
     /// Elliptic curve point in projective coordinates.
     ///
@@ -48,6 +49,7 @@ pub trait CurveArithmetic: Curve {
         + Into<Self::AffinePoint>
         + LinearCombination<[(Self::ProjectivePoint, Self::Scalar)]>
         + LinearCombination<[(Self::ProjectivePoint, Self::Scalar); 2]>
+        + TryInto<NonIdentity<Self::ProjectivePoint>>
         + group::Curve<AffineRepr = Self::AffinePoint>
         + group::Group<Scalar = Self::Scalar>;
 
@@ -80,6 +82,7 @@ pub trait CurveArithmetic: Curve {
         + PartialOrd
         + Reduce<Self::Uint, Bytes = FieldBytes<Self>>
         + ShrAssign<usize>
+        + TryInto<NonZeroScalar<Self>>
         + ff::Field
         + ff::PrimeField<Repr = FieldBytes<Self>>;
 }

--- a/elliptic-curve/src/dev.rs
+++ b/elliptic-curve/src/dev.rs
@@ -408,6 +408,14 @@ impl From<Scalar> for U256 {
     }
 }
 
+impl TryFrom<Scalar> for NonZeroScalar {
+    type Error = Error;
+
+    fn try_from(scalar: Scalar) -> Result<Self> {
+        NonZeroScalar::new(scalar).into_option().ok_or(Error)
+    }
+}
+
 impl TryFrom<U256> for Scalar {
     type Error = Error;
 
@@ -544,6 +552,14 @@ impl Mul<NonZeroScalar> for AffinePoint {
     }
 }
 
+impl TryFrom<AffinePoint> for NonIdentity<AffinePoint> {
+    type Error = Error;
+
+    fn try_from(affine: AffinePoint) -> Result<Self> {
+        NonIdentity::new(affine).into_option().ok_or(Error)
+    }
+}
+
 /// Example projective point type
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum ProjectivePoint {
@@ -619,6 +635,14 @@ impl FromEncodedPoint<MockCurve> for ProjectivePoint {
 impl ToEncodedPoint<MockCurve> for ProjectivePoint {
     fn to_encoded_point(&self, _compress: bool) -> EncodedPoint {
         unimplemented!();
+    }
+}
+
+impl TryFrom<ProjectivePoint> for NonIdentity<ProjectivePoint> {
+    type Error = Error;
+
+    fn try_from(point: ProjectivePoint) -> Result<Self> {
+        NonIdentity::new(point).into_option().ok_or(Error)
     }
 }
 


### PR DESCRIPTION
This PR adds the following requirements:
- `CurveArithmetic::Scalar`: `TryInto<NonZeroScalar>`
- `CurveArithmetic::ProjectivePoint`: `TryInto<NonIdentity<ProjectivePoint>>`
- `CurveArithmetic::AffinePoint`: `TryInto<NonIdentity<AffinePoint>>` 

Companion PR to https://github.com/RustCrypto/elliptic-curves/pull/1193.