### PR TITLE
elliptic-curve: rename `ScalarPrimitive` => `ScalarValue`

### DIFF
--- a/elliptic-curve/src/arithmetic.rs
+++ b/elliptic-curve/src/arithmetic.rs
@@ -1,7 +1,7 @@
 //! Elliptic curve arithmetic traits.
 
 use crate::{
-    Curve, CurveGroup, Error, FieldBytes, Group, NonZeroScalar, PrimeCurve, ScalarPrimitive,
+    Curve, CurveGroup, Error, FieldBytes, Group, NonZeroScalar, PrimeCurve, ScalarValue,
     ops::{Invert, LinearCombination, Mul, Reduce},
     point::{AffineCoordinates, NonIdentity},
     scalar::{FromUintUnchecked, IsHigh},
@@ -68,10 +68,10 @@ pub trait CurveArithmetic: Curve {
     type Scalar: AsRef<Self::Scalar>
         + DefaultIsZeroes
         + From<NonZeroScalar<Self>>
-        + From<ScalarPrimitive<Self>>
+        + From<ScalarValue<Self>>
         + FromUintUnchecked<Uint = Self::Uint>
         + Into<FieldBytes<Self>>
-        + Into<ScalarPrimitive<Self>>
+        + Into<ScalarValue<Self>>
         + Into<Self::Uint>
         + Invert<Output = CtOption<Self::Scalar>>
         + IsHigh

--- a/elliptic-curve/src/dev.rs
+++ b/elliptic-curve/src/dev.rs
@@ -50,9 +50,8 @@ pub type PublicKey = crate::PublicKey<MockCurve>;
 /// Secret key.
 pub type SecretKey = crate::SecretKey<MockCurve>;
 
-/// Scalar primitive type.
-// TODO(tarcieri): make this the scalar type when it's more capable
-pub type ScalarPrimitive = crate::ScalarPrimitive<MockCurve>;
+/// Scalar value type.
+pub type ScalarValue = crate::ScalarValue<MockCurve>;
 
 /// Scalar bits.
 #[cfg(feature = "bits")]
@@ -90,11 +89,11 @@ impl AssociatedOid for MockCurve {
 
 /// Example scalar type
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq, PartialOrd, Ord)]
-pub struct Scalar(ScalarPrimitive);
+pub struct Scalar(ScalarValue);
 
 impl Field for Scalar {
-    const ZERO: Self = Self(ScalarPrimitive::ZERO);
-    const ONE: Self = Self(ScalarPrimitive::ONE);
+    const ZERO: Self = Self(ScalarValue::ZERO);
+    const ONE: Self = Self(ScalarValue::ONE);
 
     fn try_from_rng<R: TryRngCore + ?Sized>(rng: &mut R) -> core::result::Result<Self, R::Error> {
         let mut bytes = FieldBytes::default();
@@ -147,7 +146,7 @@ impl PrimeField for Scalar {
     const DELTA: Self = Self::ZERO; // BOGUS!
 
     fn from_repr(bytes: FieldBytes) -> CtOption<Self> {
-        ScalarPrimitive::from_bytes(&bytes).map(Self)
+        ScalarValue::from_bytes(&bytes).map(Self)
     }
 
     fn to_repr(&self) -> FieldBytes {
@@ -184,7 +183,7 @@ impl AsRef<Scalar> for Scalar {
 
 impl ConditionallySelectable for Scalar {
     fn conditional_select(a: &Self, b: &Self, choice: Choice) -> Self {
-        Self(ScalarPrimitive::conditional_select(&a.0, &b.0, choice))
+        Self(ScalarValue::conditional_select(&a.0, &b.0, choice))
     }
 }
 
@@ -363,7 +362,7 @@ impl Reduce<U256> for Scalar {
         let (r, underflow) = w.borrowing_sub(&MockCurve::ORDER, Limb::ZERO);
         let underflow = Choice::from((underflow.0 >> (Limb::BITS - 1)) as u8);
         let reduced = U256::conditional_select(w, &r, !underflow);
-        Self(ScalarPrimitive::new(reduced).unwrap())
+        Self(ScalarValue::new(reduced).unwrap())
     }
 }
 
@@ -387,14 +386,14 @@ impl From<NonZeroScalar> for Scalar {
     }
 }
 
-impl From<ScalarPrimitive> for Scalar {
-    fn from(scalar: ScalarPrimitive) -> Scalar {
+impl From<ScalarValue> for Scalar {
+    fn from(scalar: ScalarValue) -> Scalar {
         Self(scalar)
     }
 }
 
-impl From<Scalar> for ScalarPrimitive {
-    fn from(scalar: Scalar) -> ScalarPrimitive {
+impl From<Scalar> for ScalarValue {
+    fn from(scalar: Scalar) -> ScalarValue {
         scalar.0
     }
 }
@@ -417,7 +416,7 @@ impl TryFrom<U256> for Scalar {
     type Error = Error;
 
     fn try_from(w: U256) -> Result<Self> {
-        Option::from(ScalarPrimitive::new(w)).map(Self).ok_or(Error)
+        ScalarValue::new(w).into_option().map(Self).ok_or(Error)
     }
 }
 
@@ -425,7 +424,7 @@ impl FromUintUnchecked for Scalar {
     type Uint = U256;
 
     fn from_uint_unchecked(uint: U256) -> Self {
-        Self(ScalarPrimitive::from_uint_unchecked(uint))
+        Self(ScalarValue::from_uint_unchecked(uint))
     }
 }
 

--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -62,7 +62,7 @@
 //! `Deserialize` impls are provided for the following types:
 //!
 //! - [`PublicKey`]
-//! - [`ScalarPrimitive`]
+//! - [`ScalarValue`]
 //!
 //! Please see type-specific documentation for more information.
 //!
@@ -108,7 +108,7 @@ mod public_key;
 pub use crate::{
     error::{Error, Result},
     field::{FieldBytes, FieldBytesEncoding, FieldBytesSize},
-    scalar::ScalarPrimitive,
+    scalar::ScalarValue,
     secret_key::SecretKey,
 };
 pub use crypto_bigint as bigint;

--- a/elliptic-curve/src/macros.rs
+++ b/elliptic-curve/src/macros.rs
@@ -25,27 +25,27 @@ macro_rules! scalar_from_impls {
             }
         }
 
-        impl From<$crate::ScalarPrimitive<$curve>> for $scalar {
-            fn from(w: $crate::ScalarPrimitive<$curve>) -> Self {
+        impl From<$crate::ScalarValue<$curve>> for $scalar {
+            fn from(w: $crate::ScalarValue<$curve>) -> Self {
                 <$scalar>::from(&w)
             }
         }
 
-        impl From<&$crate::ScalarPrimitive<$curve>> for $scalar {
-            fn from(w: &$crate::ScalarPrimitive<$curve>) -> $scalar {
+        impl From<&$crate::ScalarValue<$curve>> for $scalar {
+            fn from(w: &$crate::ScalarValue<$curve>) -> $scalar {
                 <$scalar>::from_uint_unchecked(*w.as_uint())
             }
         }
 
-        impl From<$scalar> for $crate::ScalarPrimitive<$curve> {
-            fn from(scalar: $scalar) -> $crate::ScalarPrimitive<$curve> {
-                $crate::ScalarPrimitive::from(&scalar)
+        impl From<$scalar> for $crate::ScalarValue<$curve> {
+            fn from(scalar: $scalar) -> $crate::ScalarValue<$curve> {
+                $crate::ScalarValue::from(&scalar)
             }
         }
 
-        impl From<&$scalar> for $crate::ScalarPrimitive<$curve> {
-            fn from(scalar: &$scalar) -> $crate::ScalarPrimitive<$curve> {
-                $crate::ScalarPrimitive::new(scalar.into()).unwrap()
+        impl From<&$scalar> for $crate::ScalarValue<$curve> {
+            fn from(scalar: &$scalar) -> $crate::ScalarValue<$curve> {
+                $crate::ScalarValue::new(scalar.into()).unwrap()
             }
         }
 

--- a/elliptic-curve/src/scalar.rs
+++ b/elliptic-curve/src/scalar.rs
@@ -4,9 +4,9 @@
 mod blinded;
 #[cfg(feature = "arithmetic")]
 mod nonzero;
-mod primitive;
+mod value;
 
-pub use self::primitive::ScalarPrimitive;
+pub use self::value::ScalarValue;
 
 #[cfg(feature = "arithmetic")]
 pub use self::{blinded::BlindedScalar, nonzero::NonZeroScalar};

--- a/elliptic-curve/src/scalar/nonzero.rs
+++ b/elliptic-curve/src/scalar/nonzero.rs
@@ -1,7 +1,7 @@
 //! Non-zero scalar type.
 
 use crate::{
-    CurveArithmetic, Error, FieldBytes, PrimeCurve, Scalar, ScalarPrimitive, SecretKey,
+    CurveArithmetic, Error, FieldBytes, PrimeCurve, Scalar, ScalarValue, SecretKey,
     ops::{self, BatchInvert, Invert, Reduce, ReduceNonZero},
     point::NonIdentity,
     scalar::IsHigh,
@@ -86,7 +86,7 @@ where
 
     /// Create a [`NonZeroScalar`] from a `C::Uint`.
     pub fn from_uint(uint: C::Uint) -> CtOption<Self> {
-        ScalarPrimitive::new(uint).and_then(|scalar| Self::new(scalar.into()))
+        ScalarValue::new(uint).and_then(|scalar| Self::new(scalar.into()))
     }
 
     /// Transform array reference containing [`NonZeroScalar`]s to an array reference to the inner
@@ -214,22 +214,22 @@ where
     }
 }
 
-impl<C> From<NonZeroScalar<C>> for ScalarPrimitive<C>
+impl<C> From<NonZeroScalar<C>> for ScalarValue<C>
 where
     C: CurveArithmetic,
 {
     #[inline]
-    fn from(scalar: NonZeroScalar<C>) -> ScalarPrimitive<C> {
+    fn from(scalar: NonZeroScalar<C>) -> ScalarValue<C> {
         Self::from(&scalar)
     }
 }
 
-impl<C> From<&NonZeroScalar<C>> for ScalarPrimitive<C>
+impl<C> From<&NonZeroScalar<C>> for ScalarValue<C>
 where
     C: CurveArithmetic,
 {
-    fn from(scalar: &NonZeroScalar<C>) -> ScalarPrimitive<C> {
-        ScalarPrimitive::from_bytes(&scalar.to_repr()).unwrap()
+    fn from(scalar: &NonZeroScalar<C>) -> ScalarValue<C> {
+        ScalarValue::from_bytes(&scalar.to_repr()).unwrap()
     }
 }
 
@@ -247,7 +247,7 @@ where
     C: CurveArithmetic,
 {
     fn from(sk: &SecretKey<C>) -> NonZeroScalar<C> {
-        let scalar = sk.as_scalar_primitive().to_scalar();
+        let scalar = sk.as_scalar_value().to_scalar();
         debug_assert!(!bool::from(scalar.is_zero()));
         Self { scalar }
     }
@@ -492,7 +492,7 @@ where
     where
         S: ser::Serializer,
     {
-        ScalarPrimitive::from(self).serialize(serializer)
+        ScalarValue::from(self).serialize(serializer)
     }
 }
 
@@ -505,7 +505,7 @@ where
     where
         D: de::Deserializer<'de>,
     {
-        let scalar = ScalarPrimitive::deserialize(deserializer)?;
+        let scalar = ScalarValue::deserialize(deserializer)?;
         Self::new(scalar.into())
             .into_option()
             .ok_or_else(|| de::Error::custom("expected non-zero scalar"))

--- a/elliptic-curve/src/secret_key.rs
+++ b/elliptic-curve/src/secret_key.rs
@@ -8,7 +8,7 @@
 #[cfg(all(feature = "pkcs8", feature = "sec1"))]
 mod pkcs8;
 
-use crate::{Curve, Error, FieldBytes, Result, ScalarPrimitive};
+use crate::{Curve, Error, FieldBytes, Result, ScalarValue};
 use core::fmt::{self, Debug};
 use hybrid_array::typenum::Unsigned;
 use subtle::{Choice, ConstantTimeEq, CtOption};
@@ -74,7 +74,7 @@ use {crate::pkcs8::DecodePrivateKey, core::str::FromStr};
 #[derive(Clone)]
 pub struct SecretKey<C: Curve> {
     /// Scalar value
-    inner: ScalarPrimitive<C>,
+    inner: ScalarValue<C>,
 }
 
 impl<C> SecretKey<C>
@@ -115,19 +115,19 @@ where
     /// # Returns
     ///
     /// This will return a none if the scalar is all-zero.
-    pub fn from_scalar(scalar: impl Into<ScalarPrimitive<C>>) -> CtOption<Self> {
+    pub fn from_scalar(scalar: impl Into<ScalarValue<C>>) -> CtOption<Self> {
         let inner = scalar.into();
         CtOption::new(Self { inner }, !inner.is_zero())
     }
 
-    /// Borrow the inner secret [`ScalarPrimitive`] value.
+    /// Borrow the inner secret [`ScalarValue`] value.
     ///
     /// # ⚠️ Warning
     ///
     /// This value is key material.
     ///
     /// Please treat it with the care it deserves!
-    pub fn as_scalar_primitive(&self) -> &ScalarPrimitive<C> {
+    pub fn as_scalar_value(&self) -> &ScalarValue<C> {
         &self.inner
     }
 
@@ -157,7 +157,7 @@ where
 
     /// Deserialize secret key from an encoded secret scalar.
     pub fn from_bytes(bytes: &FieldBytes<C>) -> Result<Self> {
-        let inner = ScalarPrimitive::<C>::from_bytes(bytes)
+        let inner = ScalarValue::<C>::from_bytes(bytes)
             .into_option()
             .ok_or(Error)?;
 


### PR DESCRIPTION
Denotes the type reperents an integer value in range of the scalar modulus.

Ideally we could get rid of this type if there were a suitable replacement type somewhere else, e.g. RustCrypto/elliptic-curves#1192