### PR TITLE
crypto-common: add `KeyExport` trait

### DIFF
--- a/crypto-common/CHANGELOG.md
+++ b/crypto-common/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Sealed `BlockSizes` trait implemented for types from `U1` to `U255`
 - `Generate` trait ([#2096])
+- `KeyExport` trait ([#2213])
 
 ### Changed
 - `BlockUser::BlockSize` is now bounded by the `BlockSizes` trait
@@ -20,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [#1759]: https://github.com/RustCrypto/traits/pull/1759
 [#2096]: https://github.com/RustCrypto/traits/pull/2096
+[#2213]: https://github.com/RustCrypto/traits/pull/2213
 
 ## 0.1.7 (2025-11-12)
 ### Changed

--- a/crypto-common/src/lib.rs
+++ b/crypto-common/src/lib.rs
@@ -156,6 +156,12 @@ pub trait AlgorithmName {
     fn write_alg_name(f: &mut fmt::Formatter<'_>) -> fmt::Result;
 }
 
+/// Serialize a key to a byte array.
+pub trait KeyExport: KeySizeUser {
+    /// Serialize this key as a byte array.
+    fn to_bytes(&self) -> Key<Self>;
+}
+
 /// Types which can be initialized from a key.
 pub trait KeyInit: KeySizeUser + Sized {
     /// Create new value from fixed size key.


### PR DESCRIPTION
Adds a companion trait to `KeyInit*` for exporting a key to a byte array sized according to `KeySizeUser`.

This is needed when generating e.g. asymmetric secret keys types using the `Generate` trait and it returns an actual key type (e.g. `SigningKey`, `DecryptionKey`, `DecapsulationKey`) as opposed to its serialized byte representation.

This PR also shows another use case for it: there's currently a gap in the `kem` crate around serialization where you can generically go from `Decapsulate::encapsulator` to the associated encapsulation key for a KEM, but there is currently no generic way to serialize it.

It adds `TryKeyInit` and `KeyExport` bounds to `kem::Encapsulate`, because as the public key component we should always be able to serialize/deserialize it.

(NOTE: happy to split the `kem` changes out, that would probably be for the best, but I thought it would help illustrate the use case)