### PR TITLE
crypto-common v0.2.0-rc.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,7 +154,7 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.0-rc.3"
+version = "0.2.0-rc.4"
 dependencies = [
  "hybrid-array",
  "rand_core",

--- a/aead/Cargo.toml
+++ b/aead/Cargo.toml
@@ -16,7 +16,7 @@ such as AES-GCM as ChaCha20Poly1305, which provide a high-level API
 """
 
 [dependencies]
-crypto-common = { version = "0.2.0-rc.3", path = "../crypto-common" }
+crypto-common = { version = "0.2.0-rc.4", path = "../crypto-common" }
 inout = "0.2.0-rc.6"
 
 # optional dependencies

--- a/cipher/Cargo.toml
+++ b/cipher/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["cryptography", "no-std"]
 description = "Traits for describing block ciphers and stream ciphers"
 
 [dependencies]
-crypto-common = { version = "0.2.0-rc.3", path = "../crypto-common" }
+crypto-common = { version = "0.2.0-rc.4", path = "../crypto-common" }
 inout = "0.2.0-rc.6"
 
 # optional dependencies

--- a/crypto-common/Cargo.toml
+++ b/crypto-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crypto-common"
-version = "0.2.0-rc.3"
+version = "0.2.0-rc.4"
 authors = ["RustCrypto Developers"]
 edition = "2024"
 rust-version = "1.85"

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["cryptography", "no-std"]
 description = "Facade crate for all of the RustCrypto traits (e.g. `aead`, `cipher`, `digest`)"
 
 [dependencies]
-crypto-common = { version = "0.2.0-rc.3", path = "../crypto-common", default-features = false }
+crypto-common = { version = "0.2.0-rc.4", path = "../crypto-common", default-features = false }
 
 # optional dependencies
 aead = { version = "0.6.0-rc.0", path = "../aead", optional = true }

--- a/digest/Cargo.toml
+++ b/digest/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["cryptography", "no-std"]
 description = "Traits for cryptographic hash functions and message authentication codes"
 
 [dependencies]
-crypto-common = { version = "0.2.0-rc.3", path = "../crypto-common" }
+crypto-common = { version = "0.2.0-rc.4", path = "../crypto-common" }
 
 # optional dependencies
 block-buffer = { version = "0.11.0-rc.5", optional = true }

--- a/universal-hash/Cargo.toml
+++ b/universal-hash/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["cryptography", "no-std"]
 description = "Traits which describe the functionality of universal hash functions (UHFs)"
 
 [dependencies]
-crypto-common = { version = "0.2.0-rc.3", path = "../crypto-common" }
+crypto-common = { version = "0.2.0-rc.4", path = "../crypto-common" }
 subtle = { version = "2.4", default-features = false }
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
Notably includes `hybrid-array` v0.4 support