### PR TITLE
password-hash: improve PHC `PasswordVerifier` blanket impl

### DIFF
--- a/password-hash/src/error.rs
+++ b/password-hash/src/error.rs
@@ -66,12 +66,6 @@ impl fmt::Display for Error {
 
 impl core::error::Error for Error {}
 
-impl From<core::num::ParseIntError> for Error {
-    fn from(_: core::num::ParseIntError) -> Error {
-        Error::EncodingInvalid
-    }
-}
-
 #[cfg(feature = "getrandom")]
 impl From<getrandom::Error> for Error {
     fn from(_: getrandom::Error) -> Self {


### PR DESCRIPTION
Rather than using the `FromStr` impl to parse the associated `Params` type, it instead bounds on a `TryFrom<phc::ParamsString>` impl, which provides a more explicit PHC-specific params conversion.