### PR TITLE
elliptic-curve: add `point::LookupTable` and `BasepointTable`

### DIFF
--- a/.github/workflows/elliptic-curve.yml
+++ b/.github/workflows/elliptic-curve.yml
@@ -45,6 +45,7 @@ jobs:
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features alloc
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features arithmetic
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features bits
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features critical-section
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features dev
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features digest
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features ecdh

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,6 +115,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dabb6555f92fb9ee4140454eb5dcd14c7960e1225c6d1a6cc361f032947713e"
 
 [[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
 name = "crypto"
 version = "0.6.0-pre"
 dependencies = [
@@ -184,6 +190,7 @@ dependencies = [
  "hex-literal",
  "hkdf",
  "hybrid-array",
+ "once_cell",
  "pem-rfc7468",
  "pkcs8",
  "rand_core",
@@ -337,6 +344,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "once_cell"
+version = "1.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+dependencies = [
+ "critical-section",
+ "portable-atomic",
+]
+
+[[package]]
 name = "password-hash"
 version = "0.6.0-rc.1"
 dependencies = [
@@ -363,6 +380,12 @@ dependencies = [
  "der",
  "spki",
 ]
+
+[[package]]
+name = "portable-atomic"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
 
 [[package]]
 name = "proc-macro2"

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -30,6 +30,7 @@ ff = { version = "=0.14.0-pre.0", optional = true, default-features = false }
 group = { version = "=0.14.0-pre.0", optional = true, default-features = false }
 hkdf = { version = "0.13.0-rc.1", optional = true, default-features = false }
 hex-literal = { version = "1", optional = true }
+once_cell = { version = "1.21", optional = true, default-features = false }
 pem-rfc7468 = { version = "1.0.0-rc.2", optional = true, features = ["alloc"] }
 pkcs8 = { version = "0.11.0-rc.7", optional = true, default-features = false }
 sec1 = { version = "0.8.0-rc.10", optional = true, features = ["subtle", "zeroize"] }
@@ -52,11 +53,14 @@ alloc = [
 std = [
     "alloc",
     "rand_core/std",
+    "once_cell?/std",
     "pkcs8?/std",
     "sec1?/std"
 ]
 
 arithmetic = ["group"]
+basepoint-table = ["arithmetic"]
+critical-section = ["basepoint-table", "once_cell/critical-section"]
 bits = ["arithmetic", "ff/bits"]
 dev = ["arithmetic", "dep:hex-literal", "pem", "pkcs8"]
 ecdh = ["arithmetic", "digest", "dep:hkdf"]

--- a/elliptic-curve/src/point.rs
+++ b/elliptic-curve/src/point.rs
@@ -1,13 +1,20 @@
 //! Traits for elliptic curve points.
 
-#[cfg(feature = "arithmetic")]
+mod basepoint_table;
+mod lookup_table;
 mod non_identity;
 
 #[cfg(feature = "arithmetic")]
-pub use {self::non_identity::NonIdentity, crate::CurveArithmetic};
+pub use {self::non_identity::NonIdentity, lookup_table::LookupTable};
+
+#[cfg(feature = "basepoint-table")]
+pub use self::basepoint_table::BasepointTable;
 
 use crate::{Curve, FieldBytes};
 use subtle::{Choice, CtOption};
+
+#[cfg(feature = "arithmetic")]
+use crate::CurveArithmetic;
 
 /// Affine point type for a given curve with a [`CurveArithmetic`]
 /// implementation.

--- a/elliptic-curve/src/point/basepoint_table.rs
+++ b/elliptic-curve/src/point/basepoint_table.rs
@@ -1,0 +1,88 @@
+//! Precomputed basepoint tables for accelerating fixed-base scalar multiplication.
+
+#![cfg(feature = "basepoint-table")]
+#![allow(clippy::cast_possible_truncation, clippy::needless_range_loop)]
+
+#[cfg(not(any(feature = "critical-section", feature = "std")))]
+compile_error!("`basepoint-table` feature requires either `critical-section` or `std`");
+
+use crate::point::LookupTable;
+use group::Group;
+use subtle::ConditionallySelectable;
+use {core::ops::Deref, ff::PrimeField};
+
+#[cfg(feature = "critical-section")]
+use once_cell::sync::Lazy as LazyLock;
+#[cfg(all(feature = "std", not(feature = "critical-section")))]
+use std::sync::LazyLock;
+
+/// Precomputed lookup table of multiples of a base point, a.k.a. generator.
+///
+/// This type leverages lazy computation, and requires one of the following crate features to be
+/// enabled in order to work:
+/// - `std`: leverages `std::sync::LazyLock`
+/// - `critical-section`: leverages `once_cell::sync::Lazy` via the `critical-section` crate,
+///   enabling the feature to be used in `no_std` contexts.
+#[derive(Debug)]
+pub struct BasepointTable<Point, const N: usize> {
+    tables: LazyLock<[LookupTable<Point>; N]>,
+}
+
+impl<Point, const N: usize> BasepointTable<Point, N>
+where
+    Point: ConditionallySelectable + Default + Group,
+{
+    /// Create a new [`BasepointTable`] which is lazily initialized on first use and can be bound
+    /// to a constant.
+    ///
+    /// Computed using the `Point`'s [`Group::generator`] as the base point.
+    pub const fn new() -> Self {
+        /// Inner function to initialize the table.
+        fn init_table<Point, const N: usize>() -> [LookupTable<Point>; N]
+        where
+            Point: ConditionallySelectable + Default + Group,
+        {
+            let mut generator = Point::generator();
+            let mut res = [LookupTable::<Point>::default(); N];
+
+            for i in 0..N {
+                res[i] = LookupTable::new(generator);
+                // We are storing tables spaced by two radix steps,
+                // to decrease the size of the precomputed data.
+                for _ in 0..8 {
+                    generator = generator.double();
+                }
+            }
+
+            res
+        }
+
+        // Ensure basepoint table contains the expected number of entries for the scalar's size
+        assert!(
+            N as u32 == 1 + Point::Scalar::NUM_BITS / 8,
+            "incorrectly sized basepoint table"
+        );
+
+        Self {
+            tables: LazyLock::new(init_table),
+        }
+    }
+}
+
+impl<Point, const N: usize> Default for BasepointTable<Point, N>
+where
+    Point: ConditionallySelectable + Default + Group,
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<Point, const N: usize> Deref for BasepointTable<Point, N> {
+    type Target = [LookupTable<Point>; N];
+
+    #[inline]
+    fn deref(&self) -> &[LookupTable<Point>; N] {
+        &self.tables
+    }
+}

--- a/elliptic-curve/src/point/lookup_table.rs
+++ b/elliptic-curve/src/point/lookup_table.rs
@@ -1,0 +1,64 @@
+//! Precomputed lookup tables which allow multiples of an elliptic curve point to be selected in
+//! constant time.
+
+#![cfg(feature = "arithmetic")]
+
+use group::Group;
+use subtle::{Choice, ConditionallySelectable, ConstantTimeEq};
+
+/// Internal constant for the number of entries in a [`LookupTable`].
+///
+/// This is defined separately from `LookupTable::SIZE` because we can't use an inherent associated
+/// constant of a generic type in generic contexts, and this doesn't vary depending on `Point`.
+const LUT_SIZE: usize = 8;
+
+/// Lookup table containing precomputed values `[p, 2p, 3p, ..., 8p]`
+#[derive(Clone, Copy, Debug, Default)]
+pub struct LookupTable<Point> {
+    points: [Point; LUT_SIZE],
+}
+
+impl<Point> LookupTable<Point>
+where
+    Point: ConditionallySelectable + Group,
+{
+    /// Number of entries in the lookup table.
+    pub const SIZE: usize = LUT_SIZE;
+
+    /// Compute a new lookup table from the given point.
+    pub fn new(p: Point) -> Self {
+        let mut points = [p; LUT_SIZE];
+
+        for j in 0..(LUT_SIZE - 1) {
+            points[j + 1] = p + points[j];
+        }
+
+        Self { points }
+    }
+
+    /// Given `-8 <= x <= 8`, returns `x * p` in constant time.
+    #[allow(clippy::cast_sign_loss)]
+    pub fn select(&self, x: i8) -> Point {
+        debug_assert!((-8..=8).contains(&x));
+
+        // Compute xabs = |x|
+        let xmask = x >> 7;
+        let xabs = (x + xmask) ^ xmask;
+
+        // Get an array element in constant time
+        let mut t = Point::identity();
+
+        #[allow(clippy::cast_possible_truncation)]
+        for j in 1..(LUT_SIZE + 1) {
+            let c = (xabs as u8).ct_eq(&(j as u8));
+            t.conditional_assign(&self.points[j - 1], c);
+        }
+        // Now t == |x| * p.
+
+        let neg_mask = Choice::from((xmask & 1) as u8);
+        t.conditional_assign(&-t, neg_mask);
+        // Now t == x * p.
+
+        t
+    }
+}

--- a/elliptic-curve/src/point/non_identity.rs
+++ b/elliptic-curve/src/point/non_identity.rs
@@ -1,5 +1,7 @@
 //! Non-identity point type.
 
+#![cfg(feature = "arithmetic")]
+
 use core::ops::{Deref, Mul};
 
 use group::{Group, GroupEncoding, prime::PrimeCurveAffine};


### PR DESCRIPTION
Implementation is originally from the `k256` crate, but written to be generic over a `Point` type which is bound by the `Group` trait.

Adds a `LookupTable` type which supports precomputed lookup tables for a given curve point which can be selected from in constant time.

Also adds a feature-gated `BasepointTable` type with a `const fn` constructor which builds a table for precomputed fixed-base scalar multiplication using the `Group::generator` as the base point.

The `const fn` support for `BasepointTable` is achieved via a `LazyLock`-style pattern which computes the table lazily upon first use in a synchronized fashion. It supports using either `std::sync::LazyLock`, or for `no_std` targets it also supports using the `critical-section` feature of the `once_cell` crate.