### PR TITLE
aead+cipher+crypto-common: depend on `getrandom` directly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,6 +152,7 @@ dependencies = [
 name = "crypto-common"
 version = "0.2.0-rc.4"
 dependencies = [
+ "getrandom",
  "hybrid-array",
  "rand_core",
 ]

--- a/aead/Cargo.toml
+++ b/aead/Cargo.toml
@@ -28,7 +28,7 @@ bytes = { version = "1", optional = true, default-features = false }
 default = ["rand_core"]
 alloc = []
 dev = ["blobby", "alloc"]
-os_rng = ["crypto-common/os_rng", "rand_core"]
+getrandom = ["crypto-common/getrandom"]
 rand_core = ["crypto-common/rand_core"]
 
 [package.metadata.docs.rs]

--- a/aead/src/lib.rs
+++ b/aead/src/lib.rs
@@ -40,8 +40,8 @@ use inout::InOutBuf;
 use alloc::vec::Vec;
 #[cfg(feature = "bytes")]
 use bytes::BytesMut;
-#[cfg(feature = "os_rng")]
-use crypto_common::rand_core::{OsError, OsRng, TryRngCore};
+#[cfg(feature = "getrandom")]
+use crypto_common::getrandom;
 #[cfg(feature = "rand_core")]
 use rand_core::{CryptoRng, TryCryptoRng};
 
@@ -125,10 +125,10 @@ pub trait AeadCore {
     ///
     /// [NIST SP 800-38D]: https://csrc.nist.gov/publications/detail/sp/800-38d/final
     /// [`aead-stream`]: https://docs.rs/aead-stream
-    #[cfg(feature = "os_rng")]
-    fn generate_nonce() -> core::result::Result<Nonce<Self>, OsError> {
+    #[cfg(feature = "getrandom")]
+    fn generate_nonce() -> core::result::Result<Nonce<Self>, getrandom::Error> {
         let mut nonce = Nonce::<Self>::default();
-        OsRng.try_fill_bytes(&mut nonce)?;
+        getrandom::fill(&mut nonce)?;
         Ok(nonce)
     }
 

--- a/cipher/Cargo.toml
+++ b/cipher/Cargo.toml
@@ -29,8 +29,8 @@ alloc = []
 block-padding = ["inout/block-padding"]
 stream-wrapper = ["block-buffer"]
 # Enable random key and IV generation methods
+getrandom = ["crypto-common/getrandom"]
 rand_core = ["crypto-common/rand_core"]
-os_rng = ["crypto-common/os_rng", "rand_core"]
 dev = ["blobby"]
 zeroize = ["dep:zeroize", "crypto-common/zeroize", "block-buffer?/zeroize"]
 

--- a/crypto-common/Cargo.toml
+++ b/crypto-common/Cargo.toml
@@ -16,10 +16,10 @@ description = "Common cryptographic traits"
 hybrid-array = "0.4"
 
 # optional dependencies
+getrandom = { version = "0.3", optional = true }
 rand_core = { version = "0.9", optional = true }
 
 [features]
-os_rng = ["rand_core/os_rng", "rand_core"]
 rand_core = ["dep:rand_core"]
 zeroize = ["hybrid-array/zeroize"]
 

--- a/crypto-common/src/lib.rs
+++ b/crypto-common/src/lib.rs
@@ -12,6 +12,8 @@
 /// Hazardous materials.
 pub mod hazmat;
 
+#[cfg(feature = "getrandom")]
+pub use getrandom;
 #[cfg(feature = "rand_core")]
 pub use rand_core;
 
@@ -26,8 +28,6 @@ use hybrid_array::{
 
 #[cfg(feature = "rand_core")]
 use rand_core::{CryptoRng, TryCryptoRng};
-#[cfg(feature = "os_rng")]
-use rand_core::{OsError, OsRng, TryRngCore};
 
 /// Block on which [`BlockSizeUser`] implementors operate.
 pub type Block<B> = Array<u8, <B as BlockSizeUser>::BlockSize>;
@@ -179,11 +179,11 @@ pub trait KeyInit: KeySizeUser + Sized {
     }
 
     /// Generate random key using the operating system's secure RNG.
-    #[cfg(feature = "os_rng")]
+    #[cfg(feature = "getrandom")]
     #[inline]
-    fn generate_key() -> Result<Key<Self>, OsError> {
+    fn generate_key() -> Result<Key<Self>, getrandom::Error> {
         let mut key = Key::<Self>::default();
-        OsRng.try_fill_bytes(&mut key)?;
+        getrandom::fill(&mut key)?;
         Ok(key)
     }
 
@@ -235,11 +235,11 @@ pub trait KeyIvInit: KeySizeUser + IvSizeUser + Sized {
     }
 
     /// Generate random key using the operating system's secure RNG.
-    #[cfg(feature = "os_rng")]
+    #[cfg(feature = "getrandom")]
     #[inline]
-    fn generate_key() -> Result<Key<Self>, OsError> {
+    fn generate_key() -> Result<Key<Self>, getrandom::Error> {
         let mut key = Key::<Self>::default();
-        OsRng.try_fill_bytes(&mut key)?;
+        getrandom::fill(&mut key)?;
         Ok(key)
     }
 
@@ -264,11 +264,11 @@ pub trait KeyIvInit: KeySizeUser + IvSizeUser + Sized {
     }
 
     /// Generate random IV using the operating system's secure RNG.
-    #[cfg(feature = "os_rng")]
+    #[cfg(feature = "getrandom")]
     #[inline]
-    fn generate_iv() -> Result<Iv<Self>, OsError> {
+    fn generate_iv() -> Result<Iv<Self>, getrandom::Error> {
         let mut iv = Iv::<Self>::default();
-        OsRng.try_fill_bytes(&mut iv)?;
+        getrandom::fill(&mut iv)?;
         Ok(iv)
     }
 
@@ -293,9 +293,9 @@ pub trait KeyIvInit: KeySizeUser + IvSizeUser + Sized {
     }
 
     /// Generate random key and IV using the operating system's secure RNG.
-    #[cfg(feature = "os_rng")]
+    #[cfg(feature = "getrandom")]
     #[inline]
-    fn generate_key_iv() -> Result<(Key<Self>, Iv<Self>), OsError> {
+    fn generate_key_iv() -> Result<(Key<Self>, Iv<Self>), getrandom::Error> {
         let key = Self::generate_key()?;
         let iv = Self::generate_iv()?;
         Ok((key, iv))
@@ -346,11 +346,11 @@ pub trait InnerIvInit: InnerUser + IvSizeUser + Sized {
     }
 
     /// Generate random IV using the operating system's secure RNG.
-    #[cfg(feature = "os_rng")]
+    #[cfg(feature = "getrandom")]
     #[inline]
-    fn generate_iv() -> Result<Iv<Self>, OsError> {
+    fn generate_iv() -> Result<Iv<Self>, getrandom::Error> {
         let mut iv = Iv::<Self>::default();
-        OsRng.try_fill_bytes(&mut iv)?;
+        getrandom::fill(&mut iv)?;
         Ok(iv)
     }
 

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -26,7 +26,7 @@ universal-hash = { version = "0.6.0-rc.1", path = "../universal-hash", optional 
 
 [features]
 std = ["elliptic-curve/std"]
-os_rng = ["crypto-common/os_rng"]
+getrandom = ["crypto-common/getrandom"]
 rand_core = ["crypto-common/rand_core"]
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
Replaces usages of `OsRng` with `getrandom`, and `OsError` with `getrandom::Error`.

In `rand_core` v0.10 prereleases, `OsRng` has been moved to the `rand` crate (at least for now). The `rand` crate also depends on `chacha20`, so if we were to depend on `rand` it would create a circular dependency. We can avoid this circular dependency by using `getrandom` directly.

By changing the feature name back to `getrandom`, it also matches the existing feature name in stable releases, which is one less thing people need to change in updates.

Since `aead` was consuming `OsRng` via `crypto-common`, the latter has been changed to re-export `getrandom`.

See also: #2063

cc @dhardy