### PR TITLE
password-hash: expose salt generating helper functions

### DIFF
--- a/password-hash/src/error.rs
+++ b/password-hash/src/error.rs
@@ -66,6 +66,14 @@ impl fmt::Display for Error {
 
 impl core::error::Error for Error {}
 
+#[cfg(feature = "getrandom")]
+impl From<getrandom::Error> for Error {
+    fn from(_: getrandom::Error) -> Self {
+        // TODO(tarcieri): should we have a specific variant for RNGs errors?
+        Error::Crypto
+    }
+}
+
 #[cfg(feature = "phc")]
 impl From<phc::Error> for Error {
     fn from(err: phc::Error) -> Self {


### PR DESCRIPTION
Right now there's not a way to generate a random salt in the context of MCF password hashes when not using the high-level
`PasswordHash::hash_password` API, e.g. for KDF usage, which is to say that for PHC password hashes `phc::Salt::generate` is fine for this purpose since it now provides raw bytes, but password hashes which use MCF don't have access to that type.

This is often still documented as using some static value with a comment saying it needs to be unique. Instead we should provide a reusable solution in the rustdoc.

These can potentially be replaced with the `crypto_common::Generate` trait and something like a `RecommendedLengthSalt` type after there's a new `getrandom` crate prerelease, but in the meantime these helper functions seem like a reasonable enough stopgap, and can potentially stick around and use the `Generate` trait for you.