### PR TITLE
kem: re-export `Generate`; add `getrandom` feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -272,7 +272,6 @@ version = "0.4.0-pre.2"
 dependencies = [
  "crypto-common",
  "rand_core",
- "zeroize",
 ]
 
 [[package]]

--- a/kem/Cargo.toml
+++ b/kem/Cargo.toml
@@ -13,12 +13,15 @@ categories = ["cryptography", "no-std"]
 description = "Traits for key encapsulation mechanisms"
 
 [dependencies]
-crypto-common = { version = "0.2.0-rc.5", features = ["rand_core"], path = "../crypto-common" }
+crypto-common = { version = "0.2.0-rc.6", features = ["rand_core"], path = "../crypto-common" }
 rand_core = "0.10.0-rc-3"
-zeroize = { version = "1.7", default-features = false }
+
+[features]
+getrandom = ["crypto-common/getrandom"]
 
 [package.metadata.docs.rs]
 all-features = true
 
+# TODO(tarcieri): make README.md an actually valid example
 [lib]
 doctest = false

--- a/kem/src/lib.rs
+++ b/kem/src/lib.rs
@@ -8,7 +8,7 @@
 #![forbid(unsafe_code)]
 #![warn(missing_docs, unused_qualifications, missing_debug_implementations)]
 
-pub use crypto_common::{KeyInit, KeySizeUser, typenum::consts};
+pub use crypto_common::{Generate, KeyInit, KeySizeUser, typenum::consts};
 
 use rand_core::TryCryptoRng;
 


### PR DESCRIPTION
Since KEMs require randomness and unconditionally enables the `rand_core` feature of `crypto-common`, this unconditionally re-exports the `Generate` trait, which can be used to generate decapsulation keys (though the bounds on `Decapsulate` remain unchanged).

This also adds a passthrough feature for `getrandom` to enable `crypto-common/getrandom`. Ideally this would also add a method to `Encapsulate` which can use `getrandom::SysRng` as the RNG for encapsulating, but since there isn't yet a prerelease with that feature this doesn't attempt to add it yet.