### PR TITLE
elliptic-curve: update `MapToCurve` to avoid `CofactorGroup` dependency

### DIFF
--- a/elliptic-curve/src/hash2curve/map2curve.rs
+++ b/elliptic-curve/src/hash2curve/map2curve.rs
@@ -1,12 +1,33 @@
 //! Traits for mapping field elements to points on the curve.
 
-/// Trait for converting field elements into a point
-/// via a mapping method like Simplified Shallue-van de Woestijne-Ulas
-/// or Elligator
-pub trait MapToCurve {
-    /// The output point
-    type Output;
+use crate::{CurveArithmetic, ProjectivePoint};
 
-    /// Map a field element into a point
-    fn map_to_curve(&self) -> Self::Output;
+use super::FromOkm;
+
+/// Trait for converting field elements into a point via a mapping method like
+/// Simplified Shallue-van de Woestijne-Ulas or Elligator.
+pub trait MapToCurve: CurveArithmetic {
+    /// The intermediate representation, an element of the curve which may or may not
+    /// be in the curve subgroup.
+    type CurvePoint;
+    /// The field element representation for a group value with multiple elements.
+    type FieldElement: FromOkm + Default + Copy;
+
+    /// Map a field element into a curve point.
+    fn map_to_curve(element: Self::FieldElement) -> Self::CurvePoint;
+
+    /// Map a curve point to a point in the curve subgroup.
+    /// This is usually done by clearing the cofactor, if necessary.
+    fn map_to_subgroup(point: Self::CurvePoint) -> ProjectivePoint<Self>;
+
+    /// Combine two curve points into a point in the curve subgroup.
+    /// This is usually done by clearing the cofactor of the sum. In case
+    /// addition is not implemented for `Self::CurvePoint`, then both terms
+    /// must be mapped to the subgroup individually before being added.
+    fn add_and_map_to_subgroup(
+        lhs: Self::CurvePoint,
+        rhs: Self::CurvePoint,
+    ) -> ProjectivePoint<Self> {
+        Self::map_to_subgroup(lhs) + Self::map_to_subgroup(rhs)
+    }
 }


### PR DESCRIPTION
Fixes #1146

This update implements `MapToCurve` for the curve itself rather than for the field element, and removes the dependency on `CofactorGroup`.

The implementation in p256 would be updated as follows:

```
impl GroupDigest for NistP256 {
    type K = U16;
}

impl MapToCurve for NistP256 {
    type CurvePoint = ProjectivePoint;
    type FieldElement = FieldElement;

    fn map_to_curve(element: Self::FieldElement) -> Self::CurvePoint {
        let (qx, qy) = element.osswu();

        // TODO(tarcieri): assert that `qy` is correct? less circuitous conversion?
        AffinePoint::decompress(&qx.to_bytes(), qy.is_odd())
            .unwrap()
            .into()
    }

    fn map_to_subgroup(point: Self::CurvePoint) -> ProjectivePoint {
        point
    }
}
```

@daxpedda 