### PR TITLE
password-hash: use `phc` v0.6.0-rc.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -338,8 +338,9 @@ dependencies = [
 
 [[package]]
 name = "phc"
-version = "0.3.0-pre"
-source = "git+https://github.com/RustCrypto/formats#1e7caeb8e57b89d5cff1fba6ab500928fb3eccf7"
+version = "0.6.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61f960577aaac5c259bc0866d685ba315c0ed30793c602d7287f54980913863"
 dependencies = [
  "base64ct",
  "subtle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,4 +18,3 @@ digest = { path = "digest" }
 signature = { path = "signature" }
 
 getrandom = { git = "https://github.com/rust-random/getrandom" }
-phc = { git = "https://github.com/RustCrypto/formats" }

--- a/password-hash/Cargo.toml
+++ b/password-hash/Cargo.toml
@@ -17,7 +17,7 @@ as well as a `no_std`-friendly implementation of the PHC string format
 """
 
 [dependencies]
-phc = { version = "0.3.0-pre", optional = true, default-features = false }
+phc = { version = "0.6.0-rc.0", optional = true, default-features = false }
 
 [features]
 alloc = ["phc?/alloc"]

--- a/password-hash/src/lib.rs
+++ b/password-hash/src/lib.rs
@@ -50,6 +50,7 @@ pub type PasswordHash = phc::PasswordHash;
     since = "0.6.0",
     note = "use `password_hash::phc::PasswordHash` or `String`"
 )]
+#[allow(deprecated)]
 pub type PasswordHashString = phc::PasswordHashString;
 
 use core::{


### PR DESCRIPTION
Switches from obtaining the `phc` crate via git to using the initial crate release