### PR TITLE
elliptic-curve: bump `crypto-bigint` to v0.7.0-rc.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,6 +110,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmov"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c11ed919bd3bae4af5ab56372b627dfc32622aba6cec36906e8ab46746037c9d"
+
+[[package]]
 name = "const-oid"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -137,10 +143,11 @@ dependencies = [
 
 [[package]]
 name = "crypto-bigint"
-version = "0.7.0-rc.10"
+version = "0.7.0-rc.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6715836b4946e8585016e80b79c7561476aff3b22f7b756778e7b109d86086c6"
+checksum = "1561a463186fad7b9f52dfb76dfd8e412cf1d41a45f8473cb86398ea9840de22"
 dependencies = [
+ "ctutils",
  "hybrid-array",
  "num-traits",
  "rand_core",
@@ -155,6 +162,16 @@ dependencies = [
  "getrandom",
  "hybrid-array",
  "rand_core",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "925ebe186f09a7894817213f89eae07c39374f5c934613605af7accc8aea6414"
+dependencies = [
+ "cmov",
+ "subtle",
 ]
 
 [[package]]

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -16,9 +16,13 @@ and traits for representing various elliptic curve forms, scalars, points,
 and public/secret keys composed thereof.
 """
 
+[dependencies.crypto-bigint]
+version = "0.7.0-rc.11"
+default-features = false
+features = ["hybrid-array", "rand_core", "subtle", "zeroize"]
+
 [dependencies]
 base16ct = "0.3"
-crypto-bigint = { version = "0.7.0-rc.10", default-features = false, features = ["rand_core", "hybrid-array", "zeroize"] }
 hybrid-array = { version = "0.4", default-features = false, features = ["zeroize"] }
 rand_core = { version = "0.10.0-rc-3", default-features = false }
 subtle = { version = "2.6", default-features = false }

--- a/elliptic-curve/src/scalar/value.rs
+++ b/elliptic-curve/src/scalar/value.rs
@@ -66,13 +66,13 @@ where
     /// Generate a random [`ScalarValue`].
     pub fn random<R: CryptoRng + ?Sized>(rng: &mut R) -> Self {
         Self {
-            inner: C::Uint::random_mod(rng, Self::MODULUS.as_nz_ref()),
+            inner: C::Uint::random_mod_vartime(rng, Self::MODULUS.as_nz_ref()),
         }
     }
 
     /// Create a new scalar from [`Curve::Uint`].
     pub fn new(uint: C::Uint) -> CtOption<Self> {
-        CtOption::new(Self { inner: uint }, uint.ct_lt(&Self::MODULUS))
+        CtOption::new(Self { inner: uint }, uint.ct_lt(&Self::MODULUS).into())
     }
 
     /// Decode [`ScalarValue`] from a serialized field element
@@ -98,17 +98,17 @@ where
 
     /// Is this [`ScalarValue`] value equal to zero?
     pub fn is_zero(&self) -> Choice {
-        self.inner.is_zero()
+        self.inner.is_zero().into()
     }
 
     /// Is this [`ScalarValue`] value even?
     pub fn is_even(&self) -> Choice {
-        self.inner.is_even()
+        self.inner.is_even().into()
     }
 
     /// Is this [`ScalarValue`] value odd?
     pub fn is_odd(&self) -> Choice {
-        self.inner.is_odd()
+        self.inner.is_odd().into()
     }
 
     /// Encode [`ScalarValue`] as a serialized field element.
@@ -160,7 +160,7 @@ where
 {
     fn conditional_select(a: &Self, b: &Self, choice: Choice) -> Self {
         Self {
-            inner: C::Uint::conditional_select(&a.inner, &b.inner, choice),
+            inner: C::Uint::ct_select(&a.inner, &b.inner, choice.into()),
         }
     }
 }
@@ -170,7 +170,7 @@ where
     C: Curve,
 {
     fn ct_eq(&self, other: &Self) -> Choice {
-        self.inner.ct_eq(&other.inner)
+        self.inner.ct_eq(&other.inner).into()
     }
 }
 
@@ -179,7 +179,7 @@ where
     C: Curve,
 {
     fn ct_lt(&self, other: &Self) -> Choice {
-        self.inner.ct_lt(&other.inner)
+        self.inner.ct_lt(&other.inner).into()
     }
 }
 
@@ -188,7 +188,7 @@ where
     C: Curve,
 {
     fn ct_gt(&self, other: &Self) -> Choice {
-        self.inner.ct_gt(&other.inner)
+        self.inner.ct_gt(&other.inner).into()
     }
 }
 
@@ -357,7 +357,7 @@ where
 {
     fn is_high(&self) -> Choice {
         let n_2 = Self::MODULUS.get() >> 1u32;
-        self.inner.ct_gt(&n_2)
+        self.inner.ct_gt(&n_2).into()
     }
 }
 


### PR DESCRIPTION
This includes a mostly-backwards-compatible migration from `subtle` to `ctutils`.