### PR TITLE
Revert "digest: remove `AssociatedOid` blanket impls for wrappers

### DIFF
--- a/digest/CHANGELOG.md
+++ b/digest/CHANGELOG.md
@@ -17,14 +17,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Mac::new`, `Mac::new_from_slice`, and `Mac::generate_key` methods ([#1173])
 - `HashReader` and `HashWriter` are moved to the `digest-io` crate ([#1809])
 - `io::Write/Read` implementations in favor of the `digest_io::IoWrapper` type ([#1809])
-- `AssociatedOid` blanket impls for `CoreWrapper` and `CtVariableCoreWrapper` ([#1810])
-- `impl_oid_carrier!` macro ([#1810])
 
 [#1173]: https://github.com/RustCrypto/traits/pull/1173
 [#1334]: https://github.com/RustCrypto/traits/pull/1334
 [#1759]: https://github.com/RustCrypto/traits/pull/1759
 [#1809]: https://github.com/RustCrypto/traits/pull/1809
-[#1810]: https://github.com/RustCrypto/traits/pull/1810
 
 ## 0.10.7 (2023-05-19)
 ### Changed

--- a/digest/src/core_api/ct_variable.rs
+++ b/digest/src/core_api/ct_variable.rs
@@ -5,6 +5,8 @@ use super::{
 #[cfg(feature = "mac")]
 use crate::MacMarker;
 use crate::{CollisionResistance, CustomizedInit, HashMarker, VarOutputCustomized};
+#[cfg(feature = "oid")]
+use const_oid::{AssociatedOid, ObjectIdentifier};
 use core::{
     fmt,
     marker::PhantomData,
@@ -16,20 +18,26 @@ use crypto_common::{
     hazmat::{DeserializeStateError, SerializableState, SerializedState, SubSerializedStateSize},
     typenum::{IsLess, IsLessOrEqual, Le, LeEq, NonZero, Sum, U1, U256},
 };
+
+/// Dummy type used with [`CtVariableCoreWrapper`] in cases when
+/// resulting hash does not have a known OID.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+pub struct NoOid;
+
 /// Wrapper around [`VariableOutputCore`] which selects output size
 /// at compile time.
 #[derive(Clone)]
-pub struct CtVariableCoreWrapper<T, OutSize>
+pub struct CtVariableCoreWrapper<T, OutSize, O = NoOid>
 where
     T: VariableOutputCore,
     OutSize: ArraySize + IsLessOrEqual<T::OutputSize>,
     LeEq<OutSize, T::OutputSize>: NonZero,
 {
     inner: T,
-    _out: PhantomData<OutSize>,
+    _out: PhantomData<(OutSize, O)>,
 }
 
-impl<T, OutSize> HashMarker for CtVariableCoreWrapper<T, OutSize>
+impl<T, OutSize, O> HashMarker for CtVariableCoreWrapper<T, OutSize, O>
 where
     T: VariableOutputCore + HashMarker,
     OutSize: ArraySize + IsLessOrEqual<T::OutputSize>,
@@ -38,7 +46,7 @@ where
 }
 
 #[cfg(feature = "mac")]
-impl<T, OutSize> MacMarker for CtVariableCoreWrapper<T, OutSize>
+impl<T, OutSize, O> MacMarker for CtVariableCoreWrapper<T, OutSize, O>
 where
     T: VariableOutputCore + MacMarker,
     OutSize: ArraySize + IsLessOrEqual<T::OutputSize>,
@@ -55,7 +63,7 @@ where
     type CollisionResistance = T::CollisionResistance;
 }
 
-impl<T, OutSize> BlockSizeUser for CtVariableCoreWrapper<T, OutSize>
+impl<T, OutSize, O> BlockSizeUser for CtVariableCoreWrapper<T, OutSize, O>
 where
     T: VariableOutputCore,
     OutSize: ArraySize + IsLessOrEqual<T::OutputSize>,
@@ -64,7 +72,7 @@ where
     type BlockSize = T::BlockSize;
 }
 
-impl<T, OutSize> UpdateCore for CtVariableCoreWrapper<T, OutSize>
+impl<T, OutSize, O> UpdateCore for CtVariableCoreWrapper<T, OutSize, O>
 where
     T: VariableOutputCore,
     OutSize: ArraySize + IsLessOrEqual<T::OutputSize>,
@@ -76,7 +84,7 @@ where
     }
 }
 
-impl<T, OutSize> OutputSizeUser for CtVariableCoreWrapper<T, OutSize>
+impl<T, OutSize, O> OutputSizeUser for CtVariableCoreWrapper<T, OutSize, O>
 where
     T: VariableOutputCore,
     OutSize: ArraySize + IsLessOrEqual<T::OutputSize>,
@@ -85,7 +93,7 @@ where
     type OutputSize = OutSize;
 }
 
-impl<T, OutSize> BufferKindUser for CtVariableCoreWrapper<T, OutSize>
+impl<T, OutSize, O> BufferKindUser for CtVariableCoreWrapper<T, OutSize, O>
 where
     T: VariableOutputCore,
     OutSize: ArraySize + IsLessOrEqual<T::OutputSize>,
@@ -94,7 +102,7 @@ where
     type BufferKind = T::BufferKind;
 }
 
-impl<T, OutSize> FixedOutputCore for CtVariableCoreWrapper<T, OutSize>
+impl<T, OutSize, O> FixedOutputCore for CtVariableCoreWrapper<T, OutSize, O>
 where
     T: VariableOutputCore,
     OutSize: ArraySize + IsLessOrEqual<T::OutputSize>,
@@ -117,7 +125,7 @@ where
     }
 }
 
-impl<T, OutSize> Default for CtVariableCoreWrapper<T, OutSize>
+impl<T, OutSize, O> Default for CtVariableCoreWrapper<T, OutSize, O>
 where
     T: VariableOutputCore,
     OutSize: ArraySize + IsLessOrEqual<T::OutputSize>,
@@ -132,7 +140,7 @@ where
     }
 }
 
-impl<T, OutSize> CustomizedInit for CtVariableCoreWrapper<T, OutSize>
+impl<T, OutSize, O> CustomizedInit for CtVariableCoreWrapper<T, OutSize, O>
 where
     T: VariableOutputCore + VarOutputCustomized,
     OutSize: ArraySize + IsLessOrEqual<T::OutputSize>,
@@ -147,7 +155,7 @@ where
     }
 }
 
-impl<T, OutSize> Reset for CtVariableCoreWrapper<T, OutSize>
+impl<T, OutSize, O> Reset for CtVariableCoreWrapper<T, OutSize, O>
 where
     T: VariableOutputCore,
     OutSize: ArraySize + IsLessOrEqual<T::OutputSize>,
@@ -159,7 +167,7 @@ where
     }
 }
 
-impl<T, OutSize> AlgorithmName for CtVariableCoreWrapper<T, OutSize>
+impl<T, OutSize, O> AlgorithmName for CtVariableCoreWrapper<T, OutSize, O>
 where
     T: VariableOutputCore + AlgorithmName,
     OutSize: ArraySize + IsLessOrEqual<T::OutputSize>,
@@ -172,8 +180,19 @@ where
     }
 }
 
+#[cfg(feature = "oid")]
+impl<T, OutSize, O> AssociatedOid for CtVariableCoreWrapper<T, OutSize, O>
+where
+    T: VariableOutputCore,
+    O: AssociatedOid,
+    OutSize: ArraySize + IsLessOrEqual<T::OutputSize>,
+    LeEq<OutSize, T::OutputSize>: NonZero,
+{
+    const OID: ObjectIdentifier = O::OID;
+}
+
 #[cfg(feature = "zeroize")]
-impl<T, OutSize> zeroize::ZeroizeOnDrop for CtVariableCoreWrapper<T, OutSize>
+impl<T, OutSize, O> zeroize::ZeroizeOnDrop for CtVariableCoreWrapper<T, OutSize, O>
 where
     T: VariableOutputCore + zeroize::ZeroizeOnDrop,
     OutSize: ArraySize + IsLessOrEqual<T::OutputSize>,
@@ -181,7 +200,7 @@ where
 {
 }
 
-impl<T, OutSize> fmt::Debug for CtVariableCoreWrapper<T, OutSize>
+impl<T, OutSize, O> fmt::Debug for CtVariableCoreWrapper<T, OutSize, O>
 where
     T: VariableOutputCore + AlgorithmName,
     OutSize: ArraySize + IsLessOrEqual<T::OutputSize>,
@@ -192,10 +211,26 @@ where
     }
 }
 
+/// Implement dummy type with hidden docs which is used to "carry" hasher
+/// OID for [`CtVariableCoreWrapper`].
+#[macro_export]
+macro_rules! impl_oid_carrier {
+    ($name:ident, $oid:literal) => {
+        #[doc(hidden)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+        pub struct $name;
+
+        #[cfg(feature = "oid")]
+        impl AssociatedOid for $name {
+            const OID: ObjectIdentifier = ObjectIdentifier::new_unwrap($oid);
+        }
+    };
+}
+
 type CtVariableCoreWrapperSerializedStateSize<T> =
     Sum<<T as SerializableState>::SerializedStateSize, U1>;
 
-impl<T, OutSize> SerializableState for CtVariableCoreWrapper<T, OutSize>
+impl<T, OutSize, O> SerializableState for CtVariableCoreWrapper<T, OutSize, O>
 where
     T: VariableOutputCore + SerializableState,
     OutSize: ArraySize + IsLessOrEqual<T::OutputSize>,

--- a/digest/src/core_api/wrapper.rs
+++ b/digest/src/core_api/wrapper.rs
@@ -21,6 +21,8 @@ use crypto_common::{
 
 #[cfg(feature = "mac")]
 use crate::MacMarker;
+#[cfg(feature = "oid")]
+use const_oid::{AssociatedOid, ObjectIdentifier};
 
 /// Wrapper around [`BufferKindUser`].
 ///
@@ -171,6 +173,14 @@ where
     fn new_customized(customization: &[u8]) -> Self {
         Self::from_core(T::new_customized(customization))
     }
+}
+
+#[cfg(feature = "oid")]
+impl<T> AssociatedOid for CoreWrapper<T>
+where
+    T: BufferKindUser + AssociatedOid,
+{
+    const OID: ObjectIdentifier = T::OID;
 }
 
 type CoreWrapperSerializedStateSize<T> =

--- a/digest/src/digest.rs
+++ b/digest/src/digest.rs
@@ -3,7 +3,7 @@ use crypto_common::{Output, OutputSizeUser, typenum::Unsigned};
 
 #[cfg(feature = "alloc")]
 use alloc::boxed::Box;
-#[cfg(feature = "oid")]
+#[cfg(feature = "const-oid")]
 use const_oid::DynAssociatedOid;
 
 /// Marker trait for cryptographic hash functions.
@@ -228,8 +228,8 @@ impl Clone for Box<dyn DynDigest> {
 }
 
 /// Convenience wrapper trait around [DynDigest] and [DynAssociatedOid].
-#[cfg(feature = "oid")]
+#[cfg(feature = "const-oid")]
 pub trait DynDigestWithOid: DynDigest + DynAssociatedOid {}
 
-#[cfg(feature = "oid")]
+#[cfg(feature = "const-oid")]
 impl<T: DynDigest + DynAssociatedOid> DynDigestWithOid for T {}

--- a/digest/src/lib.rs
+++ b/digest/src/lib.rs
@@ -63,7 +63,7 @@ pub use block_buffer;
 pub use const_oid;
 pub use crypto_common;
 
-#[cfg(feature = "oid")]
+#[cfg(feature = "const-oid")]
 pub use crate::digest::DynDigestWithOid;
 pub use crate::digest::{Digest, DynDigest, HashMarker};
 #[cfg(feature = "mac")]


### PR DESCRIPTION
This reverts commit c48ea2a4f76127bd3febce8240095b893e6edb1c (#1810)

This bring back `master` in a state that can be consumed with a `[patch.crates-io]` (see https://github.com/RustCrypto/traits/pull/1799#issuecomment-2885545411)