### PR TITLE
elliptic-curve: have `alloc` activate `hybrid-array/alloc`

### DIFF
--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -44,6 +44,7 @@ alloc = [
     "base16ct/alloc",
     "ff?/alloc",
     "group?/alloc",
+    "hybrid-array/alloc",
     "pkcs8?/alloc",
     "sec1?/alloc",
     "zeroize/alloc"


### PR DESCRIPTION
Enable `alloc` support for `hybrid-array` when the `alloc` crate feature of `elliptic-curve` is enabled