### PR TITLE
digest: simplify test macros using `stringify!`

### DIFF
--- a/digest/CHANGELOG.md
+++ b/digest/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `CtVariableCoreWrapper` renamed to `CtOutWrapper` ([#1799])
 - Removed the OID type parameter from `CtOutWrapper` ([#1799])
 - Implementations of the `SerializableState` trait ([#1953])
+- `new_test!` and `new_mac_test!` macros ([#1958])
 
 ### Removed
 - `Mac::new`, `Mac::new_from_slice`, and `Mac::generate_key` methods ([#1173])
@@ -31,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#1809]: https://github.com/RustCrypto/traits/pull/1809
 [#1820]: https://github.com/RustCrypto/traits/pull/1820
 [#1953]: https://github.com/RustCrypto/traits/pull/1953
+[#1958]: https://github.com/RustCrypto/traits/pull/1958
 
 ## 0.10.7 (2023-05-19)
 ### Changed

--- a/digest/src/dev.rs
+++ b/digest/src/dev.rs
@@ -33,7 +33,7 @@ macro_rules! new_test {
             use $crate::dev::TestVector;
 
             $crate::dev::blobby::parse_into_structs!(
-                include_bytes!(concat!("data/", stringify!($test_name), ".blb"));
+                include_bytes!(concat!("data/", stringify!($name), ".blb"));
                 static TEST_VECTORS: &[TestVector { input, output }];
             );
 

--- a/digest/src/dev.rs
+++ b/digest/src/dev.rs
@@ -27,13 +27,13 @@ pub struct TestVector {
 /// Define hash function test
 #[macro_export]
 macro_rules! new_test {
-    ($name:ident, $test_name:expr, $hasher:ty, $test_fn:ident $(,)?) => {
+    ($name:ident, $hasher:ty, $test_fn:ident $(,)?) => {
         #[test]
         fn $name() {
             use $crate::dev::TestVector;
 
             $crate::dev::blobby::parse_into_structs!(
-                include_bytes!(concat!("data/", $test_name, ".blb"));
+                include_bytes!(concat!("data/", stringify!($test_name), ".blb"));
                 static TEST_VECTORS: &[TestVector { input, output }];
             );
 

--- a/digest/src/dev/mac.rs
+++ b/digest/src/dev/mac.rs
@@ -118,22 +118,22 @@ pub fn reset_mac_test<M: Mac + KeyInit + FixedOutputReset + Clone>(
 /// Define MAC test
 #[macro_export]
 macro_rules! new_mac_test {
-    ($name:ident, $test_name:expr, $mac:ty, $test_fn:ident $(,)?) => {
-        digest::new_mac_test!($name, $test_name, $mac, $test_fn, $crate::dev::MacTruncSide::None);
+    ($name:ident, $mac:ty, $test_fn:ident $(,)?) => {
+        digest::new_mac_test!($name, $mac, $test_fn, $crate::dev::MacTruncSide::None);
     };
-    ($name:ident, $test_name:expr, $mac:ty, $test_fn:ident, trunc_left $(,)?) => {
-        digest::new_mac_test!($name, $test_name, $mac, $test_fn, $crate::dev::MacTruncSide::Left);
+    ($name:ident, $mac:ty, $test_fn:ident, trunc_left $(,)?) => {
+        digest::new_mac_test!($name, $mac, $test_fn, $crate::dev::MacTruncSide::Left);
     };
-    ($name:ident, $test_name:expr, $mac:ty, $test_fn:ident, trunc_right $(,)?) => {
-        digest::new_mac_test!($name, $test_name, $mac, $test_fn, $crate::dev::MacTruncSide::Right);
+    ($name:ident, $mac:ty, $test_fn:ident, trunc_right $(,)?) => {
+        digest::new_mac_test!($name, $mac, $test_fn, $crate::dev::MacTruncSide::Right);
     };
-    ($name:ident, $test_name:expr, $mac:ty, $test_fn:ident, $trunc:expr $(,)?) => {
+    ($name:ident, $mac:ty, $test_fn:ident, $trunc:expr $(,)?) => {
         #[test]
         fn $name() {
             use digest::dev::MacTestVector;
 
             $crate::dev::blobby::parse_into_structs!(
-                include_bytes!(concat!("data/", $test_name, ".blb"));
+                include_bytes!(concat!("data/", stringify!($name), ".blb"));
                 static TEST_VECTORS: &[MacTestVector { key, input, tag }];
             );
 

--- a/digest/src/dev/rng.rs
+++ b/digest/src/dev/rng.rs
@@ -10,7 +10,7 @@ pub(crate) const RNG: XorShiftRng = XorShiftRng {
     w: Wrapping(0xB0AD_B4F3),
 };
 
-/// Xorshift RNG instance/
+/// Xorshift RNG instance
 pub(crate) struct XorShiftRng {
     x: Wrapping<u32>,
     y: Wrapping<u32>,


### PR DESCRIPTION
Names of test functions and names of associated KAT file usually match, so it's worth to simplify the macro to reduce amount of duplication at call sites.