### PR TITLE
elliptic-curve: re-export `group::Curve` as `CurveGroup`

### DIFF
--- a/elliptic-curve/src/arithmetic.rs
+++ b/elliptic-curve/src/arithmetic.rs
@@ -1,7 +1,7 @@
 //! Elliptic curve arithmetic traits.
 
 use crate::{
-    Curve, Error, FieldBytes, NonZeroScalar, PrimeCurve, ScalarPrimitive,
+    Curve, CurveGroup, Error, FieldBytes, Group, NonZeroScalar, PrimeCurve, ScalarPrimitive,
     ops::{Invert, LinearCombination, Mul, Reduce, ShrAssign},
     point::{AffineCoordinates, NonIdentity},
     scalar::{FromUintUnchecked, IsHigh},
@@ -50,8 +50,8 @@ pub trait CurveArithmetic: Curve {
         + LinearCombination<[(Self::ProjectivePoint, Self::Scalar)]>
         + LinearCombination<[(Self::ProjectivePoint, Self::Scalar); 2]>
         + TryInto<NonIdentity<Self::ProjectivePoint>, Error = Error>
-        + group::Curve<AffineRepr = Self::AffinePoint>
-        + group::Group<Scalar = Self::Scalar>;
+        + CurveGroup<AffineRepr = Self::AffinePoint>
+        + Group<Scalar = Self::Scalar>;
 
     /// Scalar field modulo this curve's order.
     ///

--- a/elliptic-curve/src/dev.rs
+++ b/elliptic-curve/src/dev.rs
@@ -4,7 +4,7 @@
 //! the traits in this crate.
 
 use crate::{
-    BatchNormalize, Curve, CurveArithmetic, FieldBytesEncoding, PrimeCurve,
+    BatchNormalize, Curve, CurveArithmetic, CurveGroup, FieldBytesEncoding, PrimeCurve,
     array::typenum::U32,
     bigint::{Limb, U256},
     error::{Error, Result},
@@ -651,7 +651,7 @@ impl From<NonIdentity<ProjectivePoint>> for ProjectivePoint {
 
 impl From<ProjectivePoint> for AffinePoint {
     fn from(point: ProjectivePoint) -> AffinePoint {
-        group::Curve::to_affine(&point)
+        CurveGroup::to_affine(&point)
     }
 }
 
@@ -736,11 +736,11 @@ impl group::GroupEncoding for ProjectivePoint {
     }
 
     fn to_bytes(&self) -> Self::Repr {
-        group::Curve::to_affine(self).to_bytes()
+        CurveGroup::to_affine(self).to_bytes()
     }
 }
 
-impl group::Curve for ProjectivePoint {
+impl CurveGroup for ProjectivePoint {
     type AffineRepr = AffinePoint;
 
     fn to_affine(&self) -> AffinePoint {

--- a/elliptic-curve/src/ecdh.rs
+++ b/elliptic-curve/src/ecdh.rs
@@ -27,12 +27,11 @@
 //! [SIGMA]: https://webee.technion.ac.il/~hugo/sigma-pdf.pdf
 
 use crate::{
-    AffinePoint, Curve, CurveArithmetic, FieldBytes, NonZeroScalar, ProjectivePoint, PublicKey,
-    point::AffineCoordinates,
+    AffinePoint, Curve, CurveArithmetic, CurveGroup, FieldBytes, NonZeroScalar, ProjectivePoint,
+    PublicKey, point::AffineCoordinates,
 };
 use core::{borrow::Borrow, fmt};
 use digest::{Digest, crypto_common::BlockSizeUser};
-use group::Curve as _;
 use hkdf::{Hkdf, hmac::SimpleHmac};
 use rand_core::{CryptoRng, TryCryptoRng};
 use zeroize::{Zeroize, ZeroizeOnDrop};

--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -139,7 +139,7 @@ pub use {
         scalar::{NonZeroScalar, Scalar},
     },
     ff::{self, Field, PrimeField},
-    group::{self, Group},
+    group::{self, Curve as CurveGroup, Group},
 };
 
 #[cfg(feature = "jwk")]

--- a/elliptic-curve/src/ops.rs
+++ b/elliptic-curve/src/ops.rs
@@ -1,9 +1,10 @@
 //! Traits for arithmetic operations on elliptic curve field elements.
 
-use core::iter;
 pub use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Shr, ShrAssign, Sub, SubAssign};
 pub use crypto_bigint::Invert;
 
+use crate::CurveGroup;
+use core::iter;
 use crypto_bigint::Integer;
 use ff::Field;
 use subtle::{Choice, CtOption};
@@ -159,7 +160,7 @@ pub(crate) fn invert_batch_internal<T: Copy + Mul<Output = T> + MulAssign>(
 ///
 /// It's generic around `PointsAndScalars` to allow overlapping impls. For example, const generic
 /// impls can use the input size to determine the size needed to store temporary variables.
-pub trait LinearCombination<PointsAndScalars>: group::Curve
+pub trait LinearCombination<PointsAndScalars>: CurveGroup
 where
     PointsAndScalars: AsRef<[(Self, Self::Scalar)]> + ?Sized,
 {


### PR DESCRIPTION
This crate also defines a `Curve` trait, and while that trait is used to describe an elliptic curve, `group::Curve` is a `Group`, i.e. the elliptic curve group for a particular curve.

See also: zkcrypto/group#51

To prevent this name clash, this commit re-exports `group::Curve` as `CurveGroup`.

cc @daxpedda 