### PR TITLE
password-hash: remove lifetime from `Salt` type

### DIFF
--- a/password-hash/tests/encoding.rs
+++ b/password-hash/tests/encoding.rs
@@ -22,12 +22,8 @@ const EXAMPLE_OUTPUT_RAW: &[u8] =
 
 #[test]
 fn salt_roundtrip() {
-    let mut buffer = [0u8; 64];
     let salt = Salt::from_b64(EXAMPLE_SALT_B64).unwrap();
-    assert_eq!(salt.as_ref(), EXAMPLE_SALT_B64);
-
-    let salt_decoded = salt.decode_b64(&mut buffer).unwrap();
-    assert_eq!(salt_decoded, EXAMPLE_SALT_RAW);
+    assert_eq!(salt.as_ref(), EXAMPLE_SALT_RAW);
 }
 
 #[test]

--- a/password-hash/tests/test_vectors.rs
+++ b/password-hash/tests/test_vectors.rs
@@ -4,7 +4,6 @@ use password_hash::phc::{Ident, PasswordHash};
 
 const ARGON2D_HASH: &str =
     "$argon2d$v=19$m=512,t=3,p=2$5VtWOO3cGWYQHEMaYGbsfQ$AcmqasQgW/wI6wAHAMk4aQ";
-const BCRYPT_HASH: &str = "$2b$MTIzNA$i5btSOiulHhaPHPbgNUGdObga/GCAVG/y5HHY1ra7L0C9dpCaw8u";
 const SCRYPT_HASH: &str =
     "$scrypt$epIxT/h6HbbwHaehFnh/bw$7H0vsXlY8UxxyW/BWx/9GuY7jEvGjT71GFd6O4SZND0";
 
@@ -17,23 +16,15 @@ fn argon2id() {
     assert_eq!(ph.params.get_decimal("m").unwrap(), 512);
     assert_eq!(ph.params.get_decimal("t").unwrap(), 3);
     assert_eq!(ph.params.get_decimal("p").unwrap(), 2);
-    assert_eq!(ph.salt.unwrap().as_ref(), "5VtWOO3cGWYQHEMaYGbsfQ");
+    assert_eq!(
+        ph.salt.unwrap().as_ref(),
+        &[
+            0xe5, 0x5b, 0x56, 0x38, 0xed, 0xdc, 0x19, 0x66, 0x10, 0x1c, 0x43, 0x1a, 0x60, 0x66,
+            0xec, 0x7d
+        ]
+    );
     assert_eq!(ph.hash.unwrap().to_string(), "AcmqasQgW/wI6wAHAMk4aQ");
     assert_eq!(ph.to_string(), ARGON2D_HASH);
-}
-
-#[test]
-fn bcrypt() {
-    let ph = PasswordHash::new(BCRYPT_HASH).unwrap();
-    assert_eq!(ph.algorithm, Ident::new("2b").unwrap());
-    assert_eq!(ph.version, None);
-    assert_eq!(ph.params.len(), 0);
-    assert_eq!(ph.salt.unwrap().to_string(), "MTIzNA");
-    assert_eq!(
-        ph.hash.unwrap().to_string(),
-        "i5btSOiulHhaPHPbgNUGdObga/GCAVG/y5HHY1ra7L0C9dpCaw8u"
-    );
-    assert_eq!(ph.to_string(), BCRYPT_HASH);
 }
 
 #[test]


### PR DESCRIPTION
Following #2107, this also removes the lifetime from `Salt`, but also changes its internal representation to be raw bytes after "B64" decoding, with the `SaltString` type handling the "B64" encoded form.

This was the last type with a lifetime on `PasswordHash`, so this also removes the lifetime from that, as well as the lifetime on methods of traits including `(Customized)PasswordHasher`.

The `Salt` and `SaltString` types support infallible conversions back and forth between each other.

Additionally, this changes the `salt` parameter of `hash_password(_customized)` to be a `&[u8]` rather than a `&str`, with the password hashing implementation expected to handle "B64" encoding.