### PR TITLE
kem v0.3.0-rc.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -292,7 +292,7 @@ version = "0.1.0-pre.1"
 
 [[package]]
 name = "kem"
-version = "0.4.0-rc.5"
+version = "0.3.0-rc.0"
 dependencies = [
  "crypto-common",
  "rand_core",

--- a/kem/Cargo.toml
+++ b/kem/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kem"
-version = "0.4.0-rc.5"
+version = "0.3.0-rc.0"
 authors = ["RustCrypto Developers"]
 edition = "2024"
 rust-version = "1.85"


### PR DESCRIPTION
See #2224 for context

It seems at some point I (accidentally?) bumped the crate's prerelease version from v0.3.0-pre.2 to v0.4.0-pre.0. We've never had a v0.3 stable release.

I'm dropping the version down to v0.3.0-rc*, and will yank the existing v0.4.0-* prereleases.