### PR TITLE
cipher: restore `StreamCipherCoreWrapper::from_core`

### DIFF
--- a/cipher/src/stream/wrapper.rs
+++ b/cipher/src/stream/wrapper.rs
@@ -37,6 +37,14 @@ impl<T: StreamCipherCore + fmt::Debug> fmt::Debug for StreamCipherCoreWrapper<T>
 }
 
 impl<T: StreamCipherCore> StreamCipherCoreWrapper<T> {
+    /// Initialize from a [`StreamCipherCore`] instance.
+    pub fn from_core(core: T) -> Self {
+        Self {
+            core,
+            buffer: Default::default(),
+        }
+    }
+
     fn check_remaining(&self, data_len: usize) -> Result<(), StreamCipherError> {
         let rem_blocks = match self.core.remaining_blocks() {
             Some(v) => v,


### PR DESCRIPTION
Removed in #1959 but there are definitely still quite a few usages and I don't see ways to completely replace all of them with `KeyIvInit` (though that seems ideal).

See RustCrypto/AEADs#710