### PR TITLE
Remove unnecessary re-allocation in `BatchInvert`

### DIFF
--- a/elliptic-curve/src/ops.rs
+++ b/elliptic-curve/src/ops.rs
@@ -71,10 +71,7 @@ where
             field_elements_inverses.as_mut(),
         );
 
-        CtOption::new(
-            field_elements_inverses.into_iter().collect(),
-            inversion_succeeded,
-        )
+        CtOption::new(field_elements_inverses, inversion_succeeded)
     }
 }
 


### PR DESCRIPTION
I didn't look deeper into it, but I assume this was just a historic leftover.