### PR TITLE
password-hash: remove `phc::Ident` lifetime

### DIFF
--- a/password-hash/src/errors.rs
+++ b/password-hash/src/errors.rs
@@ -21,6 +21,9 @@ pub enum Error {
     /// Cryptographic error.
     Crypto,
 
+    /// Out of memory (heap allocation failure).
+    OutOfMemory,
+
     /// Output size unexpected.
     OutputSize {
         /// Indicates why the output size is unexpected.
@@ -61,11 +64,14 @@ pub enum Error {
     /// Salt invalid.
     SaltInvalid(InvalidValue),
 
+    /// Value exceeds the maximum allowed length.
+    TooLong,
+
+    /// Value does not satisfy the minimum length.
+    TooShort,
+
     /// Invalid algorithm version.
     Version,
-
-    /// Out of memory (heap allocation failure).
-    OutOfMemory,
 }
 
 impl fmt::Display for Error {
@@ -74,6 +80,7 @@ impl fmt::Display for Error {
             Self::Algorithm => write!(f, "unsupported algorithm"),
             Self::B64Encoding(err) => write!(f, "{err}"),
             Self::Crypto => write!(f, "cryptographic error"),
+            Self::OutOfMemory => write!(f, "out of memory"),
             Self::OutputSize { provided, expected } => match provided {
                 Ordering::Less => write!(
                     f,
@@ -94,8 +101,9 @@ impl fmt::Display for Error {
                 write!(f, "password hash string contains trailing characters")
             }
             Self::SaltInvalid(val_err) => write!(f, "salt invalid: {val_err}"),
+            Self::TooLong => f.write_str("value to long"),
+            Self::TooShort => f.write_str("value to short"),
             Self::Version => write!(f, "invalid algorithm version"),
-            Self::OutOfMemory => write!(f, "out of memory"),
         }
     }
 }

--- a/password-hash/src/phc.rs
+++ b/password-hash/src/phc.rs
@@ -4,22 +4,21 @@ mod ident;
 mod output;
 mod params;
 mod salt;
+mod string_buf;
 mod value;
 
-use crate::{Error, PasswordHasher, PasswordVerifier};
 pub use ident::Ident;
 pub use output::Output;
 pub use params::ParamsString;
 pub use salt::{Salt, SaltString};
 pub use value::{Decimal, Value};
 
-use core::fmt;
+use crate::{Error, PasswordHasher, PasswordVerifier};
+use core::{fmt, str::FromStr};
+use string_buf::StringBuf;
 
 #[cfg(feature = "alloc")]
-use alloc::{
-    str::FromStr,
-    string::{String, ToString},
-};
+use alloc::string::{String, ToString};
 
 /// Separator character used in password hashes (e.g. `$6$...`).
 const PASSWORD_HASH_SEPARATOR: char = '$';
@@ -62,7 +61,7 @@ pub struct PasswordHash<'a> {
     ///
     /// This corresponds to the `<id>` field in a PHC string, a.k.a. the
     /// symbolic name for the function.
-    pub algorithm: Ident<'a>,
+    pub algorithm: Ident,
 
     /// Optional version field.
     ///
@@ -103,7 +102,7 @@ impl<'a> PasswordHash<'a> {
         let algorithm = fields
             .next()
             .ok_or(Error::PhcStringField)
-            .and_then(Ident::try_from)?;
+            .and_then(Ident::from_str)?;
 
         let mut version = None;
         let mut params = ParamsString::new();
@@ -264,7 +263,7 @@ impl PasswordHashString {
     }
 
     /// Password hashing algorithm identifier.
-    pub fn algorithm(&self) -> Ident<'_> {
+    pub fn algorithm(&self) -> Ident {
         self.password_hash().algorithm
     }
 

--- a/password-hash/src/phc/string_buf.rs
+++ b/password-hash/src/phc/string_buf.rs
@@ -1,0 +1,108 @@
+use crate::{Error, Result};
+use core::{
+    fmt,
+    ops::Deref,
+    str::{self, FromStr},
+};
+
+/// Buffer for storing short stack-allocated strings.
+#[derive(Clone, Copy, Eq, Hash, PartialEq, PartialOrd, Ord)]
+pub(super) struct StringBuf<const N: usize> {
+    /// Length of the string in ASCII characters (i.e. bytes).
+    pub(super) length: u8,
+
+    /// Byte array containing an ASCII-encoded string.
+    pub(super) bytes: [u8; N],
+}
+
+impl<const N: usize> StringBuf<N> {
+    /// Create a new string buffer containing the given string
+    pub(super) const fn new(s: &str) -> Result<Self> {
+        if s.len() > N || s.len() > u8::MAX as usize {
+            return Err(Error::TooLong);
+        }
+
+        let mut bytes = [0u8; N];
+        let mut i = 0;
+
+        while i < s.len() {
+            bytes[i] = s.as_bytes()[i];
+            i += 1;
+        }
+
+        Ok(Self {
+            bytes,
+            length: s.len() as u8,
+        })
+    }
+}
+
+impl<const N: usize> AsRef<str> for StringBuf<N> {
+    fn as_ref(&self) -> &str {
+        str::from_utf8(&self.bytes[..(self.length as usize)]).expect("should be valid UTF-8")
+    }
+}
+
+impl<const N: usize> Default for StringBuf<N> {
+    fn default() -> Self {
+        StringBuf {
+            bytes: [0u8; N],
+            length: 0,
+        }
+    }
+}
+
+impl<const N: usize> Deref for StringBuf<N> {
+    type Target = str;
+
+    fn deref(&self) -> &str {
+        self.as_ref()
+    }
+}
+
+impl<const N: usize> FromStr for StringBuf<N> {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self> {
+        Self::new(s)
+    }
+}
+
+impl<const N: usize> TryFrom<&str> for StringBuf<N> {
+    type Error = Error;
+
+    fn try_from(s: &str) -> Result<Self> {
+        Self::new(s)
+    }
+}
+
+impl<const N: usize> fmt::Debug for StringBuf<N> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_ref())
+    }
+}
+
+impl<const N: usize> fmt::Display for StringBuf<N> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_ref())
+    }
+}
+
+impl<const N: usize> fmt::Write for StringBuf<N> {
+    fn write_str(&mut self, input: &str) -> fmt::Result {
+        const { debug_assert!(N <= u8::MAX as usize) }
+
+        let bytes = input.as_bytes();
+        let length = self.length as usize;
+        let new_length = length.checked_add(bytes.len()).ok_or(fmt::Error)?;
+
+        if new_length > N {
+            return Err(fmt::Error);
+        }
+
+        self.bytes[length..new_length].copy_from_slice(bytes);
+        self.length = new_length.try_into().map_err(|_| fmt::Error)?;
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
`Ident` is a short string with a max length of 32-bytes. Instead of having a lifetime, we can simply store the 32-bytes as an owned type.

This is an incremental step towards removing the lifetime from the `phc::PasswordHash` type.

The implementation makes the previous `Buffer` (now `StringBuf`) type used for `Params` const generic around a particular size, and adds some basic const init functionality, as well as checks for arithmetic overflow.