### PR TITLE
Bump `serdect` to v0.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,12 +39,6 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "base16ct"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
-
-[[package]]
-name = "base16ct"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b59d472eab27ade8d770dcb11da7201c11234bef9f82ce7aa517be028d462b"
@@ -191,7 +185,7 @@ dependencies = [
 name = "elliptic-curve"
 version = "0.14.0-rc.12"
 dependencies = [
- "base16ct 0.3.0",
+ "base16ct",
  "crypto-bigint",
  "digest",
  "ff",
@@ -441,7 +435,7 @@ name = "sec1"
 version = "0.8.0-rc.8"
 source = "git+https://github.com/RustCrypto/formats?branch=sec1%2Fhybrid-array-v0.4#fdc1f293f71bfbbee5e89997b1ec17b13e632c61"
 dependencies = [
- "base16ct 0.3.0",
+ "base16ct",
  "der",
  "hybrid-array",
  "serdect",
@@ -471,11 +465,11 @@ dependencies = [
 
 [[package]]
 name = "serdect"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90faa9344350bebcc60a4beae3290b8548ecc55a542e25f5ca1cdc83b267fe7e"
+checksum = "d3ef0e35b322ddfaecbc60f34ab448e157e48531288ee49fafbb053696b8ffe2"
 dependencies = [
- "base16ct 0.2.0",
+ "base16ct",
  "serde",
 ]
 


### PR DESCRIPTION
v0.4.0 was the last thing depending on `base16ct` v0.2