### PR TITLE
elliptic-curve: scalar `Mul` bounds

### DIFF
--- a/elliptic-curve/src/arithmetic.rs
+++ b/elliptic-curve/src/arithmetic.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     Curve, FieldBytes, NonZeroScalar, PrimeCurve, ScalarPrimitive,
-    ops::{Invert, LinearCombination, Reduce, ShrAssign},
+    ops::{Invert, LinearCombination, Mul, Reduce, ShrAssign},
     point::{AffineCoordinates, NonIdentity},
     scalar::{FromUintUnchecked, IsHigh},
 };
@@ -73,6 +73,10 @@ pub trait CurveArithmetic: Curve {
         + Into<Self::Uint>
         + Invert<Output = CtOption<Self::Scalar>>
         + IsHigh
+        + Mul<Self::AffinePoint, Output = Self::ProjectivePoint>
+        + for<'a> Mul<&'a Self::AffinePoint, Output = Self::ProjectivePoint>
+        + Mul<Self::ProjectivePoint, Output = Self::ProjectivePoint>
+        + for<'a> Mul<&'a Self::ProjectivePoint, Output = Self::ProjectivePoint>
         + PartialOrd
         + Reduce<Self::Uint, Bytes = FieldBytes<Self>>
         + ShrAssign<usize>

--- a/elliptic-curve/src/dev.rs
+++ b/elliptic-curve/src/dev.rs
@@ -271,6 +271,38 @@ impl Mul<&Scalar> for Scalar {
     }
 }
 
+impl Mul<AffinePoint> for Scalar {
+    type Output = ProjectivePoint;
+
+    fn mul(self, _other: AffinePoint) -> ProjectivePoint {
+        unimplemented!();
+    }
+}
+
+impl Mul<&AffinePoint> for Scalar {
+    type Output = ProjectivePoint;
+
+    fn mul(self, _other: &AffinePoint) -> ProjectivePoint {
+        unimplemented!();
+    }
+}
+
+impl Mul<ProjectivePoint> for Scalar {
+    type Output = ProjectivePoint;
+
+    fn mul(self, _other: ProjectivePoint) -> ProjectivePoint {
+        unimplemented!();
+    }
+}
+
+impl Mul<&ProjectivePoint> for Scalar {
+    type Output = ProjectivePoint;
+
+    fn mul(self, _other: &ProjectivePoint) -> ProjectivePoint {
+        unimplemented!();
+    }
+}
+
 impl MulAssign<Scalar> for Scalar {
     fn mul_assign(&mut self, _rhs: Scalar) {
         unimplemented!();


### PR DESCRIPTION
Adds bounds on `CurveArithmetic::Scalar` that it has a `Mul<P>` impl for both `AffinePoint` and `ProjectivePoint`