### PR TITLE
cipher: use `block_buffer::ReadBuffer` in `StreamCipherCoreWrapper`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,7 +75,7 @@ source = "git+https://github.com/RustCrypto/utils#f5ac85f6aa02aa39614f62a6a1add9
 [[package]]
 name = "block-buffer"
 version = "0.11.0-rc.4"
-source = "git+https://github.com/RustCrypto/utils?branch=block-buffer%2Fread-buf#1be52dc741e6adb5202c3ae536a706d252c361a9"
+source = "git+https://github.com/RustCrypto/utils?branch=block-buffer%2Fread-buf#79e12dfd745e732d24ba1566f705f35ba409edc6"
 dependencies = [
  "hybrid-array",
  "zeroize",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,7 +75,7 @@ source = "git+https://github.com/RustCrypto/utils#f5ac85f6aa02aa39614f62a6a1add9
 [[package]]
 name = "block-buffer"
 version = "0.11.0-rc.4"
-source = "git+https://github.com/RustCrypto/utils#f5ac85f6aa02aa39614f62a6a1add9468be67892"
+source = "git+https://github.com/RustCrypto/utils?branch=block-buffer%2Fread-buf#21054d717f77c160fa0a70f79bdef2435c578d17"
 dependencies = [
  "hybrid-array",
  "zeroize",
@@ -113,6 +113,7 @@ name = "cipher"
 version = "0.5.0-rc.0"
 dependencies = [
  "blobby",
+ "block-buffer",
  "crypto-common",
  "inout",
  "zeroize",
@@ -429,9 +430,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.96"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "beef09f85ae72cea1ef96ba6870c51e6382ebfa4f0e85b643459331f3daa5be0"
+checksum = "d61789d7719defeb74ea5fe81f2fdfdbd28a803847077cecce2ff14e1472f6f1"
 dependencies = [
  "unicode-ident",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,7 +75,7 @@ source = "git+https://github.com/RustCrypto/utils#f5ac85f6aa02aa39614f62a6a1add9
 [[package]]
 name = "block-buffer"
 version = "0.11.0-rc.4"
-source = "git+https://github.com/RustCrypto/utils?branch=block-buffer%2Fread-buf#21054d717f77c160fa0a70f79bdef2435c578d17"
+source = "git+https://github.com/RustCrypto/utils?branch=block-buffer%2Fread-buf#1be52dc741e6adb5202c3ae536a706d252c361a9"
 dependencies = [
  "hybrid-array",
  "zeroize",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,4 +21,5 @@ signature = { path = "signature" }
 blobby = { git = "https://github.com/RustCrypto/utils" }
 # https://github.com/RustCrypto/utils/pull/1192
 # https://github.com/RustCrypto/utils/pull/1200
-block-buffer = { git = "https://github.com/RustCrypto/utils" }
+# https://github.com/RustCrypto/utils/pull/1201
+block-buffer = { git = "https://github.com/RustCrypto/utils", branch = "block-buffer/read-buf" }

--- a/cipher/Cargo.toml
+++ b/cipher/Cargo.toml
@@ -18,16 +18,18 @@ inout = "0.2.0-rc.4"
 
 # optional dependencies
 blobby = { version = "0.4.0-pre.0", optional = true }
+block-buffer = { version = "0.11.0-rc.4", optional = true}
 zeroize = { version = "1.8", optional = true, default-features = false }
 
 [features]
 alloc = []
 block-padding = ["inout/block-padding"]
+stream-wrapper = ["block-buffer"]
 # Enable random key and IV generation methods
 rand_core = ["crypto-common/rand_core"]
 os_rng = ["crypto-common/os_rng", "rand_core"]
 dev = ["blobby"]
-zeroize = ["dep:zeroize", "crypto-common/zeroize"]
+zeroize = ["dep:zeroize", "crypto-common/zeroize", "block-buffer?/zeroize"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/cipher/src/dev/stream.rs
+++ b/cipher/src/dev/stream.rs
@@ -58,7 +58,7 @@ macro_rules! stream_cipher_test {
 
             for (i, tv) in TEST_VECTORS.iter().enumerate() {
                 let res = $crate::dev::stream::stream_cipher_test(tv);
-                if Err(reason) = res {
+                if let Err(reason) = res {
                     panic!(
                         "\n\
                         Failed test #{i}\n\

--- a/cipher/src/dev/stream.rs
+++ b/cipher/src/dev/stream.rs
@@ -57,7 +57,7 @@ macro_rules! stream_cipher_test {
             );
 
             for (i, tv) in TEST_VECTORS.iter().enumerate() {
-                let res = $crate::dev::stream::stream_cipher_test(tv);
+                let res = $crate::dev::stream::stream_cipher_test::<$cipher>(tv);
                 if let Err(reason) = res {
                     panic!(
                         "\n\

--- a/cipher/src/lib.rs
+++ b/cipher/src/lib.rs
@@ -17,6 +17,7 @@
     unused_lifetimes,
     missing_debug_implementations
 )]
+#![forbid(unsafe_code)]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/cipher/src/stream.rs
+++ b/cipher/src/stream.rs
@@ -9,6 +9,7 @@ use inout::{InOutBuf, NotEqualError};
 
 mod core_api;
 mod errors;
+#[cfg(feature = "stream-wrapper")]
 mod wrapper;
 
 pub use core_api::{
@@ -16,6 +17,7 @@ pub use core_api::{
     StreamCipherSeekCore,
 };
 pub use errors::{OverflowError, StreamCipherError};
+#[cfg(feature = "stream-wrapper")]
 pub use wrapper::StreamCipherCoreWrapper;
 
 /// Marker trait for block-level asynchronous stream ciphers

--- a/cipher/src/stream/wrapper.rs
+++ b/cipher/src/stream/wrapper.rs
@@ -124,7 +124,7 @@ impl<T: StreamCipherSeekCore> StreamCipherSeek for StreamCipherCoreWrapper<T> {
         self.core.set_block_pos(block_pos);
 
         self.buffer.write_block(
-            usize::from(byte_pos),
+            T::BlockSize::USIZE - usize::from(byte_pos),
             |b| self.core.write_keystream_block(b),
             |_| {},
         );

--- a/cipher/src/stream/wrapper.rs
+++ b/cipher/src/stream/wrapper.rs
@@ -1,29 +1,22 @@
 use super::{
-    Block, OverflowError, SeekNum, StreamCipher, StreamCipherCore, StreamCipherSeek,
-    StreamCipherSeekCore, errors::StreamCipherError,
+    OverflowError, SeekNum, StreamCipher, StreamCipherCore, StreamCipherSeek, StreamCipherSeekCore,
+    errors::StreamCipherError,
 };
+use block_buffer::ReadBuffer;
 use core::fmt;
 use crypto_common::{
     Iv, IvSizeUser, Key, KeyInit, KeyIvInit, KeySizeUser, array::Array, typenum::Unsigned,
 };
 use inout::InOutBuf;
 #[cfg(feature = "zeroize")]
-use zeroize::{Zeroize, ZeroizeOnDrop};
+use zeroize::ZeroizeOnDrop;
 
 /// Buffering wrapper around a [`StreamCipherCore`] implementation.
 ///
 /// It handles data buffering and implements the slice-based traits.
 pub struct StreamCipherCoreWrapper<T: StreamCipherCore> {
     core: T,
-    // First byte is used as position
-    buffer: Block<T>,
-}
-
-impl<T: StreamCipherCore + Default> Default for StreamCipherCoreWrapper<T> {
-    #[inline]
-    fn default() -> Self {
-        Self::from_core(T::default())
-    }
+    buffer: ReadBuffer<T::BlockSize>,
 }
 
 impl<T: StreamCipherCore + Clone> Clone for StreamCipherCoreWrapper<T> {
@@ -38,70 +31,19 @@ impl<T: StreamCipherCore + Clone> Clone for StreamCipherCoreWrapper<T> {
 
 impl<T: StreamCipherCore + fmt::Debug> fmt::Debug for StreamCipherCoreWrapper<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let pos = self.get_pos().into();
-        let buf_data = &self.buffer[pos..];
         f.debug_struct("StreamCipherCoreWrapper")
-            .field("core", &self.core)
-            .field("buffer_data", &buf_data)
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 
 impl<T: StreamCipherCore> StreamCipherCoreWrapper<T> {
-    /// Return reference to the core type.
-    pub fn get_core(&self) -> &T {
-        &self.core
-    }
-
-    /// Return reference to the core type.
-    pub fn from_core(core: T) -> Self {
-        let mut buffer: Block<T> = Default::default();
-        buffer[0] = T::BlockSize::U8;
-        Self { core, buffer }
-    }
-
-    /// Return current cursor position.
-    #[inline]
-    fn get_pos(&self) -> u8 {
-        let pos = self.buffer[0];
-        if pos == 0 || pos > T::BlockSize::U8 {
-            debug_assert!(false);
-            // SAFETY: `pos` never breaks the invariant
-            unsafe {
-                core::hint::unreachable_unchecked();
-            }
-        }
-        pos
-    }
-
-    /// Set buffer position without checking that it's smaller
-    /// than buffer size.
-    ///
-    /// # Safety
-    /// `pos` MUST be bigger than zero and smaller or equal to `T::BlockSize::USIZE`.
-    #[inline]
-    unsafe fn set_pos_unchecked(&mut self, pos: usize) {
-        debug_assert!(pos != 0 && pos <= T::BlockSize::USIZE);
-        // Block size is always smaller than 256 because of the `BlockSizes` bound,
-        // so if the safety condition is satisfied, the `as` cast does not truncate
-        // any non-zero bits.
-        self.buffer[0] = pos as u8;
-    }
-
-    /// Return number of remaining bytes in the internal buffer.
-    #[inline]
-    fn remaining(&self) -> u8 {
-        // This never underflows because of the safety invariant
-        T::BlockSize::U8 - self.get_pos()
-    }
-
     fn check_remaining(&self, data_len: usize) -> Result<(), StreamCipherError> {
         let rem_blocks = match self.core.remaining_blocks() {
             Some(v) => v,
             None => return Ok(()),
         };
 
-        let buf_rem = usize::from(self.remaining());
+        let buf_rem = self.buffer.remaining();
         let data_len = match data_len.checked_sub(buf_rem) {
             Some(0) | None => return Ok(()),
             Some(res) => res,
@@ -121,106 +63,46 @@ impl<T: StreamCipherCore> StreamCipher for StreamCipherCoreWrapper<T> {
     #[inline]
     fn try_apply_keystream_inout(
         &mut self,
-        mut data: InOutBuf<'_, '_, u8>,
+        data: InOutBuf<'_, '_, u8>,
     ) -> Result<(), StreamCipherError> {
         self.check_remaining(data.len())?;
 
-        let pos = usize::from(self.get_pos());
-        let rem = usize::from(self.remaining());
-        let data_len = data.len();
+        let head_ks = self.buffer.read_cached(data.len());
 
-        if rem != 0 {
-            if data_len <= rem {
-                data.xor_in2out(&self.buffer[pos..][..data_len]);
-                // SAFETY: we have checked that `data_len` is less or equal to length
-                // of remaining keystream data, thus `pos + data_len` can not be bigger
-                // than block size. Since `pos` is never zero, `pos + data_len` can not
-                // be zero. Thus `pos + data_len` satisfies the safety invariant required
-                // by `set_pos_unchecked`.
-                unsafe {
-                    self.set_pos_unchecked(pos + data_len);
-                }
-                return Ok(());
-            }
-            let (mut left, right) = data.split_at(rem);
-            data = right;
-            left.xor_in2out(&self.buffer[pos..]);
-        }
-
+        let (mut head, data) = data.split_at(head_ks.len());
         let (blocks, mut tail) = data.into_chunks();
+
+        head.xor_in2out(head_ks);
         self.core.apply_keystream_blocks_inout(blocks);
 
-        let new_pos = if tail.is_empty() {
-            T::BlockSize::USIZE
-        } else {
-            // Note that we temporarily write a pseudo-random byte into
-            // the first byte of `self.buffer`. It may break the safety invariant,
-            // but after XORing keystream block with `tail`, we immediately
-            // overwrite the first byte with a correct value.
-            self.core.write_keystream_block(&mut self.buffer);
-            tail.xor_in2out(&self.buffer[..tail.len()]);
-            tail.len()
-        };
-
-        // SAFETY: `into_chunks` always returns tail with size
-        // less than block size. If `tail.len()` is zero, we replace
-        // it with block size. Thus the invariant required by
-        // `set_pos_unchecked` is satisfied.
-        unsafe {
-            self.set_pos_unchecked(new_pos);
-        }
+        self.buffer.write_block(
+            tail.len(),
+            |b| self.core.write_keystream_block(b),
+            |tail_ks| {
+                tail.xor_in2out(tail_ks);
+            },
+        );
 
         Ok(())
     }
 
     #[inline]
-    fn try_write_keystream(&mut self, mut data: &mut [u8]) -> Result<(), StreamCipherError> {
+    fn try_write_keystream(&mut self, data: &mut [u8]) -> Result<(), StreamCipherError> {
         self.check_remaining(data.len())?;
 
-        let pos = usize::from(self.get_pos());
-        let rem = usize::from(self.remaining());
-        let data_len = data.len();
+        let head_ks = self.buffer.read_cached(data.len());
 
-        if rem != 0 {
-            if data_len <= rem {
-                data.copy_from_slice(&self.buffer[pos..][..data_len]);
-                // SAFETY: we have checked that `data_len` is less or equal to length
-                // of remaining keystream data, thus `pos + data_len` can not be bigger
-                // than block size. Since `pos` is never zero, `pos + data_len` can not
-                // be zero. Thus `pos + data_len` satisfies the safety invariant required
-                // by `set_pos_unchecked`.
-                unsafe {
-                    self.set_pos_unchecked(pos + data_len);
-                }
-                return Ok(());
-            }
-            let (left, right) = data.split_at_mut(rem);
-            data = right;
-            left.copy_from_slice(&self.buffer[pos..]);
-        }
-
+        let (head, data) = data.split_at_mut(head_ks.len());
         let (blocks, tail) = Array::slice_as_chunks_mut(data);
+
+        head.copy_from_slice(head_ks);
         self.core.write_keystream_blocks(blocks);
 
-        let new_pos = if tail.is_empty() {
-            T::BlockSize::USIZE
-        } else {
-            // Note that we temporarily write a pseudo-random byte into
-            // the first byte of `self.buffer`. It may break the safety invariant,
-            // but after writing keystream block with `tail`, we immediately
-            // overwrite the first byte with a correct value.
-            self.core.write_keystream_block(&mut self.buffer);
-            tail.copy_from_slice(&self.buffer[..tail.len()]);
-            tail.len()
-        };
-
-        // SAFETY: `into_chunks` always returns tail with size
-        // less than block size. If `tail.len()` is zero, we replace
-        // it with block size. Thus the invariant required by
-        // `set_pos_unchecked` is satisfied.
-        unsafe {
-            self.set_pos_unchecked(new_pos);
-        }
+        self.buffer.write_block(
+            tail.len(),
+            |b| self.core.write_keystream_block(b),
+            |tail_ks| tail.copy_from_slice(tail_ks),
+        );
 
         Ok(())
     }
@@ -228,7 +110,8 @@ impl<T: StreamCipherCore> StreamCipher for StreamCipherCoreWrapper<T> {
 
 impl<T: StreamCipherSeekCore> StreamCipherSeek for StreamCipherCoreWrapper<T> {
     fn try_current_pos<SN: SeekNum>(&self) -> Result<SN, OverflowError> {
-        let pos = self.get_pos();
+        let pos = u8::try_from(self.buffer.get_pos())
+            .expect("buffer position is always smaller than 256");
         SN::from_block_byte(self.core.get_block_pos(), pos, T::BlockSize::U8)
     }
 
@@ -239,19 +122,12 @@ impl<T: StreamCipherSeekCore> StreamCipherSeek for StreamCipherCoreWrapper<T> {
         assert!(byte_pos < T::BlockSize::U8);
 
         self.core.set_block_pos(block_pos);
-        let new_pos = if byte_pos != 0 {
-            // See comment in `try_apply_keystream_inout` for use of `write_keystream_block`
-            self.core.write_keystream_block(&mut self.buffer);
-            byte_pos.into()
-        } else {
-            T::BlockSize::USIZE
-        };
-        // SAFETY: we assert that `byte_pos` is always smaller than block size.
-        // If `byte_pos` is zero, we replace it with block size. Thus the invariant
-        // required by `set_pos_unchecked` is satisfied.
-        unsafe {
-            self.set_pos_unchecked(new_pos);
-        }
+
+        self.buffer.write_block(
+            usize::from(byte_pos),
+            |b| self.core.write_keystream_block(b),
+            |_| {},
+        );
         Ok(())
     }
 }
@@ -272,11 +148,9 @@ impl<T: IvSizeUser + StreamCipherCore> IvSizeUser for StreamCipherCoreWrapper<T>
 impl<T: KeyIvInit + StreamCipherCore> KeyIvInit for StreamCipherCoreWrapper<T> {
     #[inline]
     fn new(key: &Key<Self>, iv: &Iv<Self>) -> Self {
-        let mut buffer = Block::<T>::default();
-        buffer[0] = T::BlockSize::U8;
         Self {
             core: T::new(key, iv),
-            buffer,
+            buffer: Default::default(),
         }
     }
 }
@@ -284,22 +158,21 @@ impl<T: KeyIvInit + StreamCipherCore> KeyIvInit for StreamCipherCoreWrapper<T> {
 impl<T: KeyInit + StreamCipherCore> KeyInit for StreamCipherCoreWrapper<T> {
     #[inline]
     fn new(key: &Key<Self>) -> Self {
-        let mut buffer = Block::<T>::default();
-        buffer[0] = T::BlockSize::U8;
         Self {
             core: T::new(key),
-            buffer,
+            buffer: Default::default(),
         }
     }
 }
 
 #[cfg(feature = "zeroize")]
-impl<T: StreamCipherCore> Drop for StreamCipherCoreWrapper<T> {
-    fn drop(&mut self) {
-        // If present, `core` will be zeroized by its own `Drop`.
-        self.buffer.zeroize();
-    }
-}
-
-#[cfg(feature = "zeroize")]
 impl<T: StreamCipherCore + ZeroizeOnDrop> ZeroizeOnDrop for StreamCipherCoreWrapper<T> {}
+
+// Assert that `ReadBuffer` implements `ZeroizeOnDrop`
+#[cfg(feature = "zeroize")]
+const _: () = {
+    #[allow(dead_code)]
+    fn check_buffer<BS: crate::array::ArraySize>(v: &ReadBuffer<BS>) {
+        let _ = v as &dyn crate::zeroize::ZeroizeOnDrop;
+    }
+};

--- a/cipher/src/stream/wrapper.rs
+++ b/cipher/src/stream/wrapper.rs
@@ -123,8 +123,10 @@ impl<T: StreamCipherSeekCore> StreamCipherSeek for StreamCipherCoreWrapper<T> {
 
         self.core.set_block_pos(block_pos);
 
+        self.buffer.reset();
+
         self.buffer.write_block(
-            T::BlockSize::USIZE - usize::from(byte_pos),
+            usize::from(byte_pos),
             |b| self.core.write_keystream_block(b),
             |_| {},
         );

--- a/digest/src/buffer_macros/xof.rs
+++ b/digest/src/buffer_macros/xof.rs
@@ -53,20 +53,9 @@ macro_rules! buffer_xof {
             fn read(&mut self, buf: &mut [u8]) {
                 let Self { core, buffer } = self;
 
-                let head_ks = self.buffer.read_cached(buf.len());
-                let (head, buf) = buf.split_at_mut(head_ks.len());
-                let (blocks, tail) = $crate::array::Array::slice_as_chunks_mut(buf);
-
-                head.copy_from_slice(head_ks);
-                for block in blocks {
+                buffer.read(buf, |block| {
                     *block = $crate::block_api::XofReaderCore::read_block(core);
-                }
-
-                self.buffer.write_block(
-                    tail.len(),
-                    |block| *block = $crate::block_api::XofReaderCore::read_block(core),
-                    |tail_ks| tail.copy_from_slice(tail_ks),
-                );
+                });
             }
         }
 

--- a/digest/src/buffer_macros/xof.rs
+++ b/digest/src/buffer_macros/xof.rs
@@ -52,7 +52,6 @@ macro_rules! buffer_xof {
             #[inline]
             fn read(&mut self, buf: &mut [u8]) {
                 let Self { core, buffer } = self;
-
                 buffer.read(buf, |block| {
                     *block = $crate::block_api::XofReaderCore::read_block(core);
                 });

--- a/digest/src/buffer_macros/xof.rs
+++ b/digest/src/buffer_macros/xof.rs
@@ -52,9 +52,21 @@ macro_rules! buffer_xof {
             #[inline]
             fn read(&mut self, buf: &mut [u8]) {
                 let Self { core, buffer } = self;
-                buffer.read(buf, |block| {
+
+                let head_ks = self.buffer.read_cached(buf.len());
+                let (head, buf) = buf.split_at_mut(head_ks.len());
+                let (blocks, tail) = $crate::array::Array::slice_as_chunks_mut(buf);
+
+                head.copy_from_slice(head_ks);
+                for block in blocks {
                     *block = $crate::block_api::XofReaderCore::read_block(core);
-                });
+                }
+
+                self.buffer.write_block(
+                    tail.len(),
+                    |block| *block = $crate::block_api::XofReaderCore::read_block(core),
+                    |tail_ks| tail.copy_from_slice(tail_ks),
+                );
             }
         }
 


### PR DESCRIPTION
This simplifies the wrapper code and allows to mark the `cipher` crate with `#![forbid(unsafe_code)]`.

Depends on https://github.com/RustCrypto/utils/pull/1201