### PR TITLE
hash2curve: move oversized DST requirements to runtime errors

### DIFF
--- a/elliptic-curve/src/hash2curve/group_digest.rs
+++ b/elliptic-curve/src/hash2curve/group_digest.rs
@@ -23,9 +23,10 @@ pub trait GroupDigest: MapToCurve {
     /// > hash function is used.
     ///
     /// # Errors
-    /// See implementors of [`ExpandMsg`] for errors:
-    /// - [`ExpandMsgXmd`]
-    /// - [`ExpandMsgXof`]
+    /// - `len_in_bytes > u16::MAX`
+    /// - See implementors of [`ExpandMsg`] for additional errors:
+    ///   - [`ExpandMsgXmd`]
+    ///   - [`ExpandMsgXof`]
     ///
     /// `len_in_bytes = <Self::FieldElement as FromOkm>::Length * 2`
     ///
@@ -53,9 +54,10 @@ pub trait GroupDigest: MapToCurve {
     /// > points in this set are more likely to be output than others.
     ///
     /// # Errors
-    /// See implementors of [`ExpandMsg`] for errors:
-    /// - [`ExpandMsgXmd`]
-    /// - [`ExpandMsgXof`]
+    /// - `len_in_bytes > u16::MAX`
+    /// - See implementors of [`ExpandMsg`] for additional errors:
+    ///   - [`ExpandMsgXmd`]
+    ///   - [`ExpandMsgXof`]
     ///
     /// `len_in_bytes = <Self::FieldElement as FromOkm>::Length`
     ///
@@ -76,9 +78,10 @@ pub trait GroupDigest: MapToCurve {
     /// and returns a scalar.
     ///
     /// # Errors
-    /// See implementors of [`ExpandMsg`] for errors:
-    /// - [`ExpandMsgXmd`]
-    /// - [`ExpandMsgXof`]
+    /// - `len_in_bytes > u16::MAX`
+    /// - See implementors of [`ExpandMsg`] for additional errors:
+    ///   - [`ExpandMsgXmd`]
+    ///   - [`ExpandMsgXof`]
     ///
     /// `len_in_bytes = <Self::Scalar as FromOkm>::Length`
     ///


### PR DESCRIPTION
This PR introduces two changes:
- Remove requirements that were only relevant for oversized `DST`s. Now these requirements are checked on runtime. While this is unfortunate, the currently limitations simply was that usage with regular sized `DST`s incurred limitations that were not necessary.
- Change `len_in_bytes` from `NonZero<usize>` to `NonZero<u16>`. This isn't a big improvement because the error is just moved from `expand_msg()` to the various `GroupDigest` methods.

Companion PR: https://github.com/RustCrypto/elliptic-curves/pull/1256.

---
I know I have been refactoring this API over and over again, but I actually think this is the last of it (apart from https://github.com/RustCrypto/traits/pull/872 with `generic_const_exprs`).

But for completions sake I want to mention the following [from the spec](https://www.rfc-editor.org/rfc/rfc9380.html#section-5.3.1-8):
> It is possible, however, to entirely avoid this overhead by taking advantage of the fact that Z_pad depends only on H, and not on the arguments to expand_message_xmd. To do so, first precompute and save the internal state of H after ingesting Z_pad. Then, when computing b_0, initialize H using the saved state. Further details are implementation dependent and are beyond the scope of this document.

In summary, we could cache this part:
```rust
let mut b_0 = HashT::default();
b_0.update(&Array::<u8, HashT::BlockSize>::default());
```
Doing this requires passing `ExpandMsg` state, which would change the entire API having to add a parameter to every function.

However, as the spec mentions, the cost of not caching it is most likely negligible. We will see in the future if this shows up in benchmarks and if it does we can re-evaluate. I don't believe this will be the case though.

Alternatively, we could add a trait to `digest` which allows users to construct a hash prefixed with a `BlockSize` full of zeros that has been computed at compile-time. Which would also require no changes to the API except binding to this trait.