### PR TITLE
elliptic-curve: fixup rand_core API use

### DIFF
--- a/elliptic-curve/src/point/non_identity.rs
+++ b/elliptic-curve/src/point/non_identity.rs
@@ -5,7 +5,7 @@
 use core::ops::{Deref, Mul};
 
 use group::{Group, GroupEncoding, prime::PrimeCurveAffine};
-use rand_core::{CryptoRng, TryCryptoRng};
+use rand_core::{CryptoRng, RngCore, TryCryptoRng, TryRngCore};
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 
 #[cfg(feature = "alloc")]
@@ -88,16 +88,18 @@ where
     P: ConditionallySelectable + ConstantTimeEq + CurveGroup + Default,
 {
     /// Generate a random `NonIdentity<ProjectivePoint>`.
-    pub fn random<R: CryptoRng + ?Sized>(mut rng: &mut R) -> Self {
+    pub fn random<R: CryptoRng + RngCore + ?Sized>(rng: &mut R) -> Self {
         loop {
-            if let Some(point) = Self::new(P::random(&mut rng)).into() {
+            if let Some(point) = Self::new(P::random(rng)).into() {
                 break point;
             }
         }
     }
 
     /// Generate a random `NonIdentity<ProjectivePoint>`.
-    pub fn try_from_rng<R: TryCryptoRng + ?Sized>(rng: &mut R) -> Result<Self, R::Error> {
+    pub fn try_from_rng<R: TryCryptoRng + TryRngCore + ?Sized>(
+        rng: &mut R,
+    ) -> Result<Self, R::Error> {
         loop {
             if let Some(point) = Self::new(P::try_from_rng(rng)?).into() {
                 break Ok(point);

--- a/elliptic-curve/src/scalar/blinded.rs
+++ b/elliptic-curve/src/scalar/blinded.rs
@@ -4,7 +4,7 @@ use super::Scalar;
 use crate::{CurveArithmetic, ops::Invert};
 use core::fmt;
 use group::ff::Field;
-use rand_core::CryptoRng;
+use rand_core::{CryptoRng, RngCore};
 use subtle::CtOption;
 use zeroize::Zeroize;
 
@@ -38,10 +38,10 @@ where
     C: CurveArithmetic,
 {
     /// Create a new [`BlindedScalar`] from a scalar and a [`CryptoRng`].
-    pub fn new<R: CryptoRng + ?Sized>(scalar: Scalar<C>, mut rng: &mut R) -> Self {
+    pub fn new<R: CryptoRng + RngCore + ?Sized>(scalar: Scalar<C>, rng: &mut R) -> Self {
         Self {
             scalar,
-            mask: Scalar::<C>::random(&mut rng),
+            mask: Scalar::<C>::random(rng),
         }
     }
 }


### PR DESCRIPTION
This fixes changes made in https://github.com/RustCrypto/traits/pull/2195

This is due to the refactor made in rand_core in https://github.com/rust-random/rand_core/pull/45 which dropped the "trait dependency" between CryptoRng and RngCore