### PR TITLE
elliptic-curve: extract scalar macros from `primeorder`

### DIFF
--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -102,6 +102,7 @@ pub mod weierstrass;
 
 mod error;
 mod field;
+mod macros;
 mod secret_key;
 
 #[cfg(feature = "arithmetic")]

--- a/elliptic-curve/src/macros.rs
+++ b/elliptic-curve/src/macros.rs
@@ -1,0 +1,147 @@
+//! Macros for writing common patterns that interact with this crate.
+
+/// Writes all impls for scalar field types.
+#[macro_export]
+macro_rules! scalar_impls {
+    ($curve:path, $scalar:ty) => {
+        $crate::scalar_from_impls!($curve, $scalar);
+        $crate::scalar_mul_impls!($curve, $scalar);
+    };
+}
+
+/// Writes a series of `From` impls for scalar field types.
+#[macro_export]
+macro_rules! scalar_from_impls {
+    ($curve:path, $scalar:ty) => {
+        impl From<$crate::NonZeroScalar<$curve>> for $scalar {
+            fn from(scalar: $crate::NonZeroScalar<$curve>) -> Self {
+                *scalar.as_ref()
+            }
+        }
+
+        impl From<&$crate::NonZeroScalar<$curve>> for $scalar {
+            fn from(scalar: &$crate::NonZeroScalar<$curve>) -> Self {
+                *scalar.as_ref()
+            }
+        }
+
+        impl From<$crate::ScalarPrimitive<$curve>> for $scalar {
+            fn from(w: $crate::ScalarPrimitive<$curve>) -> Self {
+                <$scalar>::from(&w)
+            }
+        }
+
+        impl From<&$crate::ScalarPrimitive<$curve>> for $scalar {
+            fn from(w: &$crate::ScalarPrimitive<$curve>) -> $scalar {
+                <$scalar>::from_uint_unchecked(*w.as_uint())
+            }
+        }
+
+        impl From<$scalar> for $crate::ScalarPrimitive<$curve> {
+            fn from(scalar: $scalar) -> $crate::ScalarPrimitive<$curve> {
+                $crate::ScalarPrimitive::from(&scalar)
+            }
+        }
+
+        impl From<&$scalar> for $crate::ScalarPrimitive<$curve> {
+            fn from(scalar: &$scalar) -> $crate::ScalarPrimitive<$curve> {
+                $crate::ScalarPrimitive::new(scalar.into()).unwrap()
+            }
+        }
+
+        impl From<&$crate::SecretKey<$curve>> for $scalar {
+            fn from(secret_key: &$crate::SecretKey<$curve>) -> $scalar {
+                *secret_key.to_nonzero_scalar()
+            }
+        }
+
+        /// The constant-time alternative is available at [`$crate::NonZeroScalar<$curve>::new()`].
+        impl TryFrom<$scalar> for $crate::NonZeroScalar<$curve> {
+            type Error = $crate::Error;
+
+            fn try_from(scalar: $scalar) -> $crate::Result<Self> {
+                $crate::NonZeroScalar::new(scalar)
+                    .into_option()
+                    .ok_or($crate::Error)
+            }
+        }
+    };
+}
+
+/// Writes a series of `Mul` impls for an elliptic curve's scalar field
+#[macro_export]
+macro_rules! scalar_mul_impls {
+    ($curve:path, $scalar:ty) => {
+        impl ::core::ops::Mul<$crate::AffinePoint<$curve>> for $scalar {
+            type Output = $crate::ProjectivePoint<$curve>;
+
+            #[inline]
+            fn mul(self, rhs: $crate::AffinePoint<$curve>) -> $crate::ProjectivePoint<$curve> {
+                rhs * self
+            }
+        }
+
+        impl ::core::ops::Mul<&$crate::AffinePoint<$curve>> for $scalar {
+            type Output = $crate::ProjectivePoint<$curve>;
+
+            #[inline]
+            fn mul(self, rhs: &$crate::AffinePoint<$curve>) -> $crate::ProjectivePoint<$curve> {
+                *rhs * self
+            }
+        }
+
+        impl ::core::ops::Mul<$crate::AffinePoint<$curve>> for &$scalar {
+            type Output = $crate::ProjectivePoint<$curve>;
+
+            #[inline]
+            fn mul(self, rhs: $crate::AffinePoint<$curve>) -> $crate::ProjectivePoint<$curve> {
+                rhs * self
+            }
+        }
+
+        impl ::core::ops::Mul<&$crate::AffinePoint<$curve>> for &$scalar {
+            type Output = $crate::ProjectivePoint<$curve>;
+
+            #[inline]
+            fn mul(self, rhs: &$crate::AffinePoint<$curve>) -> $crate::ProjectivePoint<$curve> {
+                *rhs * self
+            }
+        }
+
+        impl ::core::ops::Mul<$crate::ProjectivePoint<$curve>> for $scalar {
+            type Output = $crate::ProjectivePoint<$curve>;
+
+            #[inline]
+            fn mul(self, rhs: $crate::ProjectivePoint<$curve>) -> $crate::ProjectivePoint<$curve> {
+                rhs * self
+            }
+        }
+
+        impl ::core::ops::Mul<&$crate::ProjectivePoint<$curve>> for $scalar {
+            type Output = $crate::ProjectivePoint<$curve>;
+
+            #[inline]
+            fn mul(self, rhs: &$crate::ProjectivePoint<$curve>) -> $crate::ProjectivePoint<$curve> {
+                rhs * &self
+            }
+        }
+
+        impl ::core::ops::Mul<$crate::ProjectivePoint<$curve>> for &$scalar {
+            type Output = $crate::ProjectivePoint<$curve>;
+
+            #[inline]
+            fn mul(self, rhs: $crate::ProjectivePoint<$curve>) -> $crate::ProjectivePoint<$curve> {
+                rhs * self
+            }
+        }
+
+        impl ::core::ops::Mul<&$crate::ProjectivePoint<$curve>> for &$scalar {
+            type Output = $crate::ProjectivePoint<$curve>;
+
+            #[inline]
+            fn mul(self, rhs: &$crate::ProjectivePoint<$curve>) -> $crate::ProjectivePoint<$curve> {
+                rhs * self
+            }
+        }
+    };
+}


### PR DESCRIPTION
Extracts macros for writing `From` and `Mul` impls for scalar types.

It would be nice to use these with `ed448-goldilocks` which isn't a prime order curve, and really these macros work for any elliptic curve, not just prime order curves (`primeorder` was previously just a convenient place to put them).

cc @baloo