### PR TITLE
elliptic-curve: fix doc comment in `TryFrom<Scalar>` for `NonZeroScalar`

### DIFF
--- a/elliptic-curve/src/macros.rs
+++ b/elliptic-curve/src/macros.rs
@@ -55,7 +55,8 @@ macro_rules! scalar_from_impls {
             }
         }
 
-        /// The constant-time alternative is available at [`$crate::NonZeroScalar<$curve>::new()`].
+        /// The constant-time alternative is available at
+        #[doc = concat!("[`", stringify!(elliptic_curve), "::NonZeroScalar<", stringify!($curve), ">::new()`].")]
         impl TryFrom<$scalar> for $crate::NonZeroScalar<$curve> {
             type Error = $crate::Error;
 


### PR DESCRIPTION
Currently the doc comment looks like this:
![image](https://github.com/user-attachments/assets/c19ceb8b-5c4c-4e5c-b8eb-35173e267c3b)

I used `elliptic_curve` instead of `$crate` because `stringify!($crate)` doesn't work.
Now it looks like this:
![image](https://github.com/user-attachments/assets/41b64a28-7bea-42c6-8339-9b57ab46238c)
