### PR TITLE
password-hash: make `PasswordVerifier<H: ?Sized>`

### DIFF
--- a/password-hash/src/lib.rs
+++ b/password-hash/src/lib.rs
@@ -113,7 +113,7 @@ pub trait CustomizedPasswordHasher<H> {
 ///
 /// This trait is object safe and can be used to implement abstractions over
 /// multiple password hashing algorithms.
-pub trait PasswordVerifier<H> {
+pub trait PasswordVerifier<H: ?Sized> {
     /// Compute this password hashing function against the provided password
     /// using the parameters from the provided password hash and see if the
     /// computed output matches.


### PR DESCRIPTION
Changes the `H` generic parameter of `PasswordVerifier` to allow dynamically sized types.

This is useful for `mcf::PasswordHashRef`, which is a newtype for `str`.