### PR TITLE
elliptic-curve: bump `sec1` to v0.8.0-rc.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,8 +436,9 @@ dependencies = [
 
 [[package]]
 name = "sec1"
-version = "0.8.0-rc.8"
-source = "git+https://github.com/RustCrypto/formats#4f55e5849921b1754f73903e612ca5ea3cb5cf69"
+version = "0.8.0-rc.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5e67a3c9fb9a8f065af9fa30d65812fcc16a66cbf911eff1f6946957ce48f16"
 dependencies = [
  "base16ct",
  "der",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,3 @@ signature = { path = "signature" }
 
 # https://github.com/RustCrypto/utils/pull/1187
 blobby = { git = "https://github.com/RustCrypto/utils" }
-# https://github.com/RustCrypto/utils/pull/1192
-# https://github.com/RustCrypto/utils/pull/1200
-# https://github.com/RustCrypto/utils/pull/1201
-# https://github.com/RustCrypto/utils/pull/1208
-sec1 = { git = "https://github.com/RustCrypto/formats" }

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -32,7 +32,7 @@ hkdf = { version = "0.13.0-rc.0", optional = true, default-features = false }
 hex-literal = { version = "1", optional = true }
 pem-rfc7468 = { version = "1.0.0-rc.2", optional = true, features = ["alloc"] }
 pkcs8 = { version = "0.11.0-rc.6", optional = true, default-features = false }
-sec1 = { version = "0.8.0-rc.8", optional = true, features = ["subtle", "zeroize"] }
+sec1 = { version = "0.8.0-rc.9", optional = true, features = ["subtle", "zeroize"] }
 serdect = { version = "0.4", optional = true, default-features = false, features = ["alloc"] }
 
 [dev-dependencies]


### PR DESCRIPTION
Notably this includes `hybrid-array` v0.4 support