### PR TITLE
crypto-common: vendor `getrandom::SysRng`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -212,12 +212,12 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 [[package]]
 name = "getrandom"
 version = "0.3.4"
-source = "git+https://github.com/rust-random/getrandom#658bb1a43cade84eb7aa63a3225cfa9d12b826b8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "rand_core",
  "wasip2",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,5 +16,3 @@ members = [
 [patch.crates-io]
 digest = { path = "digest" }
 signature = { path = "signature" }
-
-getrandom = { git = "https://github.com/rust-random/getrandom" }

--- a/crypto-common/Cargo.toml
+++ b/crypto-common/Cargo.toml
@@ -16,7 +16,7 @@ description = "Common cryptographic traits"
 hybrid-array = "0.4"
 
 # optional dependencies
-getrandom = { version = "0.3", optional = true, features = ["sys_rng"] }
+getrandom = { version = "0.3", optional = true }
 rand_core = { version = "0.10.0-rc-3", optional = true }
 
 [features]


### PR DESCRIPTION
It's now been a month since #2096 was merged and there still has not been a corresponding `getrandom` release.

This commit temporarily internally vendors `SysRng` (which has a very small implementation) until there is a `getrandom` crate release which is usable. This will unblock work on rolling out the `Generate` trait.

Once there is, this commit can be reverted.