### PR TITLE
password-hash: relax `FromStr` error bounds

### DIFF
--- a/password-hash/src/error.rs
+++ b/password-hash/src/error.rs
@@ -18,6 +18,9 @@ pub enum Error {
     /// Encoding errors (e.g. Base64).
     EncodingInvalid,
 
+    /// Internal error within a password hashing library.
+    Internal,
+
     /// Out of memory (heap allocation failure).
     OutOfMemory,
 
@@ -49,6 +52,7 @@ impl fmt::Display for Error {
             Self::Algorithm => write!(f, "unsupported algorithm"),
             Self::Crypto => write!(f, "cryptographic error"),
             Self::EncodingInvalid => write!(f, "invalid encoding"),
+            Self::Internal => write!(f, "internal password hashing algorithm error"),
             Self::OutOfMemory => write!(f, "out of memory"),
             Self::OutputSize => write!(f, "password hash output size invalid"),
             Self::ParamInvalid { name } => write!(f, "invalid parameter: {name:?}"),

--- a/password-hash/src/lib.rs
+++ b/password-hash/src/lib.rs
@@ -77,7 +77,7 @@ pub trait PasswordHasher<H> {
 /// Generic around a password hash to be returned (typically [`PasswordHash`])
 pub trait CustomizedPasswordHasher<H> {
     /// Algorithm-specific parameters.
-    type Params: Clone + Debug + Default + Display + FromStr<Err = Error>;
+    type Params: Clone + Debug + Default + Display + FromStr;
 
     /// Compute a [`PasswordHash`] from the provided password using an
     /// explicit set of customized algorithm parameters as opposed to the
@@ -110,7 +110,11 @@ pub trait PasswordVerifier<H> {
 }
 
 #[cfg(feature = "phc")]
-impl<T: CustomizedPasswordHasher<phc::PasswordHash>> PasswordVerifier<phc::PasswordHash> for T {
+impl<T: CustomizedPasswordHasher<phc::PasswordHash>, E> PasswordVerifier<phc::PasswordHash> for T
+where
+    T::Params: FromStr<Err = E>,
+    Error: From<E>,
+{
     fn verify_password(&self, password: &[u8], hash: &phc::PasswordHash) -> Result<()> {
         #[allow(clippy::single_match)]
         match (&hash.salt, &hash.hash) {


### PR DESCRIPTION
Changes the bound on `CustomizedPasswordHasher::Params` to remove the `Err = Error` bound on `FromStr`.

Instead, the blanket impl of `PasswordVerifier` has been updated to require `Error: From<E>` where `E` is `FromStr::Err`.

This allows crates to still use custom error types for params, which may be more expressive for a specific algorithm.