### PR TITLE
Cut prereleases with `hybrid-array` v0.4 support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,7 +15,7 @@ dependencies = [
 
 [[package]]
 name = "aead"
-version = "0.6.0-rc.1"
+version = "0.6.0-rc.2"
 dependencies = [
  "arrayvec",
  "blobby",
@@ -111,7 +111,7 @@ checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
 
 [[package]]
 name = "cipher"
-version = "0.5.0-rc.0"
+version = "0.5.0-rc.1"
 dependencies = [
  "blobby",
  "block-buffer",
@@ -174,7 +174,7 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.11.0-rc.0"
+version = "0.11.0-rc.1"
 dependencies = [
  "blobby",
  "block-buffer",
@@ -479,7 +479,7 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "3.0.0-rc.2"
+version = "3.0.0-rc.3"
 dependencies = [
  "digest",
  "rand_core",
@@ -549,7 +549,7 @@ checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "universal-hash"
-version = "0.6.0-rc.1"
+version = "0.6.0-rc.2"
 dependencies = [
  "crypto-common",
  "subtle",

--- a/aead/Cargo.toml
+++ b/aead/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aead"
-version = "0.6.0-rc.1"
+version = "0.6.0-rc.2"
 authors = ["RustCrypto Developers"]
 edition = "2024"
 rust-version = "1.85"

--- a/cipher/Cargo.toml
+++ b/cipher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cipher"
-version = "0.5.0-rc.0"
+version = "0.5.0-rc.1"
 authors = ["RustCrypto Developers"]
 edition = "2024"
 rust-version = "1.85"

--- a/digest/Cargo.toml
+++ b/digest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "digest"
-version = "0.11.0-rc.0"
+version = "0.11.0-rc.1"
 authors = ["RustCrypto Developers"]
 edition = "2024"
 rust-version = "1.85"

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -18,14 +18,14 @@ and public/secret keys composed thereof.
 
 [dependencies]
 base16ct = "0.3"
-crypto-bigint = { version = "0.7.0-rc.1", default-features = false, features = ["rand_core", "hybrid-array", "zeroize"] }
+crypto-bigint = { version = "0.7.0-rc.3", default-features = false, features = ["rand_core", "hybrid-array", "zeroize"] }
 hybrid-array = { version = "0.4", default-features = false, features = ["zeroize"] }
 rand_core = { version = "0.9.0", default-features = false }
 subtle = { version = "2.6", default-features = false }
 zeroize = { version = "1.7", default-features = false }
 
 # optional dependencies
-digest = { version = "0.11.0-rc.0", optional = true }
+digest = { version = "0.11.0-rc.1", optional = true }
 ff = { version = "=0.14.0-pre.0", optional = true, default-features = false }
 group = { version = "=0.14.0-pre.0", optional = true, default-features = false }
 hkdf = { version = "0.13.0-rc.0", optional = true, default-features = false }

--- a/signature/Cargo.toml
+++ b/signature/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "signature"
-version = "3.0.0-rc.2"
+version = "3.0.0-rc.3"
 authors = ["RustCrypto Developers"]
 edition = "2024"
 rust-version = "1.85"
@@ -13,7 +13,7 @@ categories = ["cryptography", "no-std"]
 description = "Traits for cryptographic signature algorithms (e.g. ECDSA, Ed25519)"
 
 [dependencies]
-digest = { version = "0.11.0-rc.0", optional = true, default-features = false }
+digest = { version = "0.11.0-rc.1", optional = true, default-features = false }
 rand_core = { version = "0.9", optional = true, default-features = false }
 
 [features]

--- a/universal-hash/Cargo.toml
+++ b/universal-hash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "universal-hash"
-version = "0.6.0-rc.1"
+version = "0.6.0-rc.2"
 authors = ["RustCrypto Developers"]
 edition = "2024"
 rust-version = "1.85"


### PR DESCRIPTION
Releases the following:
- `aead` v0.6.0-rc.2
- `cipher` v0.5.0-rc.1
- `digest` v0.11.0-rc.1
- `signature` v3.0.0-rc.3
- `universal-hash` v0.6.0-rc.2

A separate `elliptic-curve` release is forthcoming