### PR TITLE
[WIP] aead: add `doc_usage!` macro

### DIFF
--- a/aead/src/doc.rs
+++ b/aead/src/doc.rs
@@ -1,0 +1,29 @@
+//! Documentation macros.
+//!
+//! These are used for writing redundant documentation that shows how to use the trait-based
+//! interface with a concrete crate/type.
+
+/// Write the "Usage" section of the toplevel documentation, using the given `$aead` type in
+/// code examples.
+#[doc(hidden)]
+#[macro_export]
+#[rustfmt::skip]
+macro_rules! doc_usage {
+    ($aead:ident) => {
+        concat!(
+            "# Usage\n",
+            "\n",
+            "Simple usage (allocating, no associated data):\n",
+            "\n",
+            "```\n",
+            "use ", env!("CARGO_CRATE_NAME"), "::{\n",
+            "    aead::{Aead, AeadCore, KeyInit, rand_core::OsRng},\n",
+            "    ", stringify!($aead), ", Nonce, Key\n",
+            "};\n",
+            "\n",
+            "// The encryption key can be generated randomly:\n",
+            "let key = ", stringify!($aead), "::generate_key().expect(\"generate key\");\n",
+            "```\n"
+        )
+    };
+}

--- a/aead/src/lib.rs
+++ b/aead/src/lib.rs
@@ -18,6 +18,7 @@ extern crate alloc;
 
 #[cfg(feature = "dev")]
 pub mod dev;
+mod doc;
 
 pub use crypto_common::{
     Key, KeyInit, KeySizeUser,


### PR DESCRIPTION
Adds a macro which generates the crate usage boilerplate, customized to a specific crate and example AEAD cipher.

Downstream crates can use it like:

```rust
#![doc = include_str!("../README.md")]
#![doc = aead::doc_usage!(Aes256Gcm)]
```

Rendering of the generated rustdoc showing the macro output on top and the original boilerplate text below:

<img width="646" height="666" alt="Screenshot 2025-08-02 at 6 28 30 PM" src="https://github.com/user-attachments/assets/367c7750-baa4-4188-8201-f8b78b82c68c" />

