### PR TITLE
Remove PKCS#8 blanket impls for SEC1 private key traits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -478,13 +478,11 @@ checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 [[package]]
 name = "sec1"
 version = "0.8.0-rc.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1231d6ed04c5242799d39a97ca91aeda70ecc27a67870a5fe43149e5c12aed3d"
+source = "git+https://github.com/RustCrypto/formats/#17bb02635dba4ab75a51eeffdf5a5de80ffe8ce3"
 dependencies = [
  "base16ct",
  "der",
  "hybrid-array",
- "pkcs8",
  "serdect",
  "subtle",
  "zeroize",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,5 @@ members = [
 [patch.crates-io]
 digest = { path = "digest" }
 signature = { path = "signature" }
+
+sec1 = { git = "https://github.com/RustCrypto/formats/" }

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -66,7 +66,7 @@ ecdh = ["arithmetic", "digest", "dep:hkdf"]
 group = ["dep:group", "ff"]
 jwk = ["dep:base64ct", "dep:serde_json", "alloc", "serde", "zeroize/alloc"]
 pkcs8 = ["dep:pkcs8", "sec1"]
-pem = ["dep:pem-rfc7468", "alloc", "arithmetic", "pkcs8", "sec1/pem"]
+pem = ["dep:pem-rfc7468", "alloc", "arithmetic", "pkcs8/pem", "sec1/pem"]
 serde = ["dep:serdect", "alloc", "pkcs8", "sec1/serde"]
 
 [package.metadata.docs.rs]

--- a/elliptic-curve/src/secret_key/pkcs8.rs
+++ b/elliptic-curve/src/secret_key/pkcs8.rs
@@ -18,9 +18,8 @@ use {
     },
     pkcs8::{
         EncodePrivateKey,
-        der::{self, Encode, asn1::OctetStringRef},
+        der::{self, asn1::OctetStringRef},
     },
-    zeroize::Zeroizing,
 };
 
 // Imports for actual PEM support
@@ -72,18 +71,7 @@ where
             parameters: Some((&C::OID).into()),
         };
 
-        let private_key_bytes = Zeroizing::new(self.to_bytes());
-        let public_key_bytes = self.public_key().to_encoded_point(false);
-
-        // TODO(tarcieri): unify with `to_sec1_der()` by building an owned `EcPrivateKey`
-        let ec_private_key = Zeroizing::new(
-            EcPrivateKey {
-                private_key: &private_key_bytes,
-                parameters: None,
-                public_key: Some(public_key_bytes.as_bytes()),
-            }
-            .to_der()?,
-        );
+        let ec_private_key = self.to_sec1_der()?;
 
         let pkcs8_key = pkcs8::PrivateKeyInfoRef::new(
             algorithm_identifier,


### PR DESCRIPTION
Companion PR to RustCrypto/formats#1927 which properly composes the PKCS#8 impl in terms of the SEC1 impl