### PR TITLE
Cut new prereleases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,7 +15,7 @@ dependencies = [
 
 [[package]]
 name = "aead"
-version = "0.6.0-rc.4"
+version = "0.6.0-rc.5"
 dependencies = [
  "arrayvec",
  "blobby",
@@ -99,7 +99,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cipher"
-version = "0.5.0-rc.2"
+version = "0.5.0-rc.3"
 dependencies = [
  "blobby",
  "block-buffer",
@@ -150,7 +150,7 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.0-rc.7"
+version = "0.2.0-rc.8"
 dependencies = [
  "getrandom 0.4.0-rc.0",
  "hybrid-array",
@@ -170,7 +170,7 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.11.0-rc.4"
+version = "0.11.0-rc.5"
 dependencies = [
  "blobby",
  "block-buffer",
@@ -281,7 +281,7 @@ dependencies = [
 
 [[package]]
 name = "kem"
-version = "0.4.0-rc.0"
+version = "0.4.0-rc.1"
 dependencies = [
  "crypto-common",
  "rand_core",
@@ -507,7 +507,7 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "3.0.0-rc.5"
+version = "3.0.0-rc.6"
 dependencies = [
  "digest",
  "rand_core",
@@ -571,7 +571,7 @@ checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
 name = "universal-hash"
-version = "0.6.0-rc.3"
+version = "0.6.0-rc.4"
 dependencies = [
  "crypto-common",
  "subtle",

--- a/aead/Cargo.toml
+++ b/aead/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aead"
-version = "0.6.0-rc.4"
+version = "0.6.0-rc.5"
 authors = ["RustCrypto Developers"]
 edition = "2024"
 rust-version = "1.85"
@@ -16,7 +16,7 @@ such as AES-GCM as ChaCha20Poly1305, which provide a high-level API
 """
 
 [dependencies]
-crypto-common = { version = "0.2.0-rc.7", path = "../crypto-common" }
+crypto-common = { version = "0.2.0-rc.8", path = "../crypto-common" }
 inout = "0.2"
 
 # optional dependencies

--- a/cipher/Cargo.toml
+++ b/cipher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cipher"
-version = "0.5.0-rc.2"
+version = "0.5.0-rc.3"
 authors = ["RustCrypto Developers"]
 edition = "2024"
 rust-version = "1.85"
@@ -13,7 +13,7 @@ categories = ["cryptography", "no-std"]
 description = "Traits for describing block ciphers and stream ciphers"
 
 [dependencies]
-crypto-common = { version = "0.2.0-rc.7", path = "../crypto-common" }
+crypto-common = { version = "0.2.0-rc.8", path = "../crypto-common" }
 inout = "0.2"
 
 # optional dependencies

--- a/crypto-common/Cargo.toml
+++ b/crypto-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crypto-common"
-version = "0.2.0-rc.7"
+version = "0.2.0-rc.8"
 authors = ["RustCrypto Developers"]
 edition = "2024"
 rust-version = "1.85"

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -13,16 +13,16 @@ categories = ["cryptography", "no-std"]
 description = "Facade crate for all of the RustCrypto traits (e.g. `aead`, `cipher`, `digest`)"
 
 [dependencies]
-crypto-common = { version = "0.2.0-rc.7", path = "../crypto-common", default-features = false }
+crypto-common = { version = "0.2.0-rc.8", path = "../crypto-common", default-features = false }
 
 # optional dependencies
-aead = { version = "0.6.0-rc.3", path = "../aead", optional = true }
-cipher = { version = "0.5.0-rc.2", path = "../cipher", optional = true }
-digest = { version = "0.11.0-rc.4", path = "../digest", optional = true, features = ["mac"] }
-elliptic-curve = { version = "0.14.0-rc.2", path = "../elliptic-curve", optional = true }
-password-hash = { version = "0.6.0-rc.0", path = "../password-hash", optional = true }
-signature = { version = "3.0.0-rc.0", path = "../signature", optional = true, default-features = false }
-universal-hash = { version = "0.6.0-rc.1", path = "../universal-hash", optional = true }
+aead = { version = "0.6.0-rc.5", path = "../aead", optional = true }
+cipher = { version = "0.5.0-rc.3", path = "../cipher", optional = true }
+digest = { version = "0.11.0-rc.5", path = "../digest", optional = true, features = ["mac"] }
+elliptic-curve = { version = "0.14.0-rc.17", path = "../elliptic-curve", optional = true }
+password-hash = { version = "0.6.0-rc.6", path = "../password-hash", optional = true }
+signature = { version = "3.0.0-rc.6", path = "../signature", optional = true, default-features = false }
+universal-hash = { version = "0.6.0-rc.4", path = "../universal-hash", optional = true }
 
 [features]
 std = ["elliptic-curve/std"]

--- a/digest/Cargo.toml
+++ b/digest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "digest"
-version = "0.11.0-rc.4"
+version = "0.11.0-rc.5"
 authors = ["RustCrypto Developers"]
 edition = "2024"
 rust-version = "1.85"
@@ -13,7 +13,7 @@ categories = ["cryptography", "no-std"]
 description = "Traits for cryptographic hash functions and message authentication codes"
 
 [dependencies]
-crypto-common = { version = "0.2.0-rc.7", path = "../crypto-common" }
+crypto-common = { version = "0.2.0-rc.8", path = "../crypto-common" }
 
 # optional dependencies
 block-buffer = { version = "0.11", optional = true }

--- a/kem/Cargo.toml
+++ b/kem/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kem"
-version = "0.4.0-rc.0"
+version = "0.4.0-rc.1"
 authors = ["RustCrypto Developers"]
 edition = "2024"
 rust-version = "1.85"
@@ -17,7 +17,7 @@ Traits for Key Encapsulation Mechanisms (KEMs): public-key cryptosystems designe
 """
 
 [dependencies]
-crypto-common = { version = "0.2.0-rc.7", features = ["rand_core"], path = "../crypto-common" }
+crypto-common = { version = "0.2.0-rc.8", features = ["rand_core"], path = "../crypto-common" }
 rand_core = "0.10.0-rc-3"
 
 [features]

--- a/signature/Cargo.toml
+++ b/signature/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "signature"
-version = "3.0.0-rc.5"
+version = "3.0.0-rc.6"
 authors = ["RustCrypto Developers"]
 edition = "2024"
 rust-version = "1.85"
@@ -13,7 +13,7 @@ categories = ["cryptography", "no-std"]
 description = "Traits for cryptographic signature algorithms (e.g. ECDSA, Ed25519)"
 
 [dependencies]
-digest = { version = "0.11.0-rc.4", optional = true, default-features = false }
+digest = { version = "0.11.0-rc.5", optional = true, default-features = false }
 rand_core = { version = "0.10.0-rc-3", optional = true, default-features = false }
 
 [features]

--- a/universal-hash/Cargo.toml
+++ b/universal-hash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "universal-hash"
-version = "0.6.0-rc.3"
+version = "0.6.0-rc.4"
 authors = ["RustCrypto Developers"]
 edition = "2024"
 rust-version = "1.85"
@@ -13,7 +13,7 @@ categories = ["cryptography", "no-std"]
 description = "Traits which describe the functionality of universal hash functions (UHFs)"
 
 [dependencies]
-crypto-common = { version = "0.2.0-rc.7", path = "../crypto-common" }
+crypto-common = { version = "0.2.0-rc.8", path = "../crypto-common" }
 subtle = { version = "2.4", default-features = false }
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
Releases the following, with `getrandom` v0.4.0-rc.0 and `rand_core` v0.10.0-rc-3 as requirements:

- `aead` v0.6.0-rc.5
- `cipher` v0.5.0-rc.3
- `crypto-common` v0.2.0-rc.8
- `digest` v0.11.0-rc.5
- `kem` v0.4.0-rc.1
- `signature` v0.3.0-rc.6
- `universal-hash` v0.6.0-rc.4

The `password-hash` crate has been withheld until we can upgrade the `phc` crate to `getrandom` v0.4.0-rc.0 as well.