### PR TITLE
cipher: refactor asynchronous stream cipher traits

### DIFF
--- a/cipher/src/async_stream.rs
+++ b/cipher/src/async_stream.rs
@@ -1,0 +1,57 @@
+//! Traits which define functionality of asynchronous (a.k.a. self-synchronizing) stream ciphers.
+
+use crate::block::{BlockModeDecrypt, BlockModeEncrypt};
+use crypto_common::Block;
+use inout::{InOutBuf, NotEqualError};
+
+/// Asynchronous stream cipher encryptor.
+pub trait AsyncStreamCipherCoreEncrypt: BlockModeEncrypt {
+    /// Encrypt data using `InOutBuf`.
+    fn encrypt_inout(mut self, data: InOutBuf<'_, '_, u8>) {
+        let (blocks, mut tail) = data.into_chunks();
+        self.encrypt_blocks_inout(blocks);
+        let n = tail.len();
+        if n != 0 {
+            let mut block = Block::<Self>::default();
+            block[..n].copy_from_slice(tail.get_in());
+            self.encrypt_block(&mut block);
+            tail.get_out().copy_from_slice(&block[..n]);
+        }
+    }
+
+    /// Encrypt data in place.
+    fn encrypt(self, buf: &mut [u8]) {
+        self.encrypt_inout(buf.into());
+    }
+
+    /// Encrypt data from buffer to buffer.
+    fn encrypt_b2b(self, in_buf: &[u8], out_buf: &mut [u8]) -> Result<(), NotEqualError> {
+        InOutBuf::new(in_buf, out_buf).map(|b| self.encrypt_inout(b))
+    }
+}
+
+/// Asynchronous stream cipher decryptor.
+pub trait AsyncStreamCipherCoreDecrypt: BlockModeDecrypt {
+    /// Decrypt data using `InOutBuf`.
+    fn decrypt_inout(mut self, data: InOutBuf<'_, '_, u8>) {
+        let (blocks, mut tail) = data.into_chunks();
+        self.decrypt_blocks_inout(blocks);
+        let n = tail.len();
+        if n != 0 {
+            let mut block = Block::<Self>::default();
+            block[..n].copy_from_slice(tail.get_in());
+            self.decrypt_block(&mut block);
+            tail.get_out().copy_from_slice(&block[..n]);
+        }
+    }
+
+    /// Decrypt data in place.
+    fn decrypt(self, buf: &mut [u8]) {
+        self.decrypt_inout(buf.into());
+    }
+
+    /// Decrypt data from buffer to buffer.
+    fn decrypt_b2b(self, in_buf: &[u8], out_buf: &mut [u8]) -> Result<(), NotEqualError> {
+        InOutBuf::new(in_buf, out_buf).map(|b| self.decrypt_inout(b))
+    }
+}

--- a/cipher/src/lib.rs
+++ b/cipher/src/lib.rs
@@ -33,6 +33,7 @@ pub use inout::block_padding;
 #[cfg(feature = "zeroize")]
 pub use zeroize;
 
+pub mod async_stream;
 pub mod block;
 #[cfg(feature = "dev")]
 pub mod dev;


### PR DESCRIPTION
This PR moves the `AsyncStreamCipher` trait into separate `async_stream` module and splits into separate encryptor and decryptor traits, making them sub-traits of the counterpart block mode traits.

TODO: add buffering wrapper and traits for buffered async stream ciphers  or do it with inherent methods