### PR TITLE
elliptic-curve: add `dev::bench_projective!` macro

### DIFF
--- a/elliptic-curve/src/dev.rs
+++ b/elliptic-curve/src/dev.rs
@@ -10,3 +10,49 @@ pub mod mock_curve;
     note = "import these types from the `dev::mock_curves` module"
 )]
 pub use mock_curve::*;
+
+/// Write a series of `criterion`-based benchmarks for arithmetic on a projective curve point.
+#[macro_export]
+macro_rules! bench_projective {
+    ($name:ident, $desc:expr, $point_a:expr, $point_b:expr, $scalar:expr) => {
+        fn bench_add<M: ::criterion::measurement::Measurement>(
+            group: &mut ::criterion::BenchmarkGroup<'_, M>,
+        ) {
+            let x = core::hint::black_box($point_a);
+            let y = core::hint::black_box($point_b);
+            group.bench_function("add", |b| b.iter(|| x + y));
+        }
+
+        fn bench_sub<M: ::criterion::measurement::Measurement>(
+            group: &mut ::criterion::BenchmarkGroup<'_, M>,
+        ) {
+            let x = core::hint::black_box($point_a);
+            let y = core::hint::black_box($point_b);
+            group.bench_function("sub", |b| b.iter(|| x - y));
+        }
+
+        fn bench_neg<M: ::criterion::measurement::Measurement>(
+            group: &mut ::criterion::BenchmarkGroup<'_, M>,
+        ) {
+            let x = core::hint::black_box($point_a);
+            group.bench_function("neg", |b| b.iter(|| -x));
+        }
+
+        fn bench_scalar_mul<M: ::criterion::measurement::Measurement>(
+            group: &mut ::criterion::BenchmarkGroup<'_, M>,
+        ) {
+            let p = core::hint::black_box($point_a);
+            let s = core::hint::black_box($scalar);
+            group.bench_function("scalar mul", |b| b.iter(|| p * s));
+        }
+
+        pub fn $name(c: &mut ::criterion::Criterion) {
+            let mut group = c.benchmark_group($desc);
+            bench_add(&mut group);
+            bench_sub(&mut group);
+            bench_neg(&mut group);
+            bench_scalar_mul(&mut group);
+            group.finish();
+        }
+    };
+}


### PR DESCRIPTION
Writes `criterion` benchmarks for `ProjectivePoint` using a macro which has been tested with both `criterion` v0.7 and v0.8, which means we can release on the former (for MSRV 1.85 compat) and then later upgrade to to the latter in a non-breaking manner