### PR TITLE
aead+cipher: bump `inout` dependency to v0.2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -271,9 +271,9 @@ dependencies = [
 
 [[package]]
 name = "inout"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7357b6e7aa75618c7864ebd0634b115a7218b0615f4cb1df33ac3eca23943d4"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
 dependencies = [
  "block-padding",
  "hybrid-array",

--- a/aead/Cargo.toml
+++ b/aead/Cargo.toml
@@ -17,7 +17,7 @@ such as AES-GCM as ChaCha20Poly1305, which provide a high-level API
 
 [dependencies]
 crypto-common = { version = "0.2.0-rc.8", path = "../crypto-common" }
-inout = "0.2"
+inout = "0.2.2"
 
 # optional dependencies
 arrayvec = { version = "0.7", optional = true, default-features = false }

--- a/cipher/Cargo.toml
+++ b/cipher/Cargo.toml
@@ -14,7 +14,7 @@ description = "Traits for describing block ciphers and stream ciphers"
 
 [dependencies]
 crypto-common = { version = "0.2.0-rc.8", path = "../crypto-common" }
-inout = "0.2"
+inout = "0.2.2"
 
 # optional dependencies
 blobby = { version = "0.4", optional = true }


### PR DESCRIPTION
This requires `block-padding` v0.4.2 which ensures there aren't any incompatibilities with older, yanked versions