### PR TITLE
aead: Update to heapless 0.9.1

### DIFF
--- a/.github/workflows/aead.yml
+++ b/.github/workflows/aead.yml
@@ -39,13 +39,30 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
           targets: ${{ matrix.target }}
-      - run: cargo check --all-features
+      - run: cargo check --features arrayvec,blobby,bytes,alloc,dev,os_rng
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features alloc
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features bytes
-      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features heapless
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features rand_core
 
+  build-heapless:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - 1.87.0 # MSRV
+          - stable
+        target:
+          - thumbv7em-none-eabi
+          - wasm32-unknown-unknown
+    steps:
+      - uses: actions/checkout@v5
+      - uses: RustCrypto/actions/cargo-cache@master
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.rust }}
+          targets: ${{ matrix.target }}
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features heapless
   # TODO(tarcieri): re-enable after next `crypto-common` release
   #  minimal-versions:
   #    uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
@@ -57,7 +74,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.85.0 # MSRV
+          - 1.87.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v5

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -281,9 +281,9 @@ dependencies = [
 
 [[package]]
 name = "heapless"
-version = "0.8.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
+checksum = "b1edcd5a338e64688fbdcb7531a846cfd3476a54784dcb918a0844682bc7ada5"
 dependencies = [
  "hash32",
  "stable_deref_trait",

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Collection of traits which describe functionality of cryptographic primitives.
 
 | Name                | Algorithm | Crates.io | Docs  | MSRV |
 |---------------------|-----------|:---------:|:-----:|:----:|
-| [`aead`]            | [Authenticated encryption]    | [![crates.io](https://img.shields.io/crates/v/aead.svg)](https://crates.io/crates/aead) | [![Documentation](https://docs.rs/aead/badge.svg)](https://docs.rs/aead) | ![MSRV 1.85][msrv-1.85] |
+| [`aead`]            | [Authenticated encryption]    | [![crates.io](https://img.shields.io/crates/v/aead.svg)](https://crates.io/crates/aead) | [![Documentation](https://docs.rs/aead/badge.svg)](https://docs.rs/aead) | ![MSRV 1.87][msrv-1.87] |
 | [`async‑signature`] | [Digital signature]           | [![crates.io](https://img.shields.io/crates/v/async-signature.svg)](https://crates.io/crates/async-signature) | [![Documentation](https://docs.rs/async-signature/badge.svg)](https://docs.rs/async-signature) | ![MSRV 1.85][msrv-1.85] |
 | [`cipher`]          | [Block] and [stream cipher]   | [![crates.io](https://img.shields.io/crates/v/cipher.svg)](https://crates.io/crates/cipher) | [![Documentation](https://docs.rs/cipher/badge.svg)](https://docs.rs/cipher) | ![MSRV 1.85][msrv-1.85] |
 | [`crypto‑common`]      | Common cryptographic traits | [![crates.io](https://img.shields.io/crates/v/crypto-common.svg)](https://crates.io/crates/crypto-common) | [![Documentation](https://docs.rs/crypto-common/badge.svg)](https://docs.rs/crypto-common) | ![MSRV 1.85][msrv-1.85] |
@@ -46,6 +46,7 @@ Unless you explicitly state otherwise, any contribution intentionally submitted 
 [deps-image]: https://deps.rs/repo/github/RustCrypto/traits/status.svg
 [deps-link]: https://deps.rs/repo/github/RustCrypto/traits
 [msrv-1.85]: https://img.shields.io/badge/rustc-1.85.0+-blue.svg
+[msrv-1.87]: https://img.shields.io/badge/rustc-1.87.0+-blue.svg
 
 [//]: # (crates)
 

--- a/aead/CHANGELOG.md
+++ b/aead/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - minor documentation error in `AeadCore::TagSize` ([#1351])
 - fixup `hybrid-array` migration ([#1531])
+- Update `heapless` to `0.9.1` and bump MSRV to 1.87 ([#1974])
 
 ### Changed
 - Edition changed to 2024 and MSRV bumped to 1.85 ([#1759])
@@ -27,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - enable `missing_debug_implementations` lint and add `Debug` impls ([#1411])
 
 
+[#1974]: https://github.com/RustCrypto/traits/pull/1974
 [#1351]: https://github.com/RustCrypto/traits/pull/1351
 [#1370]: https://github.com/RustCrypto/traits/pull/1370
 [#1380]: https://github.com/RustCrypto/traits/pull/1380

--- a/aead/Cargo.toml
+++ b/aead/Cargo.toml
@@ -23,7 +23,7 @@ inout = "0.2.0-rc.4"
 arrayvec = { version = "0.7", optional = true, default-features = false }
 blobby = { version = "0.4.0-pre.0", optional = true }
 bytes = { version = "1", optional = true, default-features = false }
-heapless = { version = "0.8", optional = true, default-features = false }
+heapless = { version = "0.9", optional = true, default-features = false }
 
 [features]
 default = ["rand_core"]

--- a/aead/README.md
+++ b/aead/README.md
@@ -42,7 +42,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/aead/badge.svg
 [docs-link]: https://docs.rs/aead/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.85+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.87+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260038-AEADs
 [build-image]: https://github.com/RustCrypto/traits/actions/workflows/aead.yml/badge.svg?branch=master

--- a/aead/src/lib.rs
+++ b/aead/src/lib.rs
@@ -513,13 +513,15 @@ impl<const N: usize> Buffer for arrayvec::ArrayVec<u8, N> {
 }
 
 #[cfg(feature = "heapless")]
-impl<const N: usize> Buffer for heapless::Vec<u8, N> {
+impl<S: heapless::vec::VecStorage<u8> + ?Sized, LenT: heapless::LenType> Buffer
+    for heapless::vec::VecInner<u8, LenT, S>
+{
     fn extend_from_slice(&mut self, other: &[u8]) -> Result<()> {
-        heapless::Vec::extend_from_slice(self, other).map_err(|_| Error)
+        heapless::vec::VecInner::extend_from_slice(self, other).map_err(|_| Error)
     }
 
     fn truncate(&mut self, len: usize) {
-        heapless::Vec::truncate(self, len);
+        heapless::vec::VecInner::truncate(self, len);
     }
 }
 


### PR DESCRIPTION
This patch updates the heapless dependency of `aead` to version 0.9.1 It updates the buffer implementation to support for the new `View` types and the `LenType` optimization

More info here: https://blog.rust-embedded.org/heapless-091/