### PR TITLE
password-hash: add generic `H` param to traits

### DIFF
--- a/password-hash/src/phc.rs
+++ b/password-hash/src/phc.rs
@@ -158,7 +158,7 @@ impl PasswordHash {
 
     /// Generate a password hash using the supplied algorithm.
     pub fn generate(
-        phf: impl PasswordHasher,
+        phf: impl PasswordHasher<Self>,
         password: impl AsRef<[u8]>,
         salt: &[u8],
     ) -> crate::Result<Self> {
@@ -169,7 +169,7 @@ impl PasswordHash {
     /// [`PasswordHasher`] trait objects.
     pub fn verify_password(
         &self,
-        phfs: &[&dyn PasswordVerifier],
+        phfs: &[&dyn PasswordVerifier<Self>],
         password: impl AsRef<[u8]>,
     ) -> crate::Result<()> {
         for &phf in phfs {

--- a/password-hash/tests/hashing.rs
+++ b/password-hash/tests/hashing.rs
@@ -1,9 +1,8 @@
 //! Password hashing tests
 
 use core::{fmt::Display, str::FromStr};
-use password_hash::PasswordHasher;
-pub use password_hash::{
-    CustomizedPasswordHasher,
+use password_hash::{
+    CustomizedPasswordHasher, PasswordHasher,
     errors::{Error, Result},
     phc::{Decimal, Ident, Output, ParamsString, PasswordHash, Salt},
 };
@@ -13,13 +12,7 @@ const ALG: Ident = Ident::new_unwrap("example");
 /// Stub password hashing function for testing.
 pub struct StubPasswordHasher;
 
-impl PasswordHasher for StubPasswordHasher {
-    fn hash_password(&self, password: &[u8], salt: &[u8]) -> Result<PasswordHash> {
-        self.hash_password_customized(password, salt, None, None, StubParams)
-    }
-}
-
-impl CustomizedPasswordHasher for StubPasswordHasher {
+impl CustomizedPasswordHasher<PasswordHash> for StubPasswordHasher {
     type Params = StubParams;
 
     fn hash_password_customized(
@@ -52,6 +45,12 @@ impl CustomizedPasswordHasher for StubPasswordHasher {
             salt: Some(salt),
             hash: Some(hash),
         })
+    }
+}
+
+impl PasswordHasher<PasswordHash> for StubPasswordHasher {
+    fn hash_password(&self, password: &[u8], salt: &[u8]) -> Result<PasswordHash> {
+        self.hash_password_customized(password, salt, None, None, StubParams)
     }
 }
 


### PR DESCRIPTION
Adds a generic `H` parameter to the `(Customized)PasswordHasher` and `PasswordVerifier` traits which specifies the return type and the hash type respectively.

A generic parameter is used instead of an associated constant in order to support overlapping impls. Notably multiple commonly used password hashing algorithms (e.g. PBKDF2, scrypt) support encoding in either the Modular Crypt Format (MCF) or Password Hashing Competition (PHC) string format, which are implemented as the `mcf::PasswordHash` and `phc::PasswordHash` types respectively.

We already have open issues to add MCF support where we currently don't support it (RustCrypto/password-hashes#727,
RustCrypto/password-hashes#747).

The blanket impl of `PasswordVerifier` for `CustomizedPasswordHasher` is retained, but only for `phc::PasswordHash`, as supporting it for MCF requires algorithmic-specific interpretation of the hash. However, algorithms can provide their own impls of `PasswordVerifier<mcf::PasswordHash>`.