### PR TITLE
`signature`: use `&[&[u8]]` for messages

### DIFF
--- a/async-signature/tests/mock_impl.rs
+++ b/async-signature/tests/mock_impl.rs
@@ -11,7 +11,7 @@ struct Signature;
 struct MockSigner;
 
 impl AsyncSigner<Signature> for MockSigner {
-    async fn sign_async(&self, _msg: &[u8]) -> Result<Signature, Error> {
+    async fn sign_async(&self, _msg: &[&[u8]]) -> Result<Signature, Error> {
         unimplemented!("just meant to check compilation")
     }
 }
@@ -33,7 +33,7 @@ impl async_signature::AsyncRandomizedSigner<Signature> for MockSigner {
     >(
         &self,
         _rng: &mut R,
-        _msg: &[u8],
+        _msg: &[&[u8]],
     ) -> Result<Signature, Error> {
         unimplemented!("just meant to check compilation")
     }

--- a/signature/src/verifier.rs
+++ b/signature/src/verifier.rs
@@ -11,7 +11,7 @@ pub trait Verifier<S> {
     /// bytestring is authentic.
     ///
     /// Returns `Error` if it is inauthentic, or otherwise returns `()`.
-    fn verify(&self, msg: &[u8], signature: &S) -> Result<(), Error>;
+    fn verify(&self, msg: &[&[u8]], signature: &S) -> Result<(), Error>;
 }
 
 /// Verify the provided signature for the given prehashed message [`Digest`]


### PR DESCRIPTION
This PR changes all sign/verify methods to take a `&[&[u8]]` type as the `msg` parameters instead of a `&[u8]`. The idea here is to allow non-contiguous bytes to be passed, which is necessary when the message has to be constructed from multiple sources without wanting to allocate memory for a contiguous message. E.g. for `no_std` environments or when the message is rather big but pre-hashing is not applicable (e.g. PureEdDSA).

Resolves https://github.com/RustCrypto/signatures/issues/959.