### PR TITLE
elliptic-curve: add `ctutils` traits to `arithmetic` bounds

### DIFF
--- a/elliptic-curve/src/arithmetic.rs
+++ b/elliptic-curve/src/arithmetic.rs
@@ -2,6 +2,7 @@
 
 use crate::{
     Curve, CurveGroup, Error, FieldBytes, Group, NonZeroScalar, PrimeCurve, ScalarValue,
+    ctutils::{CtEq, CtSelect},
     ops::{Invert, LinearCombination, Mul, Reduce},
     point::{AffineCoordinates, NonIdentity},
     scalar::{FromUintUnchecked, IsHigh},
@@ -18,6 +19,8 @@ pub trait CurveArithmetic: Curve {
         + Copy
         + ConditionallySelectable
         + ConstantTimeEq
+        + CtEq
+        + CtSelect
         + Debug
         + Default
         + DefaultIsZeroes
@@ -42,6 +45,8 @@ pub trait CurveArithmetic: Curve {
     /// - [`Sync`]
     type ProjectivePoint: ConditionallySelectable
         + ConstantTimeEq
+        + CtEq
+        + CtSelect
         + Default
         + DefaultIsZeroes
         + From<Self::AffinePoint>
@@ -66,6 +71,8 @@ pub trait CurveArithmetic: Curve {
     /// - [`Send`]
     /// - [`Sync`]
     type Scalar: AsRef<Self::Scalar>
+        + CtEq
+        + CtSelect
         + DefaultIsZeroes
         + From<NonZeroScalar<Self>>
         + From<ScalarValue<Self>>

--- a/elliptic-curve/src/dev.rs
+++ b/elliptic-curve/src/dev.rs
@@ -194,6 +194,18 @@ impl ConstantTimeEq for Scalar {
     }
 }
 
+impl ctutils::CtEq for Scalar {
+    fn ct_eq(&self, other: &Self) -> ctutils::Choice {
+        ctutils::CtEq::ct_eq(&self.0, &other.0)
+    }
+}
+
+impl ctutils::CtSelect for Scalar {
+    fn ct_select(&self, other: &Self, choice: ctutils::Choice) -> Self {
+        Self(self.0.ct_select(&other.0, choice))
+    }
+}
+
 impl DefaultIsZeroes for Scalar {}
 
 impl Add<Scalar> for Scalar {
@@ -503,8 +515,20 @@ impl ConstantTimeEq for AffinePoint {
 
 impl ConditionallySelectable for AffinePoint {
     fn conditional_select(a: &Self, b: &Self, choice: Choice) -> Self {
+        ctutils::CtSelect::ct_select(a, b, choice.into())
+    }
+}
+
+impl ctutils::CtEq for AffinePoint {
+    fn ct_eq(&self, other: &Self) -> ctutils::Choice {
+        ConstantTimeEq::ct_eq(self, other).into()
+    }
+}
+
+impl ctutils::CtSelect for AffinePoint {
+    fn ct_select(&self, other: &Self, choice: ctutils::Choice) -> Self {
         // Not really constant time, but this is dev code
-        if choice.into() { *b } else { *a }
+        if choice.to_bool() { *other } else { *self }
     }
 }
 
@@ -613,7 +637,19 @@ impl ConstantTimeEq for ProjectivePoint {
 
 impl ConditionallySelectable for ProjectivePoint {
     fn conditional_select(a: &Self, b: &Self, choice: Choice) -> Self {
-        if choice.into() { *b } else { *a }
+        ctutils::CtSelect::ct_select(a, b, choice.into())
+    }
+}
+
+impl ctutils::CtEq for ProjectivePoint {
+    fn ct_eq(&self, other: &Self) -> ctutils::Choice {
+        ConstantTimeEq::ct_eq(self, other).into()
+    }
+}
+
+impl ctutils::CtSelect for ProjectivePoint {
+    fn ct_select(&self, other: &Self, choice: ctutils::Choice) -> Self {
+        if choice.to_bool() { *other } else { *self }
     }
 }
 


### PR DESCRIPTION
Makes it possible to use the `CtEq` and `CtSelect` traits on the `CurveArithmetic::{AffinePoint, ProjectivePoint, Scalar}` associated types.