### PR TITLE
kem v0.4.0-pre.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,7 +304,7 @@ dependencies = [
 
 [[package]]
 name = "kem"
-version = "0.3.0-pre.2"
+version = "0.4.0-pre.0"
 dependencies = [
  "rand_core",
  "zeroize",

--- a/kem/Cargo.toml
+++ b/kem/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kem"
-version = "0.3.0-pre.2"
+version = "0.4.0-pre.0"
 authors = ["RustCrypto Developers"]
 edition = "2024"
 rust-version = "1.85"


### PR DESCRIPTION
Republishing with a bumped minor version to address #2053, since the current release of `ml-kem` (v0.2.x) depends on `v0.3.0-pre.0`.