### PR TITLE
elliptic-curve: add `Retrieve` bound to scalar

### DIFF
--- a/elliptic-curve/src/arithmetic.rs
+++ b/elliptic-curve/src/arithmetic.rs
@@ -7,6 +7,7 @@ use crate::{
     point::{AffineCoordinates, NonIdentity},
     scalar::{FromUintUnchecked, IsHigh},
 };
+use bigint::modular::Retrieve;
 use core::fmt::Debug;
 use subtle::{ConditionallySelectable, ConstantTimeEq, CtOption};
 use zeroize::DefaultIsZeroes;
@@ -89,6 +90,7 @@ pub trait CurveArithmetic: Curve {
         + PartialOrd
         + Reduce<Self::Uint>
         + Reduce<FieldBytes<Self>>
+        + Retrieve<Output = Self::Uint>
         + TryInto<NonZeroScalar<Self>, Error = Error>
         + ff::Field
         + ff::PrimeField<Repr = FieldBytes<Self>>;

--- a/elliptic-curve/src/dev.rs
+++ b/elliptic-curve/src/dev.rs
@@ -6,7 +6,7 @@
 use crate::{
     BatchNormalize, Curve, CurveArithmetic, CurveGroup, FieldBytesEncoding, PrimeCurve,
     array::typenum::U32,
-    bigint::{Limb, Odd, U256},
+    bigint::{Limb, Odd, U256, modular::Retrieve},
     ctutils,
     error::{Error, Result},
     ops::{Invert, LinearCombination, Reduce, ShrAssign},
@@ -382,6 +382,14 @@ impl Reduce<U256> for Scalar {
 impl Reduce<FieldBytes> for Scalar {
     fn reduce(_w: &FieldBytes) -> Self {
         todo!()
+    }
+}
+
+impl Retrieve for Scalar {
+    type Output = U256;
+
+    fn retrieve(&self) -> U256 {
+        self.0.to_uint()
     }
 }
 


### PR DESCRIPTION
Provides a common API for retrieving the canonical representitive for a given field element