### PR TITLE
Update `block-buffer`, `block-padding`, and `inout` crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,8 +74,9 @@ source = "git+https://github.com/RustCrypto/utils#adfccfea2686ef191b607f653cc358
 
 [[package]]
 name = "block-buffer"
-version = "0.11.0-rc.4"
-source = "git+https://github.com/RustCrypto/utils#adfccfea2686ef191b607f653cc3587753b6ec66"
+version = "0.11.0-rc.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9ef36a6fcdb072aa548f3da057640ec10859eb4e91ddf526ee648d50c76a949"
 dependencies = [
  "hybrid-array",
  "zeroize",
@@ -83,8 +84,9 @@ dependencies = [
 
 [[package]]
 name = "block-padding"
-version = "0.4.0-rc.3"
-source = "git+https://github.com/RustCrypto/utils#adfccfea2686ef191b607f653cc3587753b6ec66"
+version = "0.4.0-rc.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e59c1aab3e6c5e56afe1b7e8650be9b5a791cb997bdea449194ae62e4bf8c73"
 dependencies = [
  "hybrid-array",
 ]
@@ -313,8 +315,9 @@ dependencies = [
 
 [[package]]
 name = "inout"
-version = "0.2.0-rc.5"
-source = "git+https://github.com/RustCrypto/utils#adfccfea2686ef191b607f653cc3587753b6ec66"
+version = "0.2.0-rc.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1603f76010ff924b616c8f44815a42eb10fb0b93d308b41deaa8da6d4251fd4b"
 dependencies = [
  "block-padding",
  "hybrid-array",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,5 @@ blobby = { git = "https://github.com/RustCrypto/utils" }
 # https://github.com/RustCrypto/utils/pull/1200
 # https://github.com/RustCrypto/utils/pull/1201
 # https://github.com/RustCrypto/utils/pull/1208
-block-buffer = { git = "https://github.com/RustCrypto/utils" }
-block-padding = { git = "https://github.com/RustCrypto/utils" }
 crypto-bigint = { git = "https://github.com/RustCrypto/crypto-bigint" }
-inout = { git = "https://github.com/RustCrypto/utils" }
 sec1 = { git = "https://github.com/RustCrypto/formats" }

--- a/aead/Cargo.toml
+++ b/aead/Cargo.toml
@@ -17,7 +17,7 @@ such as AES-GCM as ChaCha20Poly1305, which provide a high-level API
 
 [dependencies]
 crypto-common = { version = "0.2.0-rc.3", path = "../crypto-common" }
-inout = "0.2.0-rc.4"
+inout = "0.2.0-rc.6"
 
 # optional dependencies
 arrayvec = { version = "0.7", optional = true, default-features = false }

--- a/cipher/Cargo.toml
+++ b/cipher/Cargo.toml
@@ -14,11 +14,11 @@ description = "Traits for describing block ciphers and stream ciphers"
 
 [dependencies]
 crypto-common = { version = "0.2.0-rc.3", path = "../crypto-common" }
-inout = "0.2.0-rc.4"
+inout = "0.2.0-rc.6"
 
 # optional dependencies
 blobby = { version = "0.4.0-pre.0", optional = true }
-block-buffer = { version = "0.11.0-rc.4", optional = true}
+block-buffer = { version = "0.11.0-rc.5", optional = true }
 zeroize = { version = "1.8", optional = true, default-features = false }
 
 [features]

--- a/digest/Cargo.toml
+++ b/digest/Cargo.toml
@@ -16,7 +16,7 @@ description = "Traits for cryptographic hash functions and message authenticatio
 crypto-common = { version = "0.2.0-rc.3", path = "../crypto-common" }
 
 # optional dependencies
-block-buffer = { version = "0.11.0-rc.4", optional = true }
+block-buffer = { version = "0.11.0-rc.5", optional = true }
 subtle = { version = "2.4", default-features = false, optional = true }
 blobby = { version = "0.4.0-pre.0", optional = true }
 const-oid = { version = "0.10", optional = true }


### PR DESCRIPTION
Uses `hybrid-array` v0.4-compatible crate releases rather than sourcing these crates from git:

- `block-buffer` v0.11.0-rc.5
- `block-padding` v0.4.0-rc.4
- `inout` v0.2.0-rc.6