### PR TITLE
Bump `rand_core` to v0.10.0-rc-2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,8 +138,7 @@ dependencies = [
 [[package]]
 name = "crypto-bigint"
 version = "0.7.0-rc.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f4b0fda9462026d53a3ef37c5ec283639ee8494a1a5401109c0e2a3fb4d490c"
+source = "git+https://github.com/RustCrypto/crypto-bigint?branch=rand_core%2Fv0.10.0-rc-2#896b26cc24c96cad5edf957528d0e9558b13dc75"
 dependencies = [
  "hybrid-array",
  "num-traits",
@@ -205,8 +204,7 @@ dependencies = [
 [[package]]
 name = "ff"
 version = "0.14.0-pre.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d42dd26f5790eda47c1a2158ea4120e32c35ddc9a7743c98a292accc01b54ef3"
+source = "git+https://github.com/tarcieri/ff?branch=rand_core%2Fv0.10.0-rc-2#80d58e19c3649824c009b3c77cd15f969bb58ca0"
 dependencies = [
  "bitvec",
  "ff_derive",
@@ -217,8 +215,7 @@ dependencies = [
 [[package]]
 name = "ff_derive"
 version = "0.14.0-pre.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9266df7c7c72e5a865a447aca13bf480d7310eaa4f84de117c33e361d4da8888"
+source = "git+https://github.com/tarcieri/ff?branch=rand_core%2Fv0.10.0-rc-2#80d58e19c3649824c009b3c77cd15f969bb58ca0"
 dependencies = [
  "addchain",
  "num-bigint",
@@ -250,8 +247,7 @@ dependencies = [
 [[package]]
 name = "group"
 version = "0.14.0-pre.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ff6a0b2dd4b981b1ae9e3e6830ab146771f3660d31d57bafd9018805a91b0f1"
+source = "git+https://github.com/tarcieri/group?branch=rand_core%2Fv0.10.0-rc-2#642bee5b41b93c11496ca667fd99eacb6eb4a147"
 dependencies = [
  "ff",
  "rand_core",
@@ -423,12 +419,9 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand_core"
-version = "0.9.3"
+version = "0.10.0-rc-2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
-dependencies = [
- "getrandom",
-]
+checksum = "104a23e4e8b77312a823b6b5613edbac78397e2f34320bc7ac4277013ec4478e"
 
 [[package]]
 name = "sec1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,7 @@ members = [
 [patch.crates-io]
 digest = { path = "digest" }
 signature = { path = "signature" }
+
+crypto-bigint = { git = "https://github.com/RustCrypto/crypto-bigint", branch = "rand_core/v0.10.0-rc-2" }
+ff = { git = "https://github.com/tarcieri/ff", branch = "rand_core/v0.10.0-rc-2" }
+group = { git = "https://github.com/tarcieri/group", branch = "rand_core/v0.10.0-rc-2" }

--- a/crypto-common/Cargo.toml
+++ b/crypto-common/Cargo.toml
@@ -16,10 +16,11 @@ description = "Common cryptographic traits"
 hybrid-array = "0.4"
 
 # optional dependencies
-getrandom = { version = "0.3", optional = true }
-rand_core = { version = "0.9", optional = true }
+getrandom = { version = "0.3", optional = true, default-features = false }
+rand_core = { version = "0.10.0-rc-2", optional = true }
 
 [features]
+getrandom = ["dep:getrandom"]
 rand_core = ["dep:rand_core"]
 zeroize = ["hybrid-array/zeroize"]
 

--- a/crypto-common/src/lib.rs
+++ b/crypto-common/src/lib.rs
@@ -14,6 +14,7 @@ pub mod hazmat;
 
 #[cfg(feature = "getrandom")]
 pub use getrandom;
+
 #[cfg(feature = "rand_core")]
 pub use rand_core;
 

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -20,7 +20,7 @@ and public/secret keys composed thereof.
 base16ct = "0.3"
 crypto-bigint = { version = "0.7.0-rc.9", default-features = false, features = ["rand_core", "hybrid-array", "zeroize"] }
 hybrid-array = { version = "0.4", default-features = false, features = ["zeroize"] }
-rand_core = { version = "0.9.0", default-features = false }
+rand_core = { version = "0.10.0-rc-2", default-features = false }
 subtle = { version = "2.6", default-features = false }
 zeroize = { version = "1.7", default-features = false }
 
@@ -52,7 +52,6 @@ alloc = [
 ]
 std = [
     "alloc",
-    "rand_core/std",
     "once_cell?/std",
     "pkcs8?/std",
     "sec1?/std"

--- a/kem/Cargo.toml
+++ b/kem/Cargo.toml
@@ -14,7 +14,7 @@ description = "Traits for key encapsulation mechanisms"
 
 [dependencies]
 crypto-common = { version = "0.2.0-rc.4", features = ["rand_core"], path = "../crypto-common" }
-rand_core = "0.9"
+rand_core = "0.10.0-rc-2"
 zeroize = { version = "1.7", default-features = false }
 
 [package.metadata.docs.rs]

--- a/password-hash/Cargo.toml
+++ b/password-hash/Cargo.toml
@@ -21,12 +21,12 @@ base64ct = "1.7"
 subtle = { version = "2", default-features = false }
 
 # optional dependencies
-rand_core = { version = "0.9", optional = true, default-features = false }
+rand_core = { version = "0.10.0-rc-2", optional = true, default-features = false }
 
 [features]
 default = ["rand_core"]
 rand_core = ["dep:rand_core"]
-os_rng = ["rand_core", "rand_core/os_rng"]
+#os_rng = ["rand_core", "rand_core/os_rng"]
 alloc = ["base64ct/alloc"]
 
 [package.metadata.docs.rs]

--- a/signature/Cargo.toml
+++ b/signature/Cargo.toml
@@ -14,7 +14,7 @@ description = "Traits for cryptographic signature algorithms (e.g. ECDSA, Ed2551
 
 [dependencies]
 digest = { version = "0.11.0-rc.1", optional = true, default-features = false }
-rand_core = { version = "0.9", optional = true, default-features = false }
+rand_core = { version = "0.10.0-rc-2", optional = true, default-features = false }
 
 [features]
 alloc = []


### PR DESCRIPTION
Since `OsRng` has been moved to `rand`, and `rand` depends on `chacha20` which depends on `cipher` -> `crypto-common` which needs access to `OsRng`, this temporarily vendors the relevant code (which is a thin wrapper around `getrandom`) until we can sort out a better solution for accessing `OsRng` without creating a circular dependency on `rand`.

cc @dhardy