### PR TITLE
kem: additional re-exports from `crypto-common`

### DIFF
--- a/kem/Cargo.toml
+++ b/kem/Cargo.toml
@@ -17,11 +17,11 @@ Traits for Key Encapsulation Mechanisms (KEMs): public-key cryptosystems designe
 """
 
 [dependencies]
-crypto-common = { version = "0.2.0-rc.12", features = ["rand_core"] }
+common = { package = "crypto-common", version = "0.2.0-rc.12", features = ["rand_core"] }
 rand_core = "0.10.0-rc-5"
 
 [features]
-getrandom = ["crypto-common/getrandom"]
+getrandom = ["common/getrandom"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/kem/src/lib.rs
+++ b/kem/src/lib.rs
@@ -8,12 +8,14 @@
 #![forbid(unsafe_code)]
 #![warn(missing_docs, unused_qualifications, missing_debug_implementations)]
 
-pub use crypto_common::{Generate, KeyExport, KeySizeUser, TryKeyInit, typenum::consts};
+pub use common::{
+    self, Generate, InvalidKey, Key, KeyExport, KeyInit, KeySizeUser, TryKeyInit, typenum::consts,
+};
 
 use rand_core::TryCryptoRng;
 
 #[cfg(feature = "getrandom")]
-use {crypto_common::getrandom::SysRng, rand_core::TryRngCore};
+use {common::getrandom, rand_core::TryRngCore};
 
 /// Encapsulator for shared secrets.
 ///
@@ -28,8 +30,9 @@ pub trait Encapsulate<EK, SS>: TryKeyInit + KeyExport {
     /// Encapsulate a fresh shared secret generated using the system's secure RNG.
     #[cfg(feature = "getrandom")]
     fn encapsulate(&self) -> (EK, SS) {
-        let Ok(ret) = self.encapsulate_with_rng(&mut SysRng.unwrap_err());
-        ret
+        match self.encapsulate_with_rng(&mut getrandom::SysRng.unwrap_err()) {
+            Ok(ret) => ret,
+        }
     }
 }
 


### PR DESCRIPTION
- re-exports `crypto-common` itself as `common`
- re-exports `KeyInit`, which is useful for seeds
- re-exports `Key` as the type for representing serialized encapsulation and decapsulation keys
- re-exports `InvalidKey` as the error when `TryKeyInit` fails