### PR TITLE
elliptic-curve: rename `SecretKey::new` => `::from_scalar`

### DIFF
--- a/elliptic-curve/src/secret_key.rs
+++ b/elliptic-curve/src/secret_key.rs
@@ -121,8 +121,9 @@ where
     /// # Returns
     ///
     /// This will return a none if the scalar is all-zero.
-    pub fn new(scalar: ScalarPrimitive<C>) -> CtOption<Self> {
-        CtOption::new(Self { inner: scalar }, !scalar.is_zero())
+    pub fn from_scalar(scalar: impl Into<ScalarPrimitive<C>>) -> CtOption<Self> {
+        let inner = scalar.into();
+        CtOption::new(Self { inner }, !inner.is_zero())
     }
 
     /// Borrow the inner secret [`ScalarPrimitive`] value.


### PR DESCRIPTION
Also changes its arg type to accept an `impl Into<ScalarPrimitive<C>>`