### PR TITLE
workspace: avoid duplicate crypto-common definition when using git dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,5 +15,6 @@ members = [
 ]
 
 [patch.crates-io]
+crypto-common = { path = "crypto-common" }
 digest = { path = "digest" }
 signature = { path = "signature" }

--- a/aead/Cargo.toml
+++ b/aead/Cargo.toml
@@ -16,7 +16,7 @@ such as AES-GCM as ChaCha20Poly1305, which provide a high-level API
 """
 
 [dependencies]
-crypto-common = { version = "0.2.0-rc.10", path = "../crypto-common" }
+crypto-common = "0.2.0-rc.10"
 inout = "0.2.2"
 
 # optional dependencies

--- a/cipher/Cargo.toml
+++ b/cipher/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["cryptography", "no-std"]
 description = "Traits for describing block ciphers and stream ciphers"
 
 [dependencies]
-crypto-common = { version = "0.2.0-rc.10", path = "../crypto-common" }
+crypto-common = "0.2.0-rc.10"
 inout = "0.2.2"
 
 # optional dependencies

--- a/digest/Cargo.toml
+++ b/digest/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["cryptography", "no-std"]
 description = "Traits for cryptographic hash functions and message authentication codes"
 
 [dependencies]
-crypto-common = { version = "0.2.0-rc.10", path = "../crypto-common" }
+crypto-common = "0.2.0-rc.10"
 
 # optional dependencies
 block-buffer = { version = "0.11", optional = true }

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -25,7 +25,7 @@ features = ["hybrid-array", "rand_core", "subtle", "zeroize"]
 [dependencies]
 array = { package = "hybrid-array", version = "0.4", default-features = false, features = ["zeroize"] }
 base16ct = "1"
-common = { package = "crypto-common", version = "0.2.0-rc.10", features = ["rand_core"], path = "../crypto-common" }
+common = { package = "crypto-common", version = "0.2.0-rc.10", features = ["rand_core"] }
 rand_core = { version = "0.10.0-rc-4", default-features = false }
 subtle = { version = "2.6", default-features = false }
 zeroize = { version = "1.7", default-features = false }

--- a/kem/Cargo.toml
+++ b/kem/Cargo.toml
@@ -17,7 +17,7 @@ Traits for Key Encapsulation Mechanisms (KEMs): public-key cryptosystems designe
 """
 
 [dependencies]
-crypto-common = { version = "0.2.0-rc.10", features = ["rand_core"], path = "../crypto-common" }
+crypto-common = { version = "0.2.0-rc.10", features = ["rand_core"] }
 rand_core = "0.10.0-rc-4"
 
 [features]

--- a/universal-hash/Cargo.toml
+++ b/universal-hash/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["cryptography", "no-std"]
 description = "Traits which describe the functionality of universal hash functions (UHFs)"
 
 [dependencies]
-crypto-common = { version = "0.2.0-rc.10", path = "../crypto-common" }
+crypto-common = "0.2.0-rc.10"
 subtle = { version = "2.4", default-features = false }
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
When consuming an master release with `[patch.crates-io]` crypto-common would get duplicated because of the `path = "../` in each crate.

This moves the override to the workspace `Cargo.toml` and remove that duplicate crypto-common crate instance.