### PR TITLE
crypto-common: conditionally re-export `getrandom`

### DIFF
--- a/crypto-common/src/generate.rs
+++ b/crypto-common/src/generate.rs
@@ -1,9 +1,6 @@
 use hybrid_array::{Array, ArraySize};
 use rand_core::{CryptoRng, TryCryptoRng};
 
-#[cfg(feature = "getrandom")]
-use crate::RngError;
-
 /// Secure random generation.
 pub trait Generate: Sized {
     /// Generate random key using the provided [`TryCryptoRng`].
@@ -19,9 +16,10 @@ pub trait Generate: Sized {
     /// random number generator.
     ///
     /// # Errors
-    /// Returns [`RngError`] in the event the system's ambient RNG experiences an internal failure.
+    /// Returns [`getrandom::Error`] in the event the system's ambient RNG experiences an internal
+    /// failure.
     #[cfg(feature = "getrandom")]
-    fn try_generate() -> Result<Self, RngError> {
+    fn try_generate() -> Result<Self, getrandom::Error> {
         Self::try_generate_from_rng(&mut getrandom::SysRng)
     }
 

--- a/crypto-common/src/lib.rs
+++ b/crypto-common/src/lib.rs
@@ -19,10 +19,10 @@ mod generate;
 pub use hybrid_array as array;
 pub use hybrid_array::typenum;
 
+#[cfg(feature = "getrandom")]
+pub use getrandom;
 #[cfg(feature = "rand_core")]
 pub use {generate::Generate, rand_core};
-#[cfg(feature = "getrandom")]
-pub use {getrandom::Error as RngError, getrandom::SysRng};
 
 use core::fmt;
 use hybrid_array::{

--- a/kem/src/lib.rs
+++ b/kem/src/lib.rs
@@ -29,7 +29,7 @@ pub trait Encapsulate<EK, SS> {
     /// Encapsulate a fresh shared secret generated using the system's secure RNG.
     #[cfg(feature = "getrandom")]
     fn encapsulate(&self) -> Result<(EK, SS), Self::Error> {
-        self.encapsulate_with_rng(&mut crypto_common::SysRng)
+        self.encapsulate_with_rng(&mut crypto_common::getrandom::SysRng)
     }
 }
 


### PR DESCRIPTION
Removes bespoke re-exports and simply re-exports the whole crate, which replaces the following:

- `crypto_common::RngError` => `crypto_common::getrandom::Error`
- `crypto_common::SysRng` => `crypto_common::getrandom::SysRng`