### PR TITLE
kem: add `KeyInit` support to `Decapsulate`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -306,6 +306,7 @@ dependencies = [
 name = "kem"
 version = "0.4.0-pre.0"
 dependencies = [
+ "crypto-common",
  "rand_core",
  "zeroize",
 ]

--- a/kem/Cargo.toml
+++ b/kem/Cargo.toml
@@ -13,6 +13,7 @@ categories = ["cryptography", "no-std"]
 description = "Traits for key encapsulation mechanisms"
 
 [dependencies]
+crypto-common = { version = "0.2.0-rc.4", features = ["rand_core"], path = "../crypto-common" }
 rand_core = "0.9"
 zeroize = { version = "1.7", default-features = false }
 

--- a/kem/src/lib.rs
+++ b/kem/src/lib.rs
@@ -8,6 +8,8 @@
 #![forbid(unsafe_code)]
 #![warn(missing_docs, unused_qualifications, missing_debug_implementations)]
 
+pub use crypto_common::{KeyInit, KeySizeUser};
+
 use core::fmt::Debug;
 use rand_core::TryCryptoRng;
 
@@ -26,7 +28,7 @@ pub trait Encapsulate<EK, SS> {
 ///
 /// Often, this will just be a secret key. But, as with [`Encapsulate`], it can be a bundle
 /// of secret keys, or it can include a sender's private key for authenticated encapsulation.
-pub trait Decapsulate<EK, SS> {
+pub trait Decapsulate<EK, SS>: KeyInit {
     /// Decapsulation error
     type Error: Debug;
 


### PR DESCRIPTION
This notably provides a common way to initialize KEM decapsulation keys along with a common way to do key generation