### PR TITLE
digest v0.11.0-rc.0

### DIFF
--- a/.github/workflows/elliptic-curve.yml
+++ b/.github/workflows/elliptic-curve.yml
@@ -42,10 +42,10 @@ jobs:
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features bits
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features dev
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features digest
-      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features ecdh
-      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features hash2curve
+      #- run: cargo build --target ${{ matrix.target }} --release --no-default-features --features ecdh
+      #- run: cargo build --target ${{ matrix.target }} --release --no-default-features --features hash2curve
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features jwk
-      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features oprf
+      #- run: cargo build --target ${{ matrix.target }} --release --no-default-features --features oprf
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features pem
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features pkcs8
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features sec1
@@ -54,7 +54,7 @@ jobs:
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features alloc,arithmetic,pkcs8
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features alloc,serde
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features arithmetic,serde
-      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features alloc,digest,ecdh,hash2curve,jwk,oprf,pem,pkcs8,sec1,serde
+      #- run: cargo build --target ${{ matrix.target }} --release --no-default-features --features alloc,digest,ecdh,hash2curve,jwk,oprf,pem,pkcs8,sec1,serde
 
   minimal-versions:
     # Temporarily disabled until elliptic-curve 0.13.0-pre.0 is published

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,15 +134,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dabb6555f92fb9ee4140454eb5dcd14c7960e1225c6d1a6cc361f032947713e"
 
 [[package]]
-name = "cpufeatures"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "crypto"
 version = "0.6.0-pre"
 dependencies = [
@@ -190,7 +181,7 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.11.0-pre.10"
+version = "0.11.0-rc.0"
 dependencies = [
  "blobby",
  "block-buffer",
@@ -211,7 +202,6 @@ dependencies = [
  "ff",
  "group",
  "hex-literal",
- "hkdf",
  "hybrid-array",
  "pem-rfc7468",
  "pkcs8",
@@ -219,8 +209,6 @@ dependencies = [
  "sec1",
  "serde_json",
  "serdect",
- "sha2",
- "sha3",
  "subtle",
  "zeroize",
 ]
@@ -307,22 +295,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bcaaec4551594c969335c98c903c1397853d4198408ea609190f420500f6be71"
 
 [[package]]
-name = "hkdf"
-version = "0.13.0-pre.5"
-source = "git+https://github.com/RustCrypto/KDFs.git#2e2dbcd45b8678696e85dcbef922345f3ca04dbf"
-dependencies = [
- "hmac",
-]
-
-[[package]]
-name = "hmac"
-version = "0.13.0-pre.5"
-source = "git+https://github.com/RustCrypto/MACs.git#64d671d5c375838173d18e30bc14dffc80c13e51"
-dependencies = [
- "digest",
-]
-
-[[package]]
 name = "hybrid-array"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -347,15 +319,6 @@ name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
-
-[[package]]
-name = "keccak"
-version = "0.2.0-pre.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7cdd4f0dc5807b9a2b25dd48a3f58e862606fe7bd47f41ecde36e97422d7e90"
-dependencies = [
- "cpufeatures",
-]
 
 [[package]]
 name = "kem"
@@ -538,32 +501,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha2"
-version = "0.11.0-pre.5"
-source = "git+https://github.com/RustCrypto/hashes.git#d9ad085ed12dba58d2a6d75d76a17a1b2706c4c7"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest",
-]
-
-[[package]]
-name = "sha3"
-version = "0.11.0-pre.5"
-source = "git+https://github.com/RustCrypto/hashes.git#d9ad085ed12dba58d2a6d75d76a17a1b2706c4c7"
-dependencies = [
- "digest",
- "keccak",
-]
-
-[[package]]
 name = "signature"
 version = "3.0.0-pre"
 dependencies = [
  "digest",
- "hex-literal",
  "rand_core",
- "sha2",
 ]
 
 [[package]]
@@ -688,3 +630,23 @@ name = "zeroize"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+
+[[patch.unused]]
+name = "hkdf"
+version = "0.13.0-pre.5"
+source = "git+https://github.com/RustCrypto/KDFs.git#2e2dbcd45b8678696e85dcbef922345f3ca04dbf"
+
+[[patch.unused]]
+name = "hmac"
+version = "0.13.0-pre.5"
+source = "git+https://github.com/RustCrypto/MACs.git#64d671d5c375838173d18e30bc14dffc80c13e51"
+
+[[patch.unused]]
+name = "sha2"
+version = "0.11.0-pre.5"
+source = "git+https://github.com/RustCrypto/hashes.git#d9ad085ed12dba58d2a6d75d76a17a1b2706c4c7"
+
+[[patch.unused]]
+name = "sha3"
+version = "0.11.0-pre.5"
+source = "git+https://github.com/RustCrypto/hashes.git#d9ad085ed12dba58d2a6d75d76a17a1b2706c4c7"

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -18,7 +18,7 @@ crypto-common = { version = "0.2.0-rc.3", path = "../crypto-common", default-fea
 # optional dependencies
 aead = { version = "0.6.0-rc.0", path = "../aead", optional = true }
 cipher = { version = "0.5.0-pre.7", path = "../cipher", optional = true }
-digest = { version = "0.11.0-pre.9", path = "../digest", optional = true, features = ["mac"] }
+digest = { version = "0.11.0-rc.0", path = "../digest", optional = true, features = ["mac"] }
 elliptic-curve = { version = "0.14.0-rc.1", path = "../elliptic-curve", optional = true }
 password-hash = { version = "0.6.0-rc.0", path = "../password-hash", optional = true }
 signature = { version = "=3.0.0-pre", path = "../signature", optional = true, default-features = false }

--- a/digest/Cargo.toml
+++ b/digest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "digest"
-version = "0.11.0-pre.10"
+version = "0.11.0-rc.0"
 authors = ["RustCrypto Developers"]
 edition = "2024"
 rust-version = "1.85"

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -26,10 +26,10 @@ zeroize = { version = "1.7", default-features = false }
 
 # optional dependencies
 base64ct = { version = "1", optional = true, default-features = false, features = ["alloc"] }
-digest = { version = "=0.11.0-pre.10", optional = true }
+digest = { version = "0.11.0-rc.0", optional = true }
 ff = { version = "=0.14.0-pre.0", optional = true, default-features = false }
 group = { version = "=0.14.0-pre.0", optional = true, default-features = false }
-hkdf = { version = "=0.13.0-pre.5", optional = true, default-features = false }
+#hkdf = { version = "=0.13.0-pre.5", optional = true, default-features = false }
 hex-literal = { version = "1", optional = true }
 pem-rfc7468 = { version = "1.0.0-rc.2", optional = true, features = ["alloc"] }
 pkcs8 = { version = "0.11.0-rc.1", optional = true, default-features = false }
@@ -39,8 +39,8 @@ serde_json = { version = "1.0.121", optional = true, default-features = false, f
 
 [dev-dependencies]
 hex-literal = "1"
-sha2 = "=0.11.0-pre.5"
-sha3 = "=0.11.0-pre.5"
+#sha2 = "=0.11.0-pre.5"
+#sha3 = "=0.11.0-pre.5"
 
 [features]
 default = ["arithmetic"]
@@ -62,11 +62,11 @@ std = [
 arithmetic = ["group"]
 bits = ["arithmetic", "ff/bits"]
 dev = ["arithmetic", "dep:hex-literal", "pem", "pkcs8"]
-hash2curve = ["arithmetic", "digest"]
-ecdh = ["arithmetic", "digest", "dep:hkdf"]
+#ecdh = ["arithmetic", "digest", "dep:hkdf"]
 group = ["dep:group", "ff"]
+#hash2curve = ["arithmetic", "digest"]
 jwk = ["dep:base64ct", "dep:serde_json", "alloc", "serde", "zeroize/alloc"]
-oprf = ["digest", "hash2curve"]
+#oprf = ["digest", "hash2curve"]
 pkcs8 = ["dep:pkcs8", "sec1"]
 pem = ["dep:pem-rfc7468", "alloc", "arithmetic", "pkcs8", "sec1/pem"]
 serde = ["dep:serdect", "alloc", "pkcs8", "sec1/serde"]

--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -89,10 +89,10 @@ pub mod scalar;
 
 #[cfg(feature = "dev")]
 pub mod dev;
-#[cfg(feature = "ecdh")]
-pub mod ecdh;
-#[cfg(feature = "hash2curve")]
-pub mod hash2curve;
+//#[cfg(feature = "ecdh")]
+//pub mod ecdh;
+//#[cfg(feature = "hash2curve")]
+//pub mod hash2curve;
 #[cfg(feature = "arithmetic")]
 pub mod ops;
 #[cfg(feature = "sec1")]
@@ -112,8 +112,8 @@ mod public_key;
 #[cfg(feature = "jwk")]
 mod jwk;
 
-#[cfg(feature = "oprf")]
-mod oprf;
+//#[cfg(feature = "oprf")]
+//mod oprf;
 
 pub use crate::{
     error::{Error, Result},
@@ -146,8 +146,8 @@ pub use crate::jwk::{JwkEcKey, JwkParameters};
 #[cfg(feature = "pkcs8")]
 pub use pkcs8;
 
-#[cfg(feature = "oprf")]
-pub use crate::oprf::OprfParameters;
+//#[cfg(feature = "oprf")]
+//pub use crate::oprf::OprfParameters;
 
 use core::{
     fmt::Debug,

--- a/signature/Cargo.toml
+++ b/signature/Cargo.toml
@@ -13,12 +13,8 @@ categories = ["cryptography", "no-std"]
 description = "Traits for cryptographic signature algorithms (e.g. ECDSA, Ed25519)"
 
 [dependencies]
-digest = { version = "=0.11.0-pre.10", optional = true, default-features = false }
+digest = { version = "0.11.0-rc.0", optional = true, default-features = false }
 rand_core = { version = "0.9", optional = true, default-features = false }
-
-[dev-dependencies]
-hex-literal = "1"
-sha2 = { version = "=0.11.0-pre.5", default-features = false }
 
 [features]
 alloc = []


### PR DESCRIPTION
NOTE: this temporarily disables the `ecdh`, `hash2curve`, and `oprf` features of `elliptic-curve` to make the release possible.

Going forward we can remove the `=` from the `digest` version requirement now that we're done making major breaking changes, which should allow for more flexible upgrades.

They can be re-enabled when the `hmac`, `hkdf`, `sha2`, and `sha3` crates have been updated.