### PR TITLE
Remove insecure `BatchInvert` API

### DIFF
--- a/elliptic-curve/src/ops.rs
+++ b/elliptic-curve/src/ops.rs
@@ -9,7 +9,7 @@ use ff::Field;
 use subtle::{Choice, CtOption};
 
 #[cfg(feature = "alloc")]
-use alloc::{borrow::ToOwned, vec::Vec};
+use alloc::vec::Vec;
 
 /// Perform a batched inversion on a sequence of field elements (i.e. base field elements or scalars)
 /// at an amortized cost that should be practically as efficient as a single inversion.
@@ -19,18 +19,8 @@ pub trait BatchInvert<FieldElements: ?Sized>: Field + Sized {
 
     /// Invert a batch of field elements.
     fn batch_invert(
-        field_elements: &FieldElements,
+        field_elements: FieldElements,
     ) -> CtOption<<Self as BatchInvert<FieldElements>>::Output>;
-
-    /// Invert a batch of field elements in-place.
-    ///
-    /// # ⚠️ Warning
-    ///
-    /// Even though `field_elements` is modified regardless of success, on failure it does not
-    /// contain correctly inverted scalars and should be discarded instead.
-    ///
-    /// Consider using [`Self::batch_invert()`] instead.
-    fn batch_invert_mut(field_elements: &mut FieldElements) -> Choice;
 }
 
 impl<const N: usize, T> BatchInvert<[T; N]> for T
@@ -39,38 +29,28 @@ where
 {
     type Output = [Self; N];
 
-    fn batch_invert(field_elements: &[Self; N]) -> CtOption<[Self; N]> {
-        let mut field_elements_inverses = *field_elements;
-        let inversion_succeeded = Self::batch_invert_mut(&mut field_elements_inverses);
-
-        CtOption::new(field_elements_inverses, inversion_succeeded)
-    }
-
-    fn batch_invert_mut(field_elements: &mut [T; N]) -> Choice {
+    fn batch_invert(mut field_elements: [Self; N]) -> CtOption<[Self; N]> {
         let mut field_elements_pad = [Self::default(); N];
+        let inversion_succeeded =
+            invert_batch_internal(&mut field_elements, &mut field_elements_pad);
 
-        invert_batch_internal(field_elements, &mut field_elements_pad)
+        CtOption::new(field_elements, inversion_succeeded)
     }
 }
 
 #[cfg(feature = "alloc")]
-impl<T> BatchInvert<[T]> for T
+impl<T> BatchInvert<Vec<Self>> for T
 where
     T: Field,
 {
     type Output = Vec<Self>;
 
-    fn batch_invert(field_elements: &[Self]) -> CtOption<Vec<Self>> {
-        let mut field_elements_inverses: Vec<Self> = field_elements.to_owned();
-        let inversion_succeeded = Self::batch_invert_mut(field_elements_inverses.as_mut_slice());
-
-        CtOption::new(field_elements_inverses, inversion_succeeded)
-    }
-
-    fn batch_invert_mut(field_elements: &mut [T]) -> Choice {
+    fn batch_invert(mut field_elements: Vec<Self>) -> CtOption<Vec<Self>> {
         let mut field_elements_pad: Vec<Self> = vec![Self::default(); field_elements.len()];
+        let inversion_succeeded =
+            invert_batch_internal(&mut field_elements, &mut field_elements_pad);
 
-        invert_batch_internal(field_elements, field_elements_pad.as_mut())
+        CtOption::new(field_elements, inversion_succeeded)
     }
 }
 


### PR DESCRIPTION
Implementing the idea I had in https://github.com/RustCrypto/traits/pull/1864#discussion_r2112346173, which in hindsight I actually think is better.

The new implementation actually *should* take ownership instead of just cloning *for* the user. See [C-CALLER-CONTROL API guidelines](https://rust-lang.github.io/api-guidelines/flexibility.html?highlight=clone#caller-decides-where-to-copy-and-place-data-c-caller-control).

This has the advantage of getting read of the insecure `batch_invert_mut` API where users have to make sure to actually check the returned `Choice` and make sure they don't use the input slice.

I could also quickly add the following for even more control if desirable:
```rust
#[cfg(feature = "alloc")]
impl<'this, T> BatchInvert<&'this mut [Self]> for T
where
    T: Field,
{
    type Output = &'this mut [Self];

    fn batch_invert(field_elements: &'this mut [Self]) -> CtOption<&'this mut [Self]> {
        let mut field_elements_pad: Vec<Self> = vec![Self::default(); field_elements.len()];
        let inversion_succeeded = invert_batch_internal(field_elements, &mut field_elements_pad);

        CtOption::new(field_elements, inversion_succeeded)
    }
}
```