### PR TITLE
crypto-common v0.2.0-rc.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,7 +158,7 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.0-rc.11"
+version = "0.2.0-rc.12"
 dependencies = [
  "getrandom",
  "hybrid-array",

--- a/aead/Cargo.toml
+++ b/aead/Cargo.toml
@@ -16,7 +16,7 @@ such as AES-GCM as ChaCha20Poly1305, which provide a high-level API
 """
 
 [dependencies]
-crypto-common = "0.2.0-rc.11"
+crypto-common = "0.2.0-rc.12"
 inout = "0.2.2"
 
 # optional dependencies

--- a/cipher/Cargo.toml
+++ b/cipher/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["cryptography", "no-std"]
 description = "Traits for describing block ciphers and stream ciphers"
 
 [dependencies]
-crypto-common = "0.2.0-rc.11"
+crypto-common = "0.2.0-rc.12"
 inout = "0.2.2"
 
 # optional dependencies

--- a/crypto-common/Cargo.toml
+++ b/crypto-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crypto-common"
-version = "0.2.0-rc.11"
+version = "0.2.0-rc.12"
 authors = ["RustCrypto Developers"]
 edition = "2024"
 rust-version = "1.85"

--- a/digest/Cargo.toml
+++ b/digest/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["cryptography", "no-std"]
 description = "Traits for cryptographic hash functions and message authentication codes"
 
 [dependencies]
-crypto-common = "0.2.0-rc.11"
+crypto-common = "0.2.0-rc.12"
 
 # optional dependencies
 block-buffer = { version = "0.11", optional = true }

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -25,7 +25,7 @@ features = ["hybrid-array", "rand_core", "subtle", "zeroize"]
 [dependencies]
 array = { package = "hybrid-array", version = "0.4", default-features = false, features = ["zeroize"] }
 base16ct = "1"
-common = { package = "crypto-common", version = "0.2.0-rc.11", features = ["rand_core"] }
+common = { package = "crypto-common", version = "0.2.0-rc.12", features = ["rand_core"] }
 rand_core = { version = "0.10.0-rc-5", default-features = false }
 subtle = { version = "2.6", default-features = false }
 zeroize = { version = "1.7", default-features = false }

--- a/kem/Cargo.toml
+++ b/kem/Cargo.toml
@@ -17,7 +17,7 @@ Traits for Key Encapsulation Mechanisms (KEMs): public-key cryptosystems designe
 """
 
 [dependencies]
-crypto-common = { version = "0.2.0-rc.11", features = ["rand_core"] }
+crypto-common = { version = "0.2.0-rc.12", features = ["rand_core"] }
 rand_core = "0.10.0-rc-5"
 
 [features]

--- a/universal-hash/Cargo.toml
+++ b/universal-hash/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["cryptography", "no-std"]
 description = "Traits which describe the functionality of universal hash functions (UHFs)"
 
 [dependencies]
-crypto-common = "0.2.0-rc.11"
+crypto-common = "0.2.0-rc.12"
 subtle = { version = "2.4", default-features = false }
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
Includes the `KeyExport` trait