### PR TITLE
kem: re-export `KeyInit` and `KeySizeUser` from `crypto-common`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -306,6 +306,7 @@ dependencies = [
 name = "kem"
 version = "0.4.0-pre.0"
 dependencies = [
+ "crypto-common",
  "rand_core",
  "zeroize",
 ]

--- a/kem/Cargo.toml
+++ b/kem/Cargo.toml
@@ -13,6 +13,7 @@ categories = ["cryptography", "no-std"]
 description = "Traits for key encapsulation mechanisms"
 
 [dependencies]
+crypto-common = { version = "0.2.0-rc.4", features = ["rand_core"], path = "../crypto-common" }
 rand_core = "0.9"
 zeroize = { version = "1.7", default-features = false }
 

--- a/kem/src/lib.rs
+++ b/kem/src/lib.rs
@@ -8,6 +8,8 @@
 #![forbid(unsafe_code)]
 #![warn(missing_docs, unused_qualifications, missing_debug_implementations)]
 
+pub use crypto_common::{KeyInit, KeySizeUser};
+
 use core::fmt::Debug;
 use rand_core::TryCryptoRng;
 


### PR DESCRIPTION
Encourages the use of these traits for initializing decapsulators that impl the `Decapsulate` type.

(This is effectively #2056 without the supertrait bound)