### PR TITLE
elliptic-curve: upgrade dependencies (includes `pem*` V1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -525,8 +525,9 @@ checksum = "70765ff7112b0fb2d272d24d9a2f907fc206211304328fe58b2db15a5649ef28"
 
 [[package]]
 name = "rustcrypto-ff"
-version = "0.14.0-pre.0"
-source = "git+https://github.com/RustCrypto/ff?branch=rand_core%2Fv0.10.0-rc-6#57b8472fdad985bf574fa1007b5e3f7fa40cb4c9"
+version = "0.14.0-pre.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36fdf8f956089df8343b9479045c026932f9eb004d0f32d8497b4d133b316a66"
 dependencies = [
  "bitvec",
  "rand_core",
@@ -537,7 +538,8 @@ dependencies = [
 [[package]]
 name = "rustcrypto-ff_derive"
 version = "0.14.0-pre.0"
-source = "git+https://github.com/RustCrypto/ff?branch=rand_core%2Fv0.10.0-rc-6#57b8472fdad985bf574fa1007b5e3f7fa40cb4c9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2aef88cb4ddb3b1c83beff963f9197607dac780cc39a09f19c041dacbb0b6a5"
 dependencies = [
  "addchain",
  "num-bigint",
@@ -550,8 +552,9 @@ dependencies = [
 
 [[package]]
 name = "rustcrypto-group"
-version = "0.14.0-pre.0"
-source = "git+https://github.com/RustCrypto/group?branch=rand_core%2Fv0.10.0-rc-6#255a57629d11c69e5721037dc9c451586b219189"
+version = "0.14.0-pre.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df76d08c12814c794ffe95ac788b48081cccb607fade4ed746825d29791ce538"
 dependencies = [
  "rand_core",
  "rustcrypto-ff",
@@ -560,9 +563,9 @@ dependencies = [
 
 [[package]]
 name = "sec1"
-version = "0.8.0-rc.12"
+version = "0.8.0-rc.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b54617aeb7e34ace1a4b72ba79bb6297e48285dc0cce064dc063ddcbf538996"
+checksum = "7a2400ed44a13193820aa528a19f376c3843141a8ce96ff34b11104cc79763f2"
 dependencies = [
  "base16ct",
  "ctutils",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,3 @@ members = [
 crypto-common = { path = "crypto-common" }
 digest = { path = "digest" }
 signature = { path = "signature" }
-
-rustcrypto-ff = { git = "https://github.com/RustCrypto/ff", branch = "rand_core/v0.10.0-rc-6" }
-rustcrypto-group = { git = "https://github.com/RustCrypto/group", branch = "rand_core/v0.10.0-rc-6" }

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -31,16 +31,16 @@ subtle = { version = "2.6", default-features = false }
 zeroize = { version = "1.7", default-features = false }
 
 # optional dependencies
-digest = { version = "0.11.0-rc.4", optional = true }
-ff = { version = "=0.14.0-pre.0", package = "rustcrypto-ff", optional = true, default-features = false }
+digest = { version = "0.11.0-rc.8", optional = true }
+ff = { version = "=0.14.0-pre.1", package = "rustcrypto-ff", optional = true, default-features = false }
 getrandom = { version = "0.4.0-rc.1", optional = true }
-group = { version = "=0.14.0-pre.0", package = "rustcrypto-group", optional = true, default-features = false }
+group = { version = "=0.14.0-pre.1", package = "rustcrypto-group", optional = true, default-features = false }
 hkdf = { version = "0.13.0-rc.3", optional = true, default-features = false }
 hex-literal = { version = "1", optional = true }
 once_cell = { version = "1.21", optional = true, default-features = false }
-pem-rfc7468 = { version = "1.0.0-rc.2", optional = true, features = ["alloc"] }
-pkcs8 = { version = "0.11.0-rc.8", optional = true, default-features = false }
-sec1 = { version = "0.8.0-rc.12", optional = true, features = ["ctutils", "subtle", "zeroize"] }
+pem-rfc7468 = { version = "1", optional = true, features = ["alloc"] }
+pkcs8 = { version = "0.11.0-rc.9", optional = true, default-features = false }
+sec1 = { version = "0.8.0-rc.13", optional = true, features = ["ctutils", "subtle", "zeroize"] }
 serdect = { version = "0.4", optional = true, default-features = false, features = ["alloc"] }
 
 [dev-dependencies]


### PR DESCRIPTION
Upgrades the following dependency requirements in Cargo.toml:
- `digest` v0.11.0-rc.8
- `pem-rfc7468` v1
- `pkcs8` v0.11.0-rc.9
- `rustcrypto-ff` v0.14.0-pre.1
- `rustcrypto-group` v0.14.0-pre.1
- `sec1` v0.8.0-rc.13