### PR TITLE
password-hash: add `rand_core` feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -326,6 +326,7 @@ version = "0.6.0-rc.5"
 dependencies = [
  "getrandom",
  "phc",
+ "rand_core",
 ]
 
 [[package]]
@@ -345,6 +346,7 @@ checksum = "c61f960577aaac5c259bc0866d685ba315c0ed30793c602d7287f54980913863"
 dependencies = [
  "base64ct",
  "getrandom",
+ "rand_core",
  "subtle",
 ]
 

--- a/password-hash/Cargo.toml
+++ b/password-hash/Cargo.toml
@@ -19,10 +19,12 @@ as well as a `no_std`-friendly implementation of the PHC string format
 [dependencies]
 getrandom = { version = "0.3", optional = true, default-features = false }
 phc = { version = "0.6.0-rc.0", optional = true, default-features = false }
+rand_core = { version = "0.10.0-rc-2", optional = true, default-features = false }
 
 [features]
 alloc = ["phc?/alloc"]
 getrandom = ["dep:getrandom", "phc?/getrandom"]
+rand_core = ["dep:rand_core", "phc?/rand_core"]
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
Adds a `PasswordHash::hash_password_with_rng` method gated on the `rand_core` feature which uses a `TryCryptoRng` to generate a random salt, analogous to the `getrandom`-based `PasswordHash::hash_password`.