### PR TITLE
password-hash: extract `CustomizedPasswordHasher` trait

### DIFF
--- a/password-hash/src/phc.rs
+++ b/password-hash/src/phc.rs
@@ -161,7 +161,7 @@ impl<'a> PasswordHash<'a> {
     pub fn generate(
         phf: impl PasswordHasher,
         password: impl AsRef<[u8]>,
-        salt: impl Into<Salt<'a>>,
+        salt: &'a str,
     ) -> crate::Result<Self> {
         phf.hash_password(password.as_ref(), salt)
     }


### PR DESCRIPTION
Splits out `PasswordHasher::hash_password_customized` into its own separate `CustomizedPasswordHasher` trait.

This trait retains the associated `Params` type since that's used as a method argument.

This also adds a type alias `Version` for `u32` to use in place of `Decimal` (also a `u32` alias) for the `Version` parameter to `hash_password_customized`, and changes the `salt` parameter to be `&'a str`, which removes any PHC-related types as input arguments to the method.

However, there is still a dependency on `ParamsString` and `PasswordHash`, which still needs to be addressed to fully decouple the trait from PHC types.