### PR TITLE
Bump `getrandom` to v0.4.0-rc.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -253,8 +253,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "getrandom"
-version = "0.4.0-rc.0"
-source = "git+https://github.com/rust-random/getrandom?branch=rand_core-v0.10.0-rc-6#fd7b890b0340d5b9ba2f043686c99945030c6184"
+version = "0.4.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74f70a332ddf75e5e5e43284304179ba02f391f82f692f030b08a8378adf3c99"
 dependencies = [
  "cfg-if",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,4 +22,3 @@ signature = { path = "signature" }
 crypto-bigint = { git = "https://github.com/RustCrypto/crypto-bigint" }
 rustcrypto-ff = { git = "https://github.com/RustCrypto/ff", branch = "rand_core/v0.10.0-rc-6" }
 rustcrypto-group = { git = "https://github.com/RustCrypto/group", branch = "rand_core/v0.10.0-rc-6" }
-getrandom = { git = "https://github.com/rust-random/getrandom", branch = "rand_core-v0.10.0-rc-6" }

--- a/crypto-common/Cargo.toml
+++ b/crypto-common/Cargo.toml
@@ -16,7 +16,7 @@ description = "Common cryptographic traits"
 hybrid-array = "0.4"
 
 # optional dependencies
-getrandom = { version = "0.4.0-rc.0", optional = true, features = ["sys_rng"] }
+getrandom = { version = "0.4.0-rc.1", optional = true, features = ["sys_rng"] }
 rand_core = { version = "0.10.0-rc-6", optional = true }
 
 [features]

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -33,7 +33,7 @@ zeroize = { version = "1.7", default-features = false }
 # optional dependencies
 digest = { version = "0.11.0-rc.4", optional = true }
 ff = { version = "=0.14.0-pre.0", package = "rustcrypto-ff", optional = true, default-features = false }
-getrandom = { version = "0.4.0-rc.0", optional = true }
+getrandom = { version = "0.4.0-rc.1", optional = true }
 group = { version = "=0.14.0-pre.0", package = "rustcrypto-group", optional = true, default-features = false }
 hkdf = { version = "0.13.0-rc.3", optional = true, default-features = false }
 hex-literal = { version = "1", optional = true }

--- a/password-hash/Cargo.toml
+++ b/password-hash/Cargo.toml
@@ -17,7 +17,7 @@ formats (e.g. Modular Crypt Format)
 """
 
 [dependencies]
-getrandom = { version = "0.4.0-rc.0", optional = true, default-features = false }
+getrandom = { version = "0.4.0-rc.1", optional = true, default-features = false }
 phc = { version = "0.6.0-rc.1", optional = true, default-features = false }
 rand_core = { version = "0.10.0-rc-6", optional = true, default-features = false }
 


### PR DESCRIPTION
Includes `rand_core` v0.10.0-rc-6 compatibility