### PR TITLE
digest: alias core_api with a depreciation notice

### DIFF
--- a/digest/src/lib.rs
+++ b/digest/src/lib.rs
@@ -74,6 +74,13 @@ pub use crypto_common::{Output, OutputSizeUser, Reset, array, typenum, typenum::
 pub use mac::{CtOutput, Mac, MacError, MacMarker};
 pub use xof_fixed::XofFixedWrapper;
 
+#[cfg(feature = "block-api")]
+#[deprecated(
+    since = "0.11.0",
+    note = "`digest::core_api` has been replaced by `digest::block_api`"
+)]
+pub use block_api as core_api;
+
 use core::fmt;
 use crypto_common::typenum::Unsigned;
 


### PR DESCRIPTION
Alternative to #1859 