### PR TITLE
Bump `getrandom` to v0.4.0-rc.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,7 +152,7 @@ dependencies = [
 name = "crypto-common"
 version = "0.2.0-rc.7"
 dependencies = [
- "getrandom",
+ "getrandom 0.4.0-rc.0",
  "hybrid-array",
  "rand_core",
 ]
@@ -187,7 +187,7 @@ dependencies = [
  "base16ct",
  "crypto-bigint",
  "digest",
- "getrandom",
+ "getrandom 0.4.0-rc.0",
  "hex-literal",
  "hkdf",
  "hybrid-array",
@@ -218,6 +218,19 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b99f0d993a2b9b97b9a201193aa8ad21305cde06a3be9a7e1f8f4201e5cc27e"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "rand_core",
  "wasip2",
 ]
 
@@ -323,7 +336,7 @@ dependencies = [
 name = "password-hash"
 version = "0.6.0-rc.6"
 dependencies = [
- "getrandom",
+ "getrandom 0.4.0-rc.0",
  "phc",
  "rand_core",
 ]
@@ -344,7 +357,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61f960577aaac5c259bc0866d685ba315c0ed30793c602d7287f54980913863"
 dependencies = [
  "base64ct",
- "getrandom",
+ "getrandom 0.3.4",
  "rand_core",
  "subtle",
 ]

--- a/crypto-common/Cargo.toml
+++ b/crypto-common/Cargo.toml
@@ -16,7 +16,7 @@ description = "Common cryptographic traits"
 hybrid-array = "0.4"
 
 # optional dependencies
-getrandom = { version = "0.3", optional = true }
+getrandom = { version = "0.4.0-rc.0", optional = true, features = ["sys_rng"] }
 rand_core = { version = "0.10.0-rc-3", optional = true }
 
 [features]

--- a/crypto-common/src/generate.rs
+++ b/crypto-common/src/generate.rs
@@ -22,7 +22,7 @@ pub trait Generate: Sized {
     /// Returns [`RngError`] in the event the system's ambient RNG experiences an internal failure.
     #[cfg(feature = "getrandom")]
     fn try_generate() -> Result<Self, RngError> {
-        Self::try_generate_from_rng(&mut sys_rng::SysRng)
+        Self::try_generate_from_rng(&mut getrandom::SysRng)
     }
 
     /// Randomly generate a value of this type using the system's ambient cryptographically secure
@@ -83,36 +83,4 @@ impl<U: ArraySize> Generate for Array<u64, U> {
     fn try_generate_from_rng<R: TryCryptoRng + ?Sized>(rng: &mut R) -> Result<Self, R::Error> {
         Self::try_from_fn(|_| rng.try_next_u64())
     }
-}
-
-#[cfg(feature = "getrandom")]
-pub(crate) mod sys_rng {
-    use getrandom::Error;
-    use rand_core::{TryCryptoRng, TryRngCore};
-
-    /// A [`TryRngCore`] interface over the system's preferred random number source
-    // TODO(tarcieri): replace this with `getrandom::SysRng` when `sys_rng` feature is available
-    #[derive(Clone, Copy, Debug, Default)]
-    pub struct SysRng;
-
-    impl TryRngCore for SysRng {
-        type Error = Error;
-
-        #[inline]
-        fn try_next_u32(&mut self) -> Result<u32, Error> {
-            getrandom::u32()
-        }
-
-        #[inline]
-        fn try_next_u64(&mut self) -> Result<u64, Error> {
-            getrandom::u64()
-        }
-
-        #[inline]
-        fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Error> {
-            getrandom::fill(dest)
-        }
-    }
-
-    impl TryCryptoRng for SysRng {}
 }

--- a/crypto-common/src/lib.rs
+++ b/crypto-common/src/lib.rs
@@ -22,7 +22,7 @@ pub use hybrid_array::typenum;
 #[cfg(feature = "rand_core")]
 pub use {generate::Generate, rand_core};
 #[cfg(feature = "getrandom")]
-pub use {generate::sys_rng::SysRng, getrandom::Error as RngError};
+pub use {getrandom::Error as RngError, getrandom::SysRng};
 
 use core::fmt;
 use hybrid_array::{

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -27,7 +27,7 @@ zeroize = { version = "1.7", default-features = false }
 # optional dependencies
 digest = { version = "0.11.0-rc.4", optional = true }
 ff = { version = "=0.14.0-pre.0", package = "rustcrypto-ff", optional = true, default-features = false }
-getrandom = { version = "0.3", optional = true }
+getrandom = { version = "0.4.0-rc.0", optional = true }
 group = { version = "=0.14.0-pre.0", package = "rustcrypto-group", optional = true, default-features = false }
 hkdf = { version = "0.13.0-rc.3", optional = true, default-features = false }
 hex-literal = { version = "1", optional = true }

--- a/password-hash/Cargo.toml
+++ b/password-hash/Cargo.toml
@@ -17,7 +17,7 @@ as well as a `no_std`-friendly implementation of the PHC string format
 """
 
 [dependencies]
-getrandom = { version = "0.3", optional = true, default-features = false }
+getrandom = { version = "0.4.0-rc.0", optional = true, default-features = false }
 phc = { version = "0.6.0-rc.0", optional = true, default-features = false }
 rand_core = { version = "0.10.0-rc-3", optional = true, default-features = false }
 


### PR DESCRIPTION
This notably includes the new `sys_rng` feature / `SysRng` type, which is the replacement for `OsRng`, and allows us to delete the vendored version thereof from `crypto-common`.