### PR TITLE
elliptic-curve: complete `digest` v0.11.0-rc.0 upgrade

### DIFF
--- a/.github/workflows/elliptic-curve.yml
+++ b/.github/workflows/elliptic-curve.yml
@@ -42,10 +42,10 @@ jobs:
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features bits
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features dev
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features digest
-      #- run: cargo build --target ${{ matrix.target }} --release --no-default-features --features ecdh
-      #- run: cargo build --target ${{ matrix.target }} --release --no-default-features --features hash2curve
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features ecdh
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features hash2curve
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features jwk
-      #- run: cargo build --target ${{ matrix.target }} --release --no-default-features --features oprf
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features oprf
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features pem
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features pkcs8
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features sec1
@@ -54,7 +54,7 @@ jobs:
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features alloc,arithmetic,pkcs8
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features alloc,serde
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features arithmetic,serde
-      #- run: cargo build --target ${{ matrix.target }} --release --no-default-features --features alloc,digest,ecdh,hash2curve,jwk,oprf,pem,pkcs8,sec1,serde
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features alloc,digest,ecdh,hash2curve,jwk,oprf,pem,pkcs8,sec1,serde
 
   minimal-versions:
     # Temporarily disabled until elliptic-curve 0.13.0-pre.0 is published

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,6 +134,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dabb6555f92fb9ee4140454eb5dcd14c7960e1225c6d1a6cc361f032947713e"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crypto"
 version = "0.6.0-pre"
 dependencies = [
@@ -202,6 +211,7 @@ dependencies = [
  "ff",
  "group",
  "hex-literal",
+ "hkdf",
  "hybrid-array",
  "pem-rfc7468",
  "pkcs8",
@@ -209,6 +219,8 @@ dependencies = [
  "sec1",
  "serde_json",
  "serdect",
+ "sha2",
+ "sha3",
  "subtle",
  "zeroize",
 ]
@@ -295,6 +307,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bcaaec4551594c969335c98c903c1397853d4198408ea609190f420500f6be71"
 
 [[package]]
+name = "hkdf"
+version = "0.13.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6738bc5110ee31b066339f0c9454db29a93db3b0484bbf2afa8a7e9cebc62141"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8dc6a2fcc35ab09136c6df2cdf9ca49790701420a3a6b5db0987dddbabc79b21"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "hybrid-array"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -319,6 +349,15 @@ name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "keccak"
+version = "0.2.0-pre.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7cdd4f0dc5807b9a2b25dd48a3f58e862606fe7bd47f41ecde36e97422d7e90"
+dependencies = [
+ "cpufeatures",
+]
 
 [[package]]
 name = "kem"
@@ -501,6 +540,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.11.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa1d2e6b3cc4e43a8258a9a3b17aa5dfd2cc5186c7024bba8a64aa65b2c71a59"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "sha3"
+version = "0.11.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e6a92fd180fd205defdc0b78288ce847c7309d329fd6647a814567e67db50e"
+dependencies = [
+ "digest",
+ "keccak",
+]
+
+[[package]]
 name = "signature"
 version = "3.0.0-pre"
 dependencies = [
@@ -630,23 +690,3 @@ name = "zeroize"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
-
-[[patch.unused]]
-name = "hkdf"
-version = "0.13.0-pre.5"
-source = "git+https://github.com/RustCrypto/KDFs.git#2e2dbcd45b8678696e85dcbef922345f3ca04dbf"
-
-[[patch.unused]]
-name = "hmac"
-version = "0.13.0-pre.5"
-source = "git+https://github.com/RustCrypto/MACs.git#64d671d5c375838173d18e30bc14dffc80c13e51"
-
-[[patch.unused]]
-name = "sha2"
-version = "0.11.0-pre.5"
-source = "git+https://github.com/RustCrypto/hashes.git#d9ad085ed12dba58d2a6d75d76a17a1b2706c4c7"
-
-[[patch.unused]]
-name = "sha3"
-version = "0.11.0-pre.5"
-source = "git+https://github.com/RustCrypto/hashes.git#d9ad085ed12dba58d2a6d75d76a17a1b2706c4c7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,4 @@ members = [
 
 [patch.crates-io]
 digest = { path = "digest" }
-hkdf = { git = "https://github.com/RustCrypto/KDFs.git" }
-hmac = { git = "https://github.com/RustCrypto/MACs.git" }
-sha2 = { git = "https://github.com/RustCrypto/hashes.git" }
-sha3 = { git = "https://github.com/RustCrypto/hashes.git" }
 signature = { path = "signature" }

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -29,7 +29,7 @@ base64ct = { version = "1", optional = true, default-features = false, features 
 digest = { version = "0.11.0-rc.0", optional = true }
 ff = { version = "=0.14.0-pre.0", optional = true, default-features = false }
 group = { version = "=0.14.0-pre.0", optional = true, default-features = false }
-#hkdf = { version = "=0.13.0-pre.5", optional = true, default-features = false }
+hkdf = { version = "0.13.0-rc.0", optional = true, default-features = false }
 hex-literal = { version = "1", optional = true }
 pem-rfc7468 = { version = "1.0.0-rc.2", optional = true, features = ["alloc"] }
 pkcs8 = { version = "0.11.0-rc.1", optional = true, default-features = false }
@@ -39,8 +39,8 @@ serde_json = { version = "1.0.121", optional = true, default-features = false, f
 
 [dev-dependencies]
 hex-literal = "1"
-#sha2 = "=0.11.0-pre.5"
-#sha3 = "=0.11.0-pre.5"
+sha2 = "0.11.0-rc.0"
+sha3 = "0.11.0-rc.0"
 
 [features]
 default = ["arithmetic"]
@@ -62,11 +62,11 @@ std = [
 arithmetic = ["group"]
 bits = ["arithmetic", "ff/bits"]
 dev = ["arithmetic", "dep:hex-literal", "pem", "pkcs8"]
-#ecdh = ["arithmetic", "digest", "dep:hkdf"]
+ecdh = ["arithmetic", "digest", "dep:hkdf"]
 group = ["dep:group", "ff"]
-#hash2curve = ["arithmetic", "digest"]
+hash2curve = ["arithmetic", "digest"]
 jwk = ["dep:base64ct", "dep:serde_json", "alloc", "serde", "zeroize/alloc"]
-#oprf = ["digest", "hash2curve"]
+oprf = ["digest", "hash2curve"]
 pkcs8 = ["dep:pkcs8", "sec1"]
 pem = ["dep:pem-rfc7468", "alloc", "arithmetic", "pkcs8", "sec1/pem"]
 serde = ["dep:serdect", "alloc", "pkcs8", "sec1/serde"]

--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -89,10 +89,10 @@ pub mod scalar;
 
 #[cfg(feature = "dev")]
 pub mod dev;
-//#[cfg(feature = "ecdh")]
-//pub mod ecdh;
-//#[cfg(feature = "hash2curve")]
-//pub mod hash2curve;
+#[cfg(feature = "ecdh")]
+pub mod ecdh;
+#[cfg(feature = "hash2curve")]
+pub mod hash2curve;
 #[cfg(feature = "arithmetic")]
 pub mod ops;
 #[cfg(feature = "sec1")]
@@ -112,8 +112,8 @@ mod public_key;
 #[cfg(feature = "jwk")]
 mod jwk;
 
-//#[cfg(feature = "oprf")]
-//mod oprf;
+#[cfg(feature = "oprf")]
+mod oprf;
 
 pub use crate::{
     error::{Error, Result},
@@ -146,8 +146,8 @@ pub use crate::jwk::{JwkEcKey, JwkParameters};
 #[cfg(feature = "pkcs8")]
 pub use pkcs8;
 
-//#[cfg(feature = "oprf")]
-//pub use crate::oprf::OprfParameters;
+#[cfg(feature = "oprf")]
+pub use crate::oprf::OprfParameters;
 
 use core::{
     fmt::Debug,


### PR DESCRIPTION
Due to inter-repo dependency relationships and all of the crates previously using `=` to pin `digest`, some of the features of `elliptic-curve` had to be disabled to complete the `digest` v0.11.0-rc.0 release in #1868.

Now that it's been released and there are new compatible versions of the `hkdf`, `sha2`, and `sha3` crates, it's possible to re-enable this functionality.