### PR TITLE
elliptic-curve: bump `hkdf` to v0.13.0-rc.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -262,18 +262,18 @@ checksum = "e712f64ec3850b98572bffac52e2c6f282b29fe6c5fa6d42334b30be438d95c1"
 
 [[package]]
 name = "hkdf"
-version = "0.13.0-rc.2"
+version = "0.13.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8ef30358b03ca095a5b910547f4f8d4b9f163e4057669c5233ef595b1ecf008"
+checksum = "cfbb4225acf2b5cc4e12d384672cd6d1f0cb980ff5859ffcf144db25b593a24d"
 dependencies = [
  "hmac",
 ]
 
 [[package]]
 name = "hmac"
-version = "0.13.0-rc.2"
+version = "0.13.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3fd4dc94c318c1ede8a2a48341c250d6ddecd3ba793da2820301a9f92417ad9"
+checksum = "f1c597ac7d6cc8143e30e83ef70915e7f883b18d8bec2e2b2bce47f5bbb06d57"
 dependencies = [
  "digest",
 ]

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -28,7 +28,7 @@ zeroize = { version = "1.7", default-features = false }
 digest = { version = "0.11.0-rc.4", optional = true }
 ff = { version = "=0.14.0-pre.0", optional = true, default-features = false }
 group = { version = "=0.14.0-pre.0", optional = true, default-features = false }
-hkdf = { version = "0.13.0-rc.1", optional = true, default-features = false }
+hkdf = { version = "0.13.0-rc.3", optional = true, default-features = false }
 hex-literal = { version = "1", optional = true }
 once_cell = { version = "1.21", optional = true, default-features = false }
 pem-rfc7468 = { version = "1.0.0-rc.2", optional = true, features = ["alloc"] }

--- a/elliptic-curve/src/ecdh.rs
+++ b/elliptic-curve/src/ecdh.rs
@@ -26,13 +26,14 @@
 //! [AKE]: https://en.wikipedia.org/wiki/Authenticated_Key_Exchange
 //! [SIGMA]: https://www.iacr.org/cryptodb/archive/2003/CRYPTO/1495/1495.pdf
 
+pub use hkdf::hmac::EagerHash;
+
 use crate::{
     AffinePoint, Curve, CurveArithmetic, CurveGroup, FieldBytes, NonZeroScalar, ProjectivePoint,
     PublicKey, point::AffineCoordinates,
 };
 use core::{borrow::Borrow, fmt};
-use digest::{Digest, crypto_common::BlockSizeUser};
-use hkdf::{Hkdf, hmac::SimpleHmac};
+use hkdf::Hkdf;
 use rand_core::{CryptoRng, TryCryptoRng};
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
@@ -207,9 +208,9 @@ impl<C: Curve> SharedSecret<C> {
     /// material.
     ///
     /// [HKDF]: https://en.wikipedia.org/wiki/HKDF
-    pub fn extract<D>(&self, salt: Option<&[u8]>) -> Hkdf<D, SimpleHmac<D>>
+    pub fn extract<D>(&self, salt: Option<&[u8]>) -> Hkdf<D>
     where
-        D: BlockSizeUser + Clone + Digest,
+        D: EagerHash,
     {
         Hkdf::new(salt, &self.secret_bytes)
     }


### PR DESCRIPTION
This notably switches to `EagerHash` for the digest bound