### PR TITLE
password-hash: remove `Display`/`FromStr` bounds on `Params`

### DIFF
--- a/password-hash/Cargo.toml
+++ b/password-hash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "password-hash"
-version = "0.6.0-rc.9"
+version = "0.6.0-rc.10"
 authors = ["RustCrypto Developers"]
 edition = "2024"
 rust-version = "1.85"

--- a/password-hash/src/lib.rs
+++ b/password-hash/src/lib.rs
@@ -56,10 +56,7 @@ pub type PasswordHash = phc::PasswordHash;
 #[allow(deprecated)]
 pub type PasswordHashString = phc::PasswordHashString;
 
-use core::{
-    fmt::{Debug, Display},
-    str::FromStr,
-};
+use core::fmt::Debug;
 
 #[cfg(feature = "rand_core")]
 use rand_core::TryCryptoRng;
@@ -122,7 +119,7 @@ pub trait PasswordHasher<H> {
 /// Generic around a password hash to be returned (typically [`PasswordHash`])
 pub trait CustomizedPasswordHasher<H> {
     /// Algorithm-specific parameters.
-    type Params: Clone + Debug + Default + Display + FromStr;
+    type Params: Clone + Debug + Default;
 
     /// Compute a [`PasswordHash`] from the provided password using an
     /// explicit set of customized algorithm parameters as opposed to the


### PR DESCRIPTION
For the associated type `CustomizedPasswordHasher::Params`, removes the `Display` and `FromStr` bounds which aren't actually used: for PHC-related purposes which are the only ones implemented directly in `password-hash`, it instead requires a `TryFrom<phc::ParamsString>` impl instead.

Requiring these as well seemed like good hygiene so there's some way to serialize and parse the params as a string, but it becomes a problem when the params are shared between e.g. PHC and MCF implementations where each of them has a different params serialization so there's not one "true" serialization for which it actually makes sense to impl `Display` and `FromStr`.