### PR TITLE
elliptic-curve: update SIGMA protocol reference link

### DIFF
--- a/elliptic-curve/src/ecdh.rs
+++ b/elliptic-curve/src/ecdh.rs
@@ -24,7 +24,7 @@
 //! [`diffie_hellman`] function.
 //!
 //! [AKE]: https://en.wikipedia.org/wiki/Authenticated_Key_Exchange
-//! [SIGMA]: https://webee.technion.ac.il/~hugo/sigma-pdf.pdf
+//! [SIGMA]: https://www.iacr.org/cryptodb/archive/2003/CRYPTO/1495/1495.pdf
 
 use crate::{
     AffinePoint, Curve, CurveArithmetic, CurveGroup, FieldBytes, NonZeroScalar, ProjectivePoint,


### PR DESCRIPTION
Replaced the outdated SIGMA protocol reference link in the ECDH module documentation with the official IACR archive PDF. The new link points to the full text of "SIGMA: the 'SIGn-and-MAc' Approach to Authenticated Diffie-Hellman and its Use in the IKE Protocols" by Hugo Krawczyk (CRYPTO 2003), ensuring long-term accessibility and citation accuracy.