### PR TITLE
elliptic-curve: use `Cargo.toml` for `array`/`bigint` imports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,6 +148,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2bb4138de6db76c8155b4423e967049fbef2cf84ad6af7f552f73a161941b72"
 dependencies = [
  "ctutils",
+ "getrandom",
  "hybrid-array",
  "num-traits",
  "rand_core",

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -16,14 +16,15 @@ and traits for representing various elliptic curve forms, scalars, points,
 and public/secret keys composed thereof.
 """
 
-[dependencies.crypto-bigint]
+[dependencies.bigint]
+package = "crypto-bigint"
 version = "0.7.0-rc.13"
 default-features = false
 features = ["hybrid-array", "rand_core", "subtle", "zeroize"]
 
 [dependencies]
+array = { package = "hybrid-array", version = "0.4", default-features = false, features = ["zeroize"] }
 base16ct = "0.3"
-hybrid-array = { version = "0.4", default-features = false, features = ["zeroize"] }
 rand_core = { version = "0.10.0-rc-3", default-features = false }
 subtle = { version = "2.6", default-features = false }
 zeroize = { version = "1.7", default-features = false }
@@ -50,7 +51,7 @@ alloc = [
     "base16ct/alloc",
     "ff?/alloc",
     "group?/alloc",
-    "hybrid-array/alloc",
+    "array/alloc",
     "pkcs8?/alloc",
     "sec1?/alloc",
     "zeroize/alloc"
@@ -68,7 +69,7 @@ critical-section = ["basepoint-table", "once_cell/critical-section"]
 bits = ["arithmetic", "ff/bits"]
 dev = ["arithmetic", "dep:hex-literal", "pem", "pkcs8"]
 ecdh = ["arithmetic", "digest", "dep:hkdf"]
-getrandom = ["dep:getrandom", "arithmetic"]
+getrandom = ["dep:getrandom", "arithmetic", "bigint/getrandom"]
 group = ["dep:group", "ff"]
 pkcs8 = ["dep:pkcs8", "sec1"]
 pem = ["dep:pem-rfc7468", "alloc", "arithmetic", "pkcs8/pem", "sec1/pem"]

--- a/elliptic-curve/src/field.rs
+++ b/elliptic-curve/src/field.rs
@@ -4,7 +4,7 @@ use crate::{
     Curve,
     bigint::{ArrayEncoding, ByteArray, Integer},
 };
-use hybrid_array::{Array, typenum::Unsigned};
+use array::{Array, typenum::Unsigned};
 
 /// Size of serialized field elements of this elliptic curve.
 pub type FieldBytesSize<C> = <C as Curve>::FieldBytesSize;

--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -111,9 +111,9 @@ pub use crate::{
     scalar::ScalarValue,
     secret_key::SecretKey,
 };
-pub use crypto_bigint as bigint;
-pub use hybrid_array as array;
-pub use hybrid_array::typenum::consts;
+pub use array;
+pub use array::typenum::consts;
+pub use bigint;
 pub use rand_core;
 pub use subtle;
 pub use zeroize;
@@ -133,12 +133,12 @@ pub use {
 #[cfg(feature = "pkcs8")]
 pub use pkcs8;
 
+use array::ArraySize;
 use bigint::Odd;
 use core::{
     fmt::Debug,
     ops::{Add, ShrAssign},
 };
-use hybrid_array::ArraySize;
 
 /// Algorithm [`ObjectIdentifier`][`pkcs8::ObjectIdentifier`] for elliptic curve public key
 /// cryptography (`id-ecPublicKey`).

--- a/elliptic-curve/src/ops.rs
+++ b/elliptic-curve/src/ops.rs
@@ -1,7 +1,7 @@
 //! Traits for arithmetic operations on elliptic curve field elements.
 
+pub use bigint::{Invert, Reduce};
 pub use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Shr, ShrAssign, Sub, SubAssign};
-pub use crypto_bigint::{Invert, Reduce};
 
 use crate::CurveGroup;
 use core::iter;

--- a/elliptic-curve/src/scalar.rs
+++ b/elliptic-curve/src/scalar.rs
@@ -11,7 +11,7 @@ pub use self::value::ScalarValue;
 #[cfg(feature = "arithmetic")]
 pub use self::{blinded::BlindedScalar, nonzero::NonZeroScalar};
 
-use crypto_bigint::Integer;
+use bigint::Integer;
 use subtle::Choice;
 
 #[cfg(feature = "arithmetic")]

--- a/elliptic-curve/src/sec1.rs
+++ b/elliptic-curve/src/sec1.rs
@@ -5,7 +5,7 @@
 pub use sec1::point::{Coordinates, ModulusSize, Tag};
 
 use crate::{Curve, FieldBytesSize, Result, SecretKey};
-use hybrid_array::Array;
+use array::Array;
 use subtle::CtOption;
 
 #[cfg(feature = "arithmetic")]

--- a/elliptic-curve/src/secret_key.rs
+++ b/elliptic-curve/src/secret_key.rs
@@ -9,8 +9,8 @@
 mod pkcs8;
 
 use crate::{Curve, Error, FieldBytes, Result, ScalarValue};
+use array::typenum::Unsigned;
 use core::fmt::{self, Debug};
-use hybrid_array::typenum::Unsigned;
 use subtle::{Choice, ConstantTimeEq, CtOption};
 use zeroize::{Zeroize, ZeroizeOnDrop, Zeroizing};
 


### PR DESCRIPTION
Names them `array` and `bigint` in `Cargo.toml`, using the `package` field to refer to `hybrid-array` and `crypto-bigint` respectively.

This means they're consistently referred to as `array` and `bigint` from within the crate, and should also help diagnostics that sometimes get confused and refer to e.g. `elliptic_curve::crypto_bigint` using the previous approach of `pub use crypto_bigint as bigint`.