### PR TITLE
kdf: `Kdf` trait documentation improvements

### DIFF
--- a/kdf/src/lib.rs
+++ b/kdf/src/lib.rs
@@ -14,7 +14,8 @@ use core::fmt;
 ///
 /// These functions deterministically produce uniformly random outputs suitable as key material.
 ///
-/// It is recommended for types which impls this trait to also impl [`Default`] whenever possible.
+/// It is recommended for types which implement this trait to also implement [`Default`] whenever
+/// possible.
 pub trait Kdf {
     /// Writes uniformly random data suitable as key material into the entire length of `out`,
     /// derived from the following inputs:


### PR DESCRIPTION
Expands documentation and renames the second parameter (not counting `self`) to the KDF from `salt` => `non_secret`.

When impl'ing this trait for `hkdf` it became clear that, using the existing structs, `info` was the only parameter that made sense (something @newpavlov hinted at), as `salt` is the only one that can be statefully configured and accessed via `self`.

So this renames it to a much more nonspecific `non_secret` and notes in the documentation that such a parameter goes by many different names that all generally serve the same function: customizing the outputs in a non-correlated/indistinguishable manner.

It suggests consulting the algorithm-specific documentation for what parameter it actually maps to, except for `Kdf`s marked `Pbkdf` where it says it always maps to the salt.