### PR TITLE
elliptic-curve: remove `ShrAssign` bound on `Scalar`s

### DIFF
--- a/elliptic-curve/src/arithmetic.rs
+++ b/elliptic-curve/src/arithmetic.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     Curve, CurveGroup, Error, FieldBytes, Group, NonZeroScalar, PrimeCurve, ScalarPrimitive,
-    ops::{Invert, LinearCombination, Mul, Reduce, ShrAssign},
+    ops::{Invert, LinearCombination, Mul, Reduce},
     point::{AffineCoordinates, NonIdentity},
     scalar::{FromUintUnchecked, IsHigh},
 };
@@ -81,7 +81,6 @@ pub trait CurveArithmetic: Curve {
         + for<'a> Mul<&'a Self::ProjectivePoint, Output = Self::ProjectivePoint>
         + PartialOrd
         + Reduce<Self::Uint, Bytes = FieldBytes<Self>>
-        + ShrAssign<usize>
         + TryInto<NonZeroScalar<Self>, Error = Error>
         + ff::Field
         + ff::PrimeField<Repr = FieldBytes<Self>>;


### PR DESCRIPTION
Removes the bound from the `CurveArithmetic::Scalar` associated type.

I was attempting to figure out why this issue didn't result in any bugs:

https://github.com/RustCrypto/elliptic-curves/issues/1319

It appears to be completely unused.

The easiest way to fix that bug is to delete all of the relevant code.