### PR TITLE
elliptic-curve: bump crypto-bigint to v0.7.0-rc.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,9 +136,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-bigint"
-version = "0.7.0-rc.7"
+version = "0.7.0-rc.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0bfcfbe68dec4e49b4e93da8f091ce39556549554905fcb07308f6eeefae46c"
+checksum = "4113edbc9f68c0a64d5b911f803eb245d04bb812680fd56776411f69c670f3e0"
 dependencies = [
  "hybrid-array",
  "num-traits",
@@ -286,6 +286,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bad028b20a90afcdb5e28a53392562f1db2bdfa238aa1a978b911461bfffb92"
 dependencies = [
+ "subtle",
  "typenum",
  "zeroize",
 ]

--- a/digest/src/mac.rs
+++ b/digest/src/mac.rs
@@ -133,7 +133,7 @@ impl<T: Update + FixedOutput + MacMarker> Mac for T {
         if n != Self::OutputSize::USIZE {
             return Err(MacError);
         }
-        let choice = self.finalize_fixed().ct_eq(tag);
+        let choice = self.finalize_fixed().as_slice().ct_eq(tag);
         if choice.into() { Ok(()) } else { Err(MacError) }
     }
 
@@ -146,7 +146,7 @@ impl<T: Update + FixedOutput + MacMarker> Mac for T {
         if n != Self::OutputSize::USIZE {
             return Err(MacError);
         }
-        let choice = self.finalize_fixed_reset().ct_eq(tag);
+        let choice = self.finalize_fixed_reset().as_slice().ct_eq(tag);
         if choice.into() { Ok(()) } else { Err(MacError) }
     }
 

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -18,7 +18,7 @@ and public/secret keys composed thereof.
 
 [dependencies]
 base16ct = "0.3"
-crypto-bigint = { version = "0.7.0-rc.6", default-features = false, features = ["rand_core", "hybrid-array", "zeroize"] }
+crypto-bigint = { version = "0.7.0-rc.8", default-features = false, features = ["rand_core", "hybrid-array", "zeroize"] }
 hybrid-array = { version = "0.4", default-features = false, features = ["zeroize"] }
 rand_core = { version = "0.9.0", default-features = false }
 subtle = { version = "2.6", default-features = false }


### PR DESCRIPTION
This notably enables the `subtle` feature of `hybrid-array`. This apparently broke `digest` where previously the unsized coercion was working until an explicit impl was available. So this PR also includes a small fix to `digest`.