### PR TITLE
elliptic-curve: fix SEC1 serialization

### DIFF
--- a/elliptic-curve/src/secret_key.rs
+++ b/elliptic-curve/src/secret_key.rs
@@ -387,7 +387,7 @@ where
 
         Ok(der::SecretDocument::encode_msg(&sec1::EcPrivateKey {
             private_key: &private_key_bytes,
-            parameters: None,
+            parameters: Some(C::OID.into()),
             public_key: Some(public_key_bytes.as_bytes()),
         })?)
     }


### PR DESCRIPTION
It wasn't including the curve OID as `EcParameters`. Previously the logic for populating this field lived in the `sec1` crate.

Since SEC1 needs a slightly different serialization than PKCS#8 (notably the latter hoists the curve OID onto `AlgorithmParameters` and omits it from the SEC1 `EcPrivateKey` this more or less reverts the PKCS#8 serialization logic to what it was before.