### PR TITLE
Allow `BatchInvert` with zero elements

### DIFF
--- a/elliptic-curve/src/ops.rs
+++ b/elliptic-curve/src/ops.rs
@@ -97,8 +97,11 @@ fn invert_batch_internal<T: Field>(
     field_elements_pad: &mut [T],
 ) -> Choice {
     let batch_size = field_elements.len();
-    if batch_size == 0 || batch_size != field_elements_pad.len() {
+    if batch_size != field_elements_pad.len() {
         return Choice::from(0);
+    }
+    if batch_size == 0 {
+        return Choice::from(1);
     }
 
     let mut acc = field_elements[0];


### PR DESCRIPTION
This caused [panics in the `BatchNormalize` implementation of `primeorder`](https://github.com/RustCrypto/elliptic-curves/blob/0c503ceb5a3ccb9dfe5acdfc8efceba8683dddcf/primeorder/src/projective.rs#L384-L385). I don't know why we would disallow zero elements here.

Alternatively I could add a check for zero elements in `BatchNormalize`, but again: I wouldn't know why we would disallow zero elements.