### PR TITLE
elliptic-curve: extract `NonIdentity`/`NonZeroScalar` casting methods

### DIFF
--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -5,8 +5,7 @@
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg"
 )]
-// Only allowed for newtype casts.
-#![deny(unsafe_code)]
+#![deny(unsafe_code)] // Only allowed for newtype casts.
 #![warn(
     clippy::cast_lossless,
     clippy::cast_possible_truncation,

--- a/elliptic-curve/src/point/non_identity.rs
+++ b/elliptic-curve/src/point/non_identity.rs
@@ -22,7 +22,7 @@ use crate::{BatchNormalize, CurveArithmetic, NonZeroScalar, Scalar};
 /// In the context of ECC, it's useful for ensuring that certain arithmetic
 /// cannot result in the identity point.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-#[repr(transparent)]
+#[repr(transparent)] // SAFETY: needed for `unsafe` safety invariants below
 pub struct NonIdentity<P> {
     point: P,
 }
@@ -55,11 +55,6 @@ impl<P> NonIdentity<P> {
     /// Transform array reference containing [`NonIdentity`] points to an array reference to the
     /// inner point type.
     pub fn cast_array_as_inner<const N: usize>(points: &[Self; N]) -> &[P; N] {
-        // Ensure casting is safe.
-        // This always succeeds because `NonIdentity` is `repr(transparent)`.
-        debug_assert_eq!(size_of::<P>(), size_of::<NonIdentity<P>>());
-        debug_assert_eq!(align_of::<P>(), align_of::<NonIdentity<P>>());
-
         // SAFETY: `NonIdentity` is a `repr(transparent)` newtype for `P` so it's safe to cast to
         // the inner `P` type.
         #[allow(unsafe_code)]
@@ -70,11 +65,6 @@ impl<P> NonIdentity<P> {
 
     /// Transform slice containing [`NonIdentity`] points to a slice of the inner point type.
     pub fn cast_slice_as_inner(points: &[Self]) -> &[P] {
-        // Ensure casting is safe.
-        // This always succeeds because `NonIdentity` is `repr(transparent)`.
-        debug_assert_eq!(size_of::<P>(), size_of::<NonIdentity<P>>());
-        debug_assert_eq!(align_of::<P>(), align_of::<NonIdentity<P>>());
-
         // SAFETY: `NonIdentity` is a `repr(transparent)` newtype for `P` so it's safe to cast to
         // the inner `P` type.
         #[allow(unsafe_code)]

--- a/elliptic-curve/src/point/non_identity.rs
+++ b/elliptic-curve/src/point/non_identity.rs
@@ -51,6 +51,39 @@ where
     }
 }
 
+impl<P> NonIdentity<P> {
+    /// Transform array reference containing [`NonIdentity`] points to an array reference to the
+    /// inner point type.
+    pub fn cast_array_as_inner<const N: usize>(points: &[Self; N]) -> &[P; N] {
+        // Ensure casting is safe.
+        // This always succeeds because `NonIdentity` is `repr(transparent)`.
+        debug_assert_eq!(size_of::<P>(), size_of::<NonIdentity<P>>());
+        debug_assert_eq!(align_of::<P>(), align_of::<NonIdentity<P>>());
+
+        // SAFETY: `NonIdentity` is a `repr(transparent)` newtype for `P` so it's safe to cast to
+        // the inner `P` type.
+        #[allow(unsafe_code)]
+        unsafe {
+            &*points.as_ptr().cast()
+        }
+    }
+
+    /// Transform slice containing [`NonIdentity`] points to a slice of the inner point type.
+    pub fn cast_slice_as_inner(points: &[Self]) -> &[P] {
+        // Ensure casting is safe.
+        // This always succeeds because `NonIdentity` is `repr(transparent)`.
+        debug_assert_eq!(size_of::<P>(), size_of::<NonIdentity<P>>());
+        debug_assert_eq!(align_of::<P>(), align_of::<NonIdentity<P>>());
+
+        // SAFETY: `NonIdentity` is a `repr(transparent)` newtype for `P` so it's safe to cast to
+        // the inner `P` type.
+        #[allow(unsafe_code)]
+        unsafe {
+            &*(points as *const [NonIdentity<P>] as *const [P])
+        }
+    }
+}
+
 impl<P: Copy> NonIdentity<P> {
     /// Return wrapped point.
     pub fn to_point(self) -> P {
@@ -114,26 +147,8 @@ where
     type Output = [NonIdentity<P::AffineRepr>; N];
 
     fn batch_normalize(points: &[Self; N]) -> [NonIdentity<P::AffineRepr>; N] {
-        // Ensure casting is safe.
-        // This always succeeds because `NonIdentity` is `repr(transparent)`.
-        debug_assert_eq!(size_of::<P>(), size_of::<NonIdentity<P>>());
-        debug_assert_eq!(align_of::<P>(), align_of::<NonIdentity<P>>());
-
-        #[allow(unsafe_code)]
-        // SAFETY: `NonIdentity` is `repr(transparent)`.
-        let points: &[P; N] = unsafe { &*points.as_ptr().cast() };
+        let points = Self::cast_array_as_inner::<N>(points);
         let affine_points = <P as BatchNormalize<_>>::batch_normalize(points);
-
-        // Ensure `array::map()` can be optimized to a `memcpy`.
-        debug_assert_eq!(
-            size_of::<P::AffineRepr>(),
-            size_of::<NonIdentity<P::AffineRepr>>()
-        );
-        debug_assert_eq!(
-            align_of::<P::AffineRepr>(),
-            align_of::<NonIdentity<P::AffineRepr>>()
-        );
-
         affine_points.map(|point| NonIdentity { point })
     }
 }
@@ -146,26 +161,8 @@ where
     type Output = Vec<NonIdentity<P::AffineRepr>>;
 
     fn batch_normalize(points: &[Self]) -> Vec<NonIdentity<P::AffineRepr>> {
-        // Ensure casting is safe.
-        // This always succeeds because `NonIdentity` is `repr(transparent)`.
-        debug_assert_eq!(size_of::<P>(), size_of::<NonIdentity<P>>());
-        debug_assert_eq!(align_of::<P>(), align_of::<NonIdentity<P>>());
-
-        #[allow(unsafe_code)]
-        // SAFETY: `NonIdentity` is `repr(transparent)`.
-        let points: &[P] = unsafe { &*(points as *const [NonIdentity<P>] as *const [P]) };
+        let points = Self::cast_slice_as_inner(points);
         let affine_points = <P as BatchNormalize<_>>::batch_normalize(points);
-
-        // Ensure `into_iter()` + `collect()` can be optimized away.
-        debug_assert_eq!(
-            size_of::<P::AffineRepr>(),
-            size_of::<NonIdentity<P::AffineRepr>>()
-        );
-        debug_assert_eq!(
-            align_of::<P::AffineRepr>(),
-            align_of::<NonIdentity<P::AffineRepr>>()
-        );
-
         affine_points
             .into_iter()
             .map(|point| NonIdentity { point })


### PR DESCRIPTION
These methods encapsulate safely casting references for arrays and slices of `NonIdentity<P>` to array/slice references to the inner `P` type, and the same for `NonZeroScalar` and its inner `Scalar<C>` type.

Note the choice of method names follows from similar ones in `hybrid-array`: https://docs.rs/hybrid-array/latest/hybrid_array/struct.Array.html#method.cast_slice_to_core

cc @daxpedda 