### PR TITLE
elliptic-curve: expose `AffineCoordinates::y`

### DIFF
--- a/elliptic-curve/src/dev.rs
+++ b/elliptic-curve/src/dev.rs
@@ -476,6 +476,10 @@ impl AffineCoordinates for AffinePoint {
     fn y(&self) -> FieldBytes {
         unimplemented!();
     }
+
+    fn y_is_odd(&self) -> Choice {
+        unimplemented!();
+    }
 }
 
 impl ConstantTimeEq for AffinePoint {

--- a/elliptic-curve/src/dev.rs
+++ b/elliptic-curve/src/dev.rs
@@ -473,7 +473,7 @@ impl AffineCoordinates for AffinePoint {
         unimplemented!();
     }
 
-    fn y_is_odd(&self) -> Choice {
+    fn y(&self) -> FieldBytes {
         unimplemented!();
     }
 }

--- a/elliptic-curve/src/dev.rs
+++ b/elliptic-curve/src/dev.rs
@@ -477,6 +477,10 @@ impl AffineCoordinates for AffinePoint {
         unimplemented!();
     }
 
+    fn x_is_odd(&self) -> Choice {
+        unimplemented!();
+    }
+
     fn y_is_odd(&self) -> Choice {
         unimplemented!();
     }

--- a/elliptic-curve/src/point.rs
+++ b/elliptic-curve/src/point.rs
@@ -28,8 +28,8 @@ pub trait AffineCoordinates {
     /// Get the affine x-coordinate as a serialized field element.
     fn x(&self) -> Self::FieldRepr;
 
-    /// Is the affine y-coordinate odd?
-    fn y_is_odd(&self) -> Choice;
+    /// Get the affine y-coordinate as a serialized field element.
+    fn y(&self) -> Self::FieldRepr;
 }
 
 /// Normalize point(s) in projective representation by converting them to their affine ones.

--- a/elliptic-curve/src/point.rs
+++ b/elliptic-curve/src/point.rs
@@ -22,7 +22,7 @@ pub type ProjectivePoint<C> = <C as CurveArithmetic>::ProjectivePoint;
 /// Access to the affine coordinates of an elliptic curve point.
 // TODO: use zkcrypto/group#30 coordinate API when available
 pub trait AffineCoordinates {
-    /// Field element representation.
+    /// Field element representation with curve-specific serialization/endianness.
     type FieldRepr: AsRef<[u8]>;
 
     /// Get the affine x-coordinate as a serialized field element.
@@ -30,6 +30,9 @@ pub trait AffineCoordinates {
 
     /// Get the affine y-coordinate as a serialized field element.
     fn y(&self) -> Self::FieldRepr;
+
+    /// Is the affine y-coordinate odd?
+    fn y_is_odd(&self) -> Choice;
 }
 
 /// Normalize point(s) in projective representation by converting them to their affine ones.

--- a/elliptic-curve/src/point.rs
+++ b/elliptic-curve/src/point.rs
@@ -31,6 +31,9 @@ pub trait AffineCoordinates {
     /// Get the affine y-coordinate as a serialized field element.
     fn y(&self) -> Self::FieldRepr;
 
+    /// Is the affine x-coordinate odd?
+    fn x_is_odd(&self) -> Choice;
+
     /// Is the affine y-coordinate odd?
     fn y_is_odd(&self) -> Choice;
 }


### PR DESCRIPTION
In the past we've deliberately avoided exposing the y-coordinate to prevent the possibility of things like invalid curve attacks, although with time we have exposed more and more to support things like alternative point compression formats. See #1237 for some history.

We're now trying to use these traits with Edwards curves like Curve25519 (in `curve25519-dalek`) and Ed448-Goldilocks, which use compressed Edwards y-coordinates as their compressed point format. That requires y-coordinate access.

As such, this changes the previous `y_is_odd` method, which was used to implement SEC1-like compressed points, to a full `fn y` which returns a serialized field element for the y-coordinate.

Closes #1019