### PR TITLE
[WIP] elliptic-curve: use `IntoIterator` bound on `LinearCombination`

### DIFF
--- a/elliptic-curve/src/arithmetic.rs
+++ b/elliptic-curve/src/arithmetic.rs
@@ -47,8 +47,8 @@ pub trait CurveArithmetic: Curve {
         + From<Self::AffinePoint>
         + From<NonIdentity<Self::ProjectivePoint>>
         + Into<Self::AffinePoint>
-        + LinearCombination<[(Self::ProjectivePoint, Self::Scalar)]>
-        + LinearCombination<[(Self::ProjectivePoint, Self::Scalar); 2]>
+        + for<'a> LinearCombination<'a, [(Self::ProjectivePoint, Self::Scalar)]>
+        + for<'a> LinearCombination<'a, [(Self::ProjectivePoint, Self::Scalar); 2]>
         + TryInto<NonIdentity<Self::ProjectivePoint>, Error = Error>
         + CurveGroup<AffineRepr = Self::AffinePoint>
         + Group<Scalar = Self::Scalar>;

--- a/elliptic-curve/src/dev.rs
+++ b/elliptic-curve/src/dev.rs
@@ -752,8 +752,8 @@ impl CurveGroup for ProjectivePoint {
     }
 }
 
-impl LinearCombination<[(ProjectivePoint, Scalar)]> for ProjectivePoint {}
-impl<const N: usize> LinearCombination<[(ProjectivePoint, Scalar); N]> for ProjectivePoint {}
+impl LinearCombination<'_, [(ProjectivePoint, Scalar)]> for ProjectivePoint {}
+impl<const N: usize> LinearCombination<'_, [(ProjectivePoint, Scalar); N]> for ProjectivePoint {}
 
 impl Add<ProjectivePoint> for ProjectivePoint {
     type Output = ProjectivePoint;

--- a/elliptic-curve/src/ops.rs
+++ b/elliptic-curve/src/ops.rs
@@ -160,15 +160,15 @@ pub(crate) fn invert_batch_internal<T: Copy + Mul<Output = T> + MulAssign>(
 ///
 /// It's generic around `PointsAndScalars` to allow overlapping impls. For example, const generic
 /// impls can use the input size to determine the size needed to store temporary variables.
-pub trait LinearCombination<PointsAndScalars>: CurveGroup
+pub trait LinearCombination<'a, PointsAndScalars>: CurveGroup
 where
-    PointsAndScalars: AsRef<[(Self, Self::Scalar)]> + ?Sized,
+    PointsAndScalars: ?Sized + 'a,
+    &'a PointsAndScalars: IntoIterator<Item = &'a (Self, Self::Scalar)>,
 {
     /// Calculates `x1 * k1 + ... + xn * kn`.
-    fn lincomb(points_and_scalars: &PointsAndScalars) -> Self {
+    fn lincomb(points_and_scalars: &'a PointsAndScalars) -> Self {
         points_and_scalars
-            .as_ref()
-            .iter()
+            .into_iter()
             .copied()
             .map(|(point, scalar)| point * scalar)
             .sum()


### PR DESCRIPTION
Allows passing any type which produces an iterator, rather than requiring all inputs are in a contiguous slice of memory