### PR TITLE
password-hash: add `phc` feature

### DIFF
--- a/.github/workflows/password-hash.yml
+++ b/.github/workflows/password-hash.yml
@@ -39,12 +39,10 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
           targets: ${{ matrix.target }}
-      - run: cargo build --target ${{ matrix.target }} --release --no-default-features
-      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features alloc
-      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features rand_core
+      - uses: RustCrypto/actions/cargo-hack-install@master
+      - run: cargo hack build --target ${{ matrix.target }} --feature-powerset --exclude-features getrandom
 
-  # TODO: use the reusable workflow after this crate will be part of the
-  # toot workspace
+  # TODO: use the reusable workflow after this crate will be part of the root workspace
   minimal-versions:
     if: false # disabled until we stop using pre-releases
     runs-on: ubuntu-latest
@@ -71,7 +69,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
+      - uses: RustCrypto/actions/cargo-hack-install@master
       - run: cargo check --all-features
-      - run: cargo test --release --no-default-features
-      - run: cargo test --release
+      - run: cargo hack test --feature-powerset
       - run: cargo test --release --all-features

--- a/password-hash/Cargo.toml
+++ b/password-hash/Cargo.toml
@@ -25,10 +25,11 @@ getrandom = { version = "0.3", optional = true, default-features = false }
 rand_core = { version = "0.10.0-rc-2", optional = true, default-features = false }
 
 [features]
-default = ["rand_core"]
-getrandom = ["dep:getrandom"]
-rand_core = ["dep:rand_core"]
+default = ["phc", "rand_core"]
 alloc = ["base64ct/alloc"]
+getrandom = ["dep:getrandom"]
+phc = []
+rand_core = ["dep:rand_core"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/password-hash/src/lib.rs
+++ b/password-hash/src/lib.rs
@@ -26,18 +26,21 @@
 //! For more information, please see the documentation for [`PasswordHash`].
 
 #[cfg(feature = "alloc")]
+#[allow(unused_extern_crates)]
 extern crate alloc;
 
 #[cfg(feature = "rand_core")]
 pub use rand_core;
 
 pub mod errors;
+#[cfg(feature = "phc")]
 pub mod phc;
 
 pub use crate::errors::{Error, Result};
-pub use phc::PasswordHash;
 
-#[cfg(feature = "alloc")]
+#[cfg(feature = "phc")]
+pub use phc::PasswordHash;
+#[cfg(all(feature = "alloc", feature = "phc"))]
 pub use phc::PasswordHashString;
 
 use core::{
@@ -97,6 +100,7 @@ pub trait PasswordVerifier<H> {
     fn verify_password(&self, password: &[u8], hash: &H) -> Result<()>;
 }
 
+#[cfg(feature = "phc")]
 impl<T: CustomizedPasswordHasher<PasswordHash>> PasswordVerifier<PasswordHash> for T {
     fn verify_password(&self, password: &[u8], hash: &PasswordHash) -> Result<()> {
         #[allow(clippy::single_match)]
@@ -128,6 +132,7 @@ impl<T: CustomizedPasswordHasher<PasswordHash>> PasswordVerifier<PasswordHash> f
 /// [Modular Crypt Format (MCF)][MCF].
 ///
 /// [MCF]: https://passlib.readthedocs.io/en/stable/modular_crypt_format.html
+#[cfg(feature = "phc")]
 pub trait McfHasher {
     /// Upgrade an MCF hash to a PHC hash. MCF follow this rough format:
     ///

--- a/password-hash/tests/encoding.rs
+++ b/password-hash/tests/encoding.rs
@@ -8,6 +8,8 @@
 //!
 //! <https://github.com/P-H-C/phc-string-format/blob/master/phc-sf-spec.md#b64>
 
+#![cfg(feature = "phc")]
+
 use password_hash::phc::{Output, Salt};
 
 // Example salt encoded as a B64 string.

--- a/password-hash/tests/hashing.rs
+++ b/password-hash/tests/hashing.rs
@@ -1,5 +1,7 @@
 //! Password hashing tests
 
+#![cfg(feature = "phc")]
+
 use core::{fmt::Display, str::FromStr};
 use password_hash::{
     CustomizedPasswordHasher, PasswordHasher,

--- a/password-hash/tests/password_hash.rs
+++ b/password-hash/tests/password_hash.rs
@@ -4,6 +4,8 @@
 //! of the string encoding, and ensures password hashes round trip under each
 //! of the conditions.
 
+#![cfg(feature = "phc")]
+
 use password_hash::phc::{Ident, ParamsString, PasswordHash, Salt};
 
 const EXAMPLE_ALGORITHM: Ident = Ident::new_unwrap("argon2d");

--- a/password-hash/tests/test_vectors.rs
+++ b/password-hash/tests/test_vectors.rs
@@ -1,5 +1,7 @@
 //! Test vectors for commonly used password hashing algorithms.
 
+#![cfg(feature = "phc")]
+
 use password_hash::phc::{Ident, PasswordHash};
 
 const ARGON2D_HASH: &str =


### PR DESCRIPTION
Makes support for the Password Hashing Competition string format optional.

After this it can potentially be extracted into its own crate and made an optional dependency.