### PR TITLE
elliptic-curve: make hash2curve traits depend on `Group` rather than `CurveArithmetic`

### DIFF
--- a/elliptic-curve/src/hash2curve/group_digest.rs
+++ b/elliptic-curve/src/hash2curve/group_digest.rs
@@ -1,7 +1,7 @@
 //! Traits for handling hash to curve.
 
 use super::{ExpandMsg, MapToCurve, hash_to_field};
-use crate::{ProjectivePoint, Result};
+use crate::Result;
 use hybrid_array::typenum::Unsigned;
 
 /// Hash arbitrary byte sequences to a valid group element.
@@ -32,7 +32,7 @@ pub trait GroupDigest: MapToCurve {
     ///
     /// [`ExpandMsgXmd`]: crate::hash2curve::ExpandMsgXmd
     /// [`ExpandMsgXof`]: crate::hash2curve::ExpandMsgXof
-    fn hash_from_bytes<X>(msg: &[&[u8]], dst: &[&[u8]]) -> Result<ProjectivePoint<Self>>
+    fn hash_from_bytes<X>(msg: &[&[u8]], dst: &[&[u8]]) -> Result<Self>
     where
         X: ExpandMsg<Self::K>,
     {
@@ -63,7 +63,7 @@ pub trait GroupDigest: MapToCurve {
     ///
     /// [`ExpandMsgXmd`]: crate::hash2curve::ExpandMsgXmd
     /// [`ExpandMsgXof`]: crate::hash2curve::ExpandMsgXof
-    fn encode_from_bytes<X>(msg: &[&[u8]], dst: &[&[u8]]) -> Result<ProjectivePoint<Self>>
+    fn encode_from_bytes<X>(msg: &[&[u8]], dst: &[&[u8]]) -> Result<Self>
     where
         X: ExpandMsg<Self::K>,
     {

--- a/elliptic-curve/src/hash2curve/map2curve.rs
+++ b/elliptic-curve/src/hash2curve/map2curve.rs
@@ -1,12 +1,12 @@
 //! Traits for mapping field elements to points on the curve.
 
-use crate::{CurveArithmetic, ProjectivePoint};
+use crate::Group;
 
 use super::FromOkm;
 
 /// Trait for converting field elements into a point via a mapping method like
 /// Simplified Shallue-van de Woestijne-Ulas or Elligator.
-pub trait MapToCurve: CurveArithmetic<Scalar: FromOkm> {
+pub trait MapToCurve: Group<Scalar: FromOkm> {
     /// The intermediate representation, an element of the curve which may or may not
     /// be in the curve subgroup.
     type CurvePoint;
@@ -18,7 +18,7 @@ pub trait MapToCurve: CurveArithmetic<Scalar: FromOkm> {
 
     /// Map a curve point to a point in the curve subgroup.
     /// This is usually done by clearing the cofactor, if necessary.
-    fn map_to_subgroup(point: Self::CurvePoint) -> ProjectivePoint<Self>;
+    fn map_to_subgroup(point: Self::CurvePoint) -> Self;
 
     /// Combine two curve points into a point in the curve subgroup.
     /// This is usually done by clearing the cofactor of the sum. In case
@@ -27,7 +27,7 @@ pub trait MapToCurve: CurveArithmetic<Scalar: FromOkm> {
     fn add_and_map_to_subgroup(
         lhs: Self::CurvePoint,
         rhs: Self::CurvePoint,
-    ) -> ProjectivePoint<Self> {
+    ) -> Self {
         Self::map_to_subgroup(lhs) + Self::map_to_subgroup(rhs)
     }
 }

--- a/elliptic-curve/src/hash2curve/map2curve.rs
+++ b/elliptic-curve/src/hash2curve/map2curve.rs
@@ -24,10 +24,7 @@ pub trait MapToCurve: Group<Scalar: FromOkm> {
     /// This is usually done by clearing the cofactor of the sum. In case
     /// addition is not implemented for `Self::CurvePoint`, then both terms
     /// must be mapped to the subgroup individually before being added.
-    fn add_and_map_to_subgroup(
-        lhs: Self::CurvePoint,
-        rhs: Self::CurvePoint,
-    ) -> Self {
+    fn add_and_map_to_subgroup(lhs: Self::CurvePoint, rhs: Self::CurvePoint) -> Self {
         Self::map_to_subgroup(lhs) + Self::map_to_subgroup(rhs)
     }
 }


### PR DESCRIPTION
This was previously requested as part of #1177, and some related discussion took place in #1911.
 
This seems relevant as the main trait name is `GroupDigest`.

I will also open a PR to all implementing crates.