### PR TITLE
elliptic-curve: remove `alloc` from `serde` feature

### DIFF
--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -67,7 +67,7 @@ group = ["dep:group", "ff"]
 jwk = ["dep:base64ct", "dep:serde_json", "alloc", "serde", "zeroize/alloc"]
 pkcs8 = ["dep:pkcs8", "sec1"]
 pem = ["dep:pem-rfc7468", "alloc", "arithmetic", "pkcs8/pem", "sec1/pem"]
-serde = ["dep:serdect", "alloc", "pkcs8", "sec1/serde"]
+serde = ["dep:serdect", "pkcs8", "sec1/serde"]
 
 [package.metadata.docs.rs]
 features = ["bits", "ecdh", "jwk", "pem", "std"]


### PR DESCRIPTION
It doesn't actually appear to be used.

Closes #1960 