### PR TITLE
Use pre-computation tables for `PublicKey::from_secret_scalar()`

### DIFF
--- a/elliptic-curve/src/public_key.rs
+++ b/elliptic-curve/src/public_key.rs
@@ -109,7 +109,7 @@ where
     pub fn from_secret_scalar(scalar: &NonZeroScalar<C>) -> Self {
         // `NonZeroScalar` ensures the resulting point is not the identity
         Self {
-            point: (C::ProjectivePoint::generator() * scalar.as_ref()).to_affine(),
+            point: ProjectivePoint::<C>::mul_by_generator(scalar).to_affine(),
         }
     }
 


### PR DESCRIPTION
Potentially use pre-computation tables for calculating the `PublicKey` from a `SecretKey`. Though AFAICS currently only `k256` uses pre-computation tables.