### PR TITLE
Bump `rand_core` to v0.10.0-rc-4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,7 +15,7 @@ dependencies = [
 
 [[package]]
 name = "aead"
-version = "0.6.0-rc.5"
+version = "0.6.0-rc.6"
 dependencies = [
  "arrayvec",
  "blobby",
@@ -99,7 +99,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cipher"
-version = "0.5.0-rc.3"
+version = "0.5.0-rc.4"
 dependencies = [
  "blobby",
  "block-buffer",
@@ -158,7 +158,7 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.0-rc.9"
+version = "0.2.0-rc.10"
 dependencies = [
  "getrandom",
  "hybrid-array",
@@ -188,7 +188,7 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.11.0-rc.5"
+version = "0.11.0-rc.6"
 dependencies = [
  "blobby",
  "block-buffer",
@@ -345,7 +345,7 @@ dependencies = [
 
 [[package]]
 name = "password-hash"
-version = "0.6.0-rc.8"
+version = "0.6.0-rc.9"
 dependencies = [
  "getrandom",
  "phc",
@@ -421,9 +421,9 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand_core"
-version = "0.10.0-rc-3"
+version = "0.10.0-rc-4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f66ee92bc15280519ef199a274fe0cafff4245d31bc39aaa31c011ad56cb1f05"
+checksum = "43bb1e3655c24705492d72208c9bacdefe07c30c14b8f7664c556a3e1953b72c"
 
 [[package]]
 name = "rustcrypto-ff"
@@ -519,7 +519,7 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "3.0.0-rc.6"
+version = "3.0.0-rc.7"
 dependencies = [
  "digest",
  "rand_core",
@@ -583,7 +583,7 @@ checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
 name = "universal-hash"
-version = "0.6.0-rc.4"
+version = "0.6.0-rc.5"
 dependencies = [
  "crypto-common",
  "subtle",

--- a/aead/Cargo.toml
+++ b/aead/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aead"
-version = "0.6.0-rc.5"
+version = "0.6.0-rc.6"
 authors = ["RustCrypto Developers"]
 edition = "2024"
 rust-version = "1.85"
@@ -16,7 +16,7 @@ such as AES-GCM as ChaCha20Poly1305, which provide a high-level API
 """
 
 [dependencies]
-crypto-common = { version = "0.2.0-rc.9", path = "../crypto-common" }
+crypto-common = { version = "0.2.0-rc.10", path = "../crypto-common" }
 inout = "0.2.2"
 
 # optional dependencies

--- a/cipher/Cargo.toml
+++ b/cipher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cipher"
-version = "0.5.0-rc.3"
+version = "0.5.0-rc.4"
 authors = ["RustCrypto Developers"]
 edition = "2024"
 rust-version = "1.85"
@@ -13,7 +13,7 @@ categories = ["cryptography", "no-std"]
 description = "Traits for describing block ciphers and stream ciphers"
 
 [dependencies]
-crypto-common = { version = "0.2.0-rc.9", path = "../crypto-common" }
+crypto-common = { version = "0.2.0-rc.10", path = "../crypto-common" }
 inout = "0.2.2"
 
 # optional dependencies

--- a/crypto-common/Cargo.toml
+++ b/crypto-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crypto-common"
-version = "0.2.0-rc.9"
+version = "0.2.0-rc.10"
 authors = ["RustCrypto Developers"]
 edition = "2024"
 rust-version = "1.85"
@@ -17,7 +17,7 @@ hybrid-array = "0.4"
 
 # optional dependencies
 getrandom = { version = "0.4.0-rc.0", optional = true, features = ["sys_rng"] }
-rand_core = { version = "0.10.0-rc-3", optional = true }
+rand_core = { version = "0.10.0-rc-4", optional = true }
 
 [features]
 getrandom = ["rand_core", "dep:getrandom"]

--- a/digest/Cargo.toml
+++ b/digest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "digest"
-version = "0.11.0-rc.5"
+version = "0.11.0-rc.6"
 authors = ["RustCrypto Developers"]
 edition = "2024"
 rust-version = "1.85"
@@ -13,7 +13,7 @@ categories = ["cryptography", "no-std"]
 description = "Traits for cryptographic hash functions and message authentication codes"
 
 [dependencies]
-crypto-common = { version = "0.2.0-rc.9", path = "../crypto-common" }
+crypto-common = { version = "0.2.0-rc.10", path = "../crypto-common" }
 
 # optional dependencies
 block-buffer = { version = "0.11", optional = true }

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -25,8 +25,8 @@ features = ["hybrid-array", "rand_core", "subtle", "zeroize"]
 [dependencies]
 array = { package = "hybrid-array", version = "0.4", default-features = false, features = ["zeroize"] }
 base16ct = "1"
-common = { package = "crypto-common", version = "0.2.0-rc.9", features = ["rand_core"], path = "../crypto-common" }
-rand_core = { version = "0.10.0-rc-3", default-features = false }
+common = { package = "crypto-common", version = "0.2.0-rc.10", features = ["rand_core"], path = "../crypto-common" }
+rand_core = { version = "0.10.0-rc-4", default-features = false }
 subtle = { version = "2.6", default-features = false }
 zeroize = { version = "1.7", default-features = false }
 

--- a/elliptic-curve/src/point/non_identity.rs
+++ b/elliptic-curve/src/point/non_identity.rs
@@ -88,9 +88,9 @@ where
     P: ConditionallySelectable + ConstantTimeEq + CurveGroup + Default,
 {
     /// Generate a random `NonIdentity<ProjectivePoint>`.
-    pub fn random<R: CryptoRng + ?Sized>(rng: &mut R) -> Self {
+    pub fn random<R: CryptoRng + ?Sized>(mut rng: &mut R) -> Self {
         loop {
-            if let Some(point) = Self::new(P::random(rng)).into() {
+            if let Some(point) = Self::new(P::random(&mut rng)).into() {
                 break point;
             }
         }

--- a/elliptic-curve/src/scalar/blinded.rs
+++ b/elliptic-curve/src/scalar/blinded.rs
@@ -38,10 +38,10 @@ where
     C: CurveArithmetic,
 {
     /// Create a new [`BlindedScalar`] from a scalar and a [`CryptoRng`].
-    pub fn new<R: CryptoRng + ?Sized>(scalar: Scalar<C>, rng: &mut R) -> Self {
+    pub fn new<R: CryptoRng + ?Sized>(scalar: Scalar<C>, mut rng: &mut R) -> Self {
         Self {
             scalar,
-            mask: Scalar::<C>::random(rng),
+            mask: Scalar::<C>::random(&mut rng),
         }
     }
 }

--- a/kem/Cargo.toml
+++ b/kem/Cargo.toml
@@ -17,8 +17,8 @@ Traits for Key Encapsulation Mechanisms (KEMs): public-key cryptosystems designe
 """
 
 [dependencies]
-crypto-common = { version = "0.2.0-rc.9", features = ["rand_core"], path = "../crypto-common" }
-rand_core = "0.10.0-rc-3"
+crypto-common = { version = "0.2.0-rc.10", features = ["rand_core"], path = "../crypto-common" }
+rand_core = "0.10.0-rc-4"
 
 [features]
 getrandom = ["crypto-common/getrandom"]

--- a/password-hash/Cargo.toml
+++ b/password-hash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "password-hash"
-version = "0.6.0-rc.8"
+version = "0.6.0-rc.9"
 authors = ["RustCrypto Developers"]
 edition = "2024"
 rust-version = "1.85"
@@ -19,7 +19,7 @@ formats (e.g. Modular Crypt Format)
 [dependencies]
 getrandom = { version = "0.4.0-rc.0", optional = true, default-features = false }
 phc = { version = "0.6.0-rc.1", optional = true, default-features = false }
-rand_core = { version = "0.10.0-rc-3", optional = true, default-features = false }
+rand_core = { version = "0.10.0-rc-4", optional = true, default-features = false }
 
 [features]
 alloc = ["phc?/alloc"]

--- a/signature/Cargo.toml
+++ b/signature/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "signature"
-version = "3.0.0-rc.6"
+version = "3.0.0-rc.7"
 authors = ["RustCrypto Developers"]
 edition = "2024"
 rust-version = "1.85"
@@ -14,7 +14,7 @@ description = "Traits for cryptographic signature algorithms (e.g. ECDSA, Ed2551
 
 [dependencies]
 digest = { version = "0.11.0-rc.5", optional = true, default-features = false }
-rand_core = { version = "0.10.0-rc-3", optional = true, default-features = false }
+rand_core = { version = "0.10.0-rc-4", optional = true, default-features = false }
 
 [features]
 alloc = []

--- a/universal-hash/Cargo.toml
+++ b/universal-hash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "universal-hash"
-version = "0.6.0-rc.4"
+version = "0.6.0-rc.5"
 authors = ["RustCrypto Developers"]
 edition = "2024"
 rust-version = "1.85"
@@ -13,7 +13,7 @@ categories = ["cryptography", "no-std"]
 description = "Traits which describe the functionality of universal hash functions (UHFs)"
 
 [dependencies]
-crypto-common = { version = "0.2.0-rc.9", path = "../crypto-common" }
+crypto-common = { version = "0.2.0-rc.10", path = "../crypto-common" }
 subtle = { version = "2.4", default-features = false }
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
It seems like the changes are backwards compatible with every crate except for `elliptic-curve`, where some reborrowing was required