### PR TITLE
Cut new prereleases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,7 +15,7 @@ dependencies = [
 
 [[package]]
 name = "aead"
-version = "0.6.0-rc.7"
+version = "0.6.0-rc.8"
 dependencies = [
  "arrayvec",
  "blobby",
@@ -111,7 +111,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cipher"
-version = "0.5.0-rc.5"
+version = "0.5.0-rc.6"
 dependencies = [
  "blobby",
  "block-buffer",
@@ -199,7 +199,7 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.11.0-rc.7"
+version = "0.11.0-rc.8"
 dependencies = [
  "blobby",
  "block-buffer",
@@ -361,7 +361,7 @@ version = "0.1.0-pre.1"
 
 [[package]]
 name = "kem"
-version = "0.3.0-rc.0"
+version = "0.3.0-rc.1"
 dependencies = [
  "crypto-common",
  "rand_core",
@@ -432,7 +432,7 @@ dependencies = [
 
 [[package]]
 name = "password-hash"
-version = "0.6.0-rc.10"
+version = "0.6.0-rc.11"
 dependencies = [
  "getrandom",
  "phc",
@@ -632,7 +632,7 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "3.0.0-rc.8"
+version = "3.0.0-rc.9"
 dependencies = [
  "digest",
  "rand_core",
@@ -702,7 +702,7 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "universal-hash"
-version = "0.6.0-rc.6"
+version = "0.6.0-rc.7"
 dependencies = [
  "crypto-common",
  "subtle",

--- a/aead/Cargo.toml
+++ b/aead/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aead"
-version = "0.6.0-rc.7"
+version = "0.6.0-rc.8"
 authors = ["RustCrypto Developers"]
 edition = "2024"
 rust-version = "1.85"

--- a/cipher/Cargo.toml
+++ b/cipher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cipher"
-version = "0.5.0-rc.5"
+version = "0.5.0-rc.6"
 authors = ["RustCrypto Developers"]
 edition = "2024"
 rust-version = "1.85"

--- a/digest/Cargo.toml
+++ b/digest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "digest"
-version = "0.11.0-rc.7"
+version = "0.11.0-rc.8"
 authors = ["RustCrypto Developers"]
 edition = "2024"
 rust-version = "1.85"

--- a/kem/Cargo.toml
+++ b/kem/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kem"
-version = "0.3.0-rc.0"
+version = "0.3.0-rc.1"
 authors = ["RustCrypto Developers"]
 edition = "2024"
 rust-version = "1.85"

--- a/password-hash/Cargo.toml
+++ b/password-hash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "password-hash"
-version = "0.6.0-rc.10"
+version = "0.6.0-rc.11"
 authors = ["RustCrypto Developers"]
 edition = "2024"
 rust-version = "1.85"

--- a/signature/Cargo.toml
+++ b/signature/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "signature"
-version = "3.0.0-rc.8"
+version = "3.0.0-rc.9"
 authors = ["RustCrypto Developers"]
 edition = "2024"
 rust-version = "1.85"
@@ -13,7 +13,7 @@ categories = ["cryptography", "no-std"]
 description = "Traits for cryptographic signature algorithms (e.g. ECDSA, Ed25519)"
 
 [dependencies]
-digest = { version = "0.11.0-rc.7", optional = true, default-features = false }
+digest = { version = "0.11.0-rc.8", optional = true, default-features = false }
 rand_core = { version = "0.10.0-rc-6", optional = true, default-features = false }
 
 [features]

--- a/universal-hash/Cargo.toml
+++ b/universal-hash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "universal-hash"
-version = "0.6.0-rc.6"
+version = "0.6.0-rc.7"
 authors = ["RustCrypto Developers"]
 edition = "2024"
 rust-version = "1.85"


### PR DESCRIPTION
Releases the following new versions that include an upgrade to `rand_core` v0.10.0-rc-6, which includes the `(Try)RngCore` => `(Try)Rng` rename:

- `aead` v0.6.0-rc.8
- `cipher` v0.5.0-rc.6
- `digest` v0.11.0-rc.8
- `kem` v0.3.0-rc.1
- `password-hash` v0.6.0-rc.11
- `signature` v3.0.0-rc.9
- `universal-hash` v0.6.0-rc.7

Not includes is `elliptic-curve`, which will need a new `crypto-bigint` release first.