### PR TITLE
password-hash: impl `From<phc::Error>` for `Error`

### DIFF
--- a/password-hash/src/error.rs
+++ b/password-hash/src/error.rs
@@ -65,3 +65,22 @@ impl fmt::Display for Error {
 }
 
 impl core::error::Error for Error {}
+
+#[cfg(feature = "phc")]
+impl From<phc::Error> for Error {
+    fn from(err: phc::Error) -> Self {
+        match err {
+            phc::Error::B64Encoding(_) | phc::Error::MissingField | phc::Error::TrailingData => {
+                Self::EncodingInvalid
+            }
+            phc::Error::OutputSize { .. } => Self::OutputSize,
+            phc::Error::ParamNameDuplicated
+            | phc::Error::ParamNameInvalid
+            | phc::Error::ParamValueTooLong
+            | phc::Error::ParamsMaxExceeded
+            | phc::Error::ValueTooLong => Self::ParamsInvalid,
+            phc::Error::SaltTooShort | phc::Error::SaltTooLong => Self::SaltInvalid,
+            _ => Self::Internal, // Branch since `phc::Error` is `non_exhaustive`
+        }
+    }
+}


### PR DESCRIPTION
This is useful within the impls of traits like `PasswordHasher` where the return type is `password_hash::Result<phc::PasswordHash>` but various `phc::Error`s may occur when constructing the `PasswordHash` from the params, salt, and output