### PR TITLE
kem: re-export `typenum::consts`

### DIFF
--- a/kem/src/lib.rs
+++ b/kem/src/lib.rs
@@ -8,7 +8,7 @@
 #![forbid(unsafe_code)]
 #![warn(missing_docs, unused_qualifications, missing_debug_implementations)]
 
-pub use crypto_common::{KeyInit, KeySizeUser};
+pub use crypto_common::{KeyInit, KeySizeUser, typenum::consts};
 
 use core::fmt::Debug;
 use rand_core::TryCryptoRng;


### PR DESCRIPTION
Access to typenum constants is needed to impl `KeySizeUser`