### PR TITLE
Bump `blobby` to v0.4

### DIFF
--- a/aead/Cargo.toml
+++ b/aead/Cargo.toml
@@ -21,7 +21,7 @@ inout = "0.2"
 
 # optional dependencies
 arrayvec = { version = "0.7", optional = true, default-features = false }
-blobby = { version = "0.4.0-pre.1", optional = true }
+blobby = { version = "0.4", optional = true }
 bytes = { version = "1", optional = true, default-features = false }
 
 [features]

--- a/cipher/Cargo.toml
+++ b/cipher/Cargo.toml
@@ -17,7 +17,7 @@ crypto-common = { version = "0.2.0-rc.7", path = "../crypto-common" }
 inout = "0.2"
 
 # optional dependencies
-blobby = { version = "0.4.0-pre.1", optional = true }
+blobby = { version = "0.4", optional = true }
 block-buffer = { version = "0.11", optional = true }
 zeroize = { version = "1.8", optional = true, default-features = false }
 

--- a/digest/Cargo.toml
+++ b/digest/Cargo.toml
@@ -18,7 +18,7 @@ crypto-common = { version = "0.2.0-rc.7", path = "../crypto-common" }
 # optional dependencies
 block-buffer = { version = "0.11", optional = true }
 subtle = { version = "2.4", default-features = false, optional = true }
-blobby = { version = "0.4.0-pre.1", optional = true }
+blobby = { version = "0.4", optional = true }
 const-oid = { version = "0.10", optional = true }
 zeroize = { version = "1.7", optional = true, default-features = false }
 


### PR DESCRIPTION
We've already been using it due to the relaxed dependency, this just makes it official in: `aead`, `cipher`, `digest`