### PR TITLE
password-hash: restore `getrandom` feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -324,6 +324,7 @@ dependencies = [
 name = "password-hash"
 version = "0.6.0-rc.4"
 dependencies = [
+ "getrandom",
  "phc",
 ]
 
@@ -343,6 +344,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61f960577aaac5c259bc0866d685ba315c0ed30793c602d7287f54980913863"
 dependencies = [
  "base64ct",
+ "getrandom",
  "subtle",
 ]
 

--- a/password-hash/Cargo.toml
+++ b/password-hash/Cargo.toml
@@ -17,10 +17,12 @@ as well as a `no_std`-friendly implementation of the PHC string format
 """
 
 [dependencies]
+getrandom = { version = "0.3", optional = true, default-features = false }
 phc = { version = "0.6.0-rc.0", optional = true, default-features = false }
 
 [features]
 alloc = ["phc?/alloc"]
+getrandom = ["dep:getrandom", "phc?/getrandom"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/password-hash/tests/traits.rs
+++ b/password-hash/tests/traits.rs
@@ -48,7 +48,7 @@ impl CustomizedPasswordHasher<PasswordHash> for StubPasswordHasher {
 }
 
 impl PasswordHasher<PasswordHash> for StubPasswordHasher {
-    fn hash_password(&self, password: &[u8], salt: &[u8]) -> Result<PasswordHash> {
+    fn hash_password_with_salt(&self, password: &[u8], salt: &[u8]) -> Result<PasswordHash> {
         self.hash_password_customized(password, salt, None, None, StubParams)
     }
 }
@@ -84,7 +84,7 @@ fn verify_password_hash() {
     let valid_password = b"test password";
     let salt = Salt::from_b64("testsalt000").unwrap();
     let hash = StubPasswordHasher
-        .hash_password(valid_password, &salt)
+        .hash_password_with_salt(valid_password, &salt)
         .unwrap();
 
     // Sanity tests for StubFunction impl above


### PR DESCRIPTION
Renames `PasswordHash::hash_password` to `hash_password_with_salt`, and adds a new `getrandom`-gated method to `PasswordHash` called `hash_password`, but which only takes `&self` and `password` as arguments, automatically generating a salt of the recommended length.