### PR TITLE
Re-export `crypto_common` as `common`

### DIFF
--- a/aead/CHANGELOG.md
+++ b/aead/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- Re-export `crypto_common` as `common` ([#2237])
+
 ### Fixed
 - Minor documentation error in `AeadCore::TagSize` ([#1351])
 - Fixup `hybrid-array` migration ([#1531])
@@ -43,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#1531]: https://github.com/RustCrypto/traits/pull/1531
 [#1759]: https://github.com/RustCrypto/traits/pull/1759
 [#1999]: https://github.com/RustCrypto/traits/pull/1999
+[#2237]: https://github.com/RustCrypto/traits/pull/2237
 
 ## 0.5.2 (2023-04-02)
 ### Added

--- a/aead/Cargo.toml
+++ b/aead/Cargo.toml
@@ -16,7 +16,7 @@ such as AES-GCM as ChaCha20Poly1305, which provide a high-level API
 """
 
 [dependencies]
-crypto-common = "0.2.0-rc.13"
+common = { version = "0.2.0-rc.13", package = "crypto-common" }
 inout = "0.2.2"
 
 # optional dependencies
@@ -28,8 +28,8 @@ bytes = { version = "1", optional = true, default-features = false }
 default = ["rand_core"]
 alloc = []
 dev = ["blobby", "alloc"]
-getrandom = ["crypto-common/getrandom"]
-rand_core = ["crypto-common/rand_core"]
+getrandom = ["common/getrandom"]
+rand_core = ["common/rand_core"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/aead/src/dev.rs
+++ b/aead/src/dev.rs
@@ -3,7 +3,7 @@ use crate::{
     Aead, AeadInOut, Payload, Tag, TagPosition, array::typenum::Unsigned, inout::InOutBuf,
 };
 pub use blobby;
-use crypto_common::KeyInit;
+use common::KeyInit;
 
 /// AEAD test vector
 #[derive(Debug, Clone, Copy)]

--- a/aead/src/lib.rs
+++ b/aead/src/lib.rs
@@ -19,8 +19,8 @@ extern crate alloc;
 #[cfg(feature = "dev")]
 pub mod dev;
 
-pub use crypto_common::{
-    Key, KeyInit, KeySizeUser,
+pub use common::{
+    self, Key, KeyInit, KeySizeUser,
     array::{self, typenum::consts},
 };
 
@@ -29,11 +29,11 @@ pub use arrayvec;
 #[cfg(feature = "bytes")]
 pub use bytes;
 #[cfg(feature = "rand_core")]
-pub use crypto_common::{Generate, rand_core};
+pub use common::{Generate, rand_core};
 pub use inout;
 
+use common::array::{Array, ArraySize, typenum::Unsigned};
 use core::fmt;
-use crypto_common::array::{Array, ArraySize, typenum::Unsigned};
 use inout::InOutBuf;
 
 #[cfg(feature = "alloc")]

--- a/cipher/CHANGELOG.md
+++ b/cipher/CHANGELOG.md
@@ -8,12 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## 0.5.0 (UNRELEASED)
 ### Changed
 - Edition changed to 2024 and MSRV bumped to 1.85 ([#1759])
+- Re-export of `crypto-common` moved to `cipher::common` ([#2237])
 
 ### Fixed
 - Seeking implementation in the stream cipher wrapper ([#2052])
 
 [#1759]: https://github.com/RustCrypto/traits/pull/1759
 [#2052]: https://github.com/RustCrypto/traits/pull/2052
+[#2237]: https://github.com/RustCrypto/traits/pull/2237
 
 ## 0.4.4 (2022-03-09)
 ### Changed

--- a/cipher/Cargo.toml
+++ b/cipher/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["cryptography", "no-std"]
 description = "Traits for describing block ciphers and stream ciphers"
 
 [dependencies]
-crypto-common = "0.2.0-rc.13"
+common = { version = "0.2.0-rc.13", package = "crypto-common" }
 inout = "0.2.2"
 
 # optional dependencies
@@ -29,10 +29,10 @@ alloc = []
 block-padding = ["inout/block-padding"]
 stream-wrapper = ["block-buffer"]
 # Enable random key and IV generation methods
-getrandom = ["crypto-common/getrandom"]
-rand_core = ["crypto-common/rand_core"]
+getrandom = ["common/getrandom"]
+rand_core = ["common/rand_core"]
 dev = ["blobby"]
-zeroize = ["dep:zeroize", "crypto-common/zeroize", "block-buffer?/zeroize"]
+zeroize = ["dep:zeroize", "common/zeroize", "block-buffer?/zeroize"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/cipher/src/block.rs
+++ b/cipher/src/block.rs
@@ -12,7 +12,7 @@
 
 #[cfg(all(feature = "block-padding", feature = "alloc"))]
 use alloc::{vec, vec::Vec};
-use crypto_common::{Block, BlockSizeUser};
+use common::{Block, BlockSizeUser};
 use inout::{InOut, InOutBuf, NotEqualError};
 #[cfg(feature = "block-padding")]
 use inout::{
@@ -136,8 +136,8 @@ pub trait BlockCipherEncrypt: BlockSizeUser + Sized {
     #[inline]
     fn encrypt_padded_vec<P: Padding>(&self, msg: &[u8]) -> Vec<u8> {
         use block_padding::{NoPadding, ZeroPadding};
+        use common::typenum::Unsigned;
         use core::any::TypeId;
-        use crypto_common::typenum::Unsigned;
 
         let bs = Self::BlockSize::USIZE;
         let msg_len = msg.len();
@@ -404,8 +404,8 @@ pub trait BlockModeEncrypt: BlockSizeUser + Sized {
     #[inline]
     fn encrypt_padded_vec<P: Padding>(self, msg: &[u8]) -> Vec<u8> {
         use block_padding::{NoPadding, ZeroPadding};
+        use common::typenum::Unsigned;
         use core::any::TypeId;
-        use crypto_common::typenum::Unsigned;
 
         let bs = Self::BlockSize::USIZE;
         let msg_len = msg.len();

--- a/cipher/src/block/backends.rs
+++ b/cipher/src/block/backends.rs
@@ -1,4 +1,4 @@
-use crypto_common::{Block, BlockSizeUser, ParBlocks, ParBlocksSizeUser, typenum::Unsigned};
+use common::{Block, BlockSizeUser, ParBlocks, ParBlocksSizeUser, typenum::Unsigned};
 use inout::{InOut, InOutBuf};
 
 /// Trait implemented by block cipher mode encryption backends.

--- a/cipher/src/block/ctx.rs
+++ b/cipher/src/block/ctx.rs
@@ -1,4 +1,4 @@
-use crypto_common::{Block, BlockSizeUser, BlockSizes, typenum::Unsigned};
+use common::{Block, BlockSizeUser, BlockSizes, typenum::Unsigned};
 use inout::{InOut, InOutBuf};
 
 use super::{

--- a/cipher/src/lib.rs
+++ b/cipher/src/lib.rs
@@ -24,9 +24,9 @@ extern crate alloc;
 
 #[cfg(feature = "dev")]
 pub use blobby;
-pub use crypto_common;
+pub use common;
 #[cfg(feature = "rand_core")]
-pub use crypto_common::rand_core;
+pub use common::rand_core;
 pub use inout;
 #[cfg(feature = "block-padding")]
 pub use inout::block_padding;
@@ -43,10 +43,13 @@ pub use block::*;
 pub use stream::*;
 pub use tweak::*;
 
-pub use crypto_common::{
+pub use common::{
     AlgorithmName, Block, BlockSizeUser, InnerIvInit, InvalidLength, Iv, IvSizeUser, IvState, Key,
     KeyInit, KeyIvInit, KeySizeUser, ParBlocks, ParBlocksSizeUser,
     array::{self, Array},
     typenum::{self, consts},
 };
 pub use inout::{InOut, InOutBuf};
+
+#[deprecated(since = "0.5.0", note = "use `cipher::common` instead")]
+pub use common as crypto_common;

--- a/cipher/src/stream.rs
+++ b/cipher/src/stream.rs
@@ -4,7 +4,7 @@
 //! for ciphers implementation.
 
 use crate::block::{BlockModeDecrypt, BlockModeEncrypt};
-use crypto_common::Block;
+use common::Block;
 use inout::{InOutBuf, NotEqualError};
 
 mod core_api;

--- a/cipher/src/stream/core_api.rs
+++ b/cipher/src/stream/core_api.rs
@@ -1,6 +1,6 @@
 use super::StreamCipherError;
 use crate::{array::Array, typenum::Unsigned};
-use crypto_common::{Block, BlockSizeUser, BlockSizes, ParBlocks, ParBlocksSizeUser};
+use common::{Block, BlockSizeUser, BlockSizes, ParBlocks, ParBlocksSizeUser};
 use inout::{InOut, InOutBuf};
 
 /// Trait implemented by stream cipher backends.

--- a/cipher/src/stream/wrapper.rs
+++ b/cipher/src/stream/wrapper.rs
@@ -5,10 +5,10 @@ use super::{
     errors::StreamCipherError,
 };
 use block_buffer::ReadBuffer;
-use core::fmt;
-use crypto_common::{
+use common::{
     Iv, IvSizeUser, Key, KeyInit, KeyIvInit, KeySizeUser, array::Array, typenum::Unsigned,
 };
+use core::fmt;
 use inout::InOutBuf;
 #[cfg(feature = "zeroize")]
 use zeroize::ZeroizeOnDrop;

--- a/cipher/src/tweak.rs
+++ b/cipher/src/tweak.rs
@@ -1,7 +1,7 @@
 //! Traits used to define functionality of [tweakable block ciphers][1].
 //!
 //! [1]: https://people.eecs.berkeley.edu/~daw/papers/tweak-crypto02.pdf
-use crypto_common::{
+use common::{
     Block, BlockSizeUser,
     array::{Array, ArraySize},
 };

--- a/cipher/src/tweak/ctx.rs
+++ b/cipher/src/tweak/ctx.rs
@@ -1,4 +1,4 @@
-use crypto_common::{Block, BlockSizeUser, BlockSizes, array::ArraySize};
+use common::{Block, BlockSizeUser, BlockSizes, array::ArraySize};
 use inout::InOut;
 
 use super::{

--- a/cipher/src/tweak/zero.rs
+++ b/cipher/src/tweak/zero.rs
@@ -1,6 +1,6 @@
 use core::marker::PhantomData;
 
-use crypto_common::{Block, BlockSizes, ParBlocksSizeUser, array::ArraySize};
+use common::{Block, BlockSizes, ParBlocksSizeUser, array::ArraySize};
 
 use super::{
     TweakBlockCipherDecBackend, TweakBlockCipherDecClosure, TweakBlockCipherDecrypt,

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["cryptography", "no-std"]
 description = "Facade crate for all of the RustCrypto traits (e.g. `aead`, `cipher`, `digest`)"
 
 [dependencies]
-crypto-common = { version = "0.2.0-rc.13", path = "../crypto-common", default-features = false }
+common = { version = "0.2.0-rc.13", package = "crypto-common", path = "../crypto-common", default-features = false }
 
 # optional dependencies
 aead = { version = "0.6.0-rc.5", path = "../aead", optional = true }
@@ -26,8 +26,8 @@ universal-hash = { version = "0.6.0-rc.4", path = "../universal-hash", optional 
 
 [features]
 std = ["elliptic-curve/std"]
-getrandom = ["crypto-common/getrandom"]
-rand_core = ["crypto-common/rand_core"]
+getrandom = ["common/getrandom"]
+rand_core = ["common/rand_core"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -8,7 +8,7 @@
 #![forbid(unsafe_code)]
 #![warn(rust_2018_idioms, missing_debug_implementations)]
 
-pub use crypto_common as common;
+pub use common;
 
 #[cfg(feature = "aead")]
 pub use aead;

--- a/digest/CHANGELOG.md
+++ b/digest/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed the OID type parameter from `CtOutWrapper` ([#1799])
 - Implementations of the `SerializableState` trait ([#1953])
 - `new_test!` and `new_mac_test!` macros ([#1958])
+- Re-export of `crypto-common` moved to `digest::common` ([#2237])
 
 ### Removed
 - `Mac::new`, `Mac::new_from_slice`, and `Mac::generate_key` methods ([#1173])
@@ -36,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#1953]: https://github.com/RustCrypto/traits/pull/1953
 [#1958]: https://github.com/RustCrypto/traits/pull/1958
 [#2043]: https://github.com/RustCrypto/traits/pull/2043
+[#2237]: https://github.com/RustCrypto/traits/pull/2237
 
 ## 0.10.7 (2023-05-19)
 ### Changed

--- a/digest/Cargo.toml
+++ b/digest/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["cryptography", "no-std"]
 description = "Traits for cryptographic hash functions and message authentication codes"
 
 [dependencies]
-crypto-common = "0.2.0-rc.13"
+common = { version = "0.2.0-rc.13", package = "crypto-common" }
 
 # optional dependencies
 block-buffer = { version = "0.11", optional = true }
@@ -26,8 +26,8 @@ zeroize = { version = "1.7", optional = true, default-features = false }
 default = ["block-api"]
 block-api = ["block-buffer"] # Enable block API traits
 mac = ["subtle"] # Enable MAC traits
-rand_core = ["crypto-common/rand_core"] # Enable random key generation methods
-getrandom = ["crypto-common/getrandom", "rand_core"]
+rand_core = ["common/rand_core"] # Enable random key generation methods
+getrandom = ["common/getrandom", "rand_core"]
 oid = ["const-oid"]
 zeroize = ["dep:zeroize", "block-buffer?/zeroize"]
 alloc = []

--- a/digest/src/block_api.rs
+++ b/digest/src/block_api.rs
@@ -6,10 +6,10 @@
 use crate::{Digest, HashMarker, InvalidOutputSize};
 
 pub use block_buffer::{Eager, Lazy};
-pub use crypto_common::{AlgorithmName, Block, BlockSizeUser, OutputSizeUser, Reset};
+pub use common::{AlgorithmName, Block, BlockSizeUser, OutputSizeUser, Reset};
 
 use block_buffer::{BlockBuffer, BufferKind};
-use crypto_common::Output;
+use common::Output;
 
 mod ct_variable;
 pub use ct_variable::CtOutWrapper;

--- a/digest/src/block_api/ct_variable.rs
+++ b/digest/src/block_api/ct_variable.rs
@@ -5,13 +5,13 @@ use super::{
 #[cfg(feature = "mac")]
 use crate::MacMarker;
 use crate::{CollisionResistance, CustomizedInit, HashMarker};
-use core::{fmt, marker::PhantomData};
-use crypto_common::{
+use common::{
     Block, BlockSizeUser, OutputSizeUser,
     array::{Array, ArraySize},
     hazmat::{DeserializeStateError, SerializableState, SerializedState},
     typenum::{IsLessOrEqual, True},
 };
+use core::{fmt, marker::PhantomData};
 
 /// Wrapper around [`VariableOutputCore`] which selects output size at compile time.
 #[derive(Clone)]

--- a/digest/src/buffer_macros/fixed.rs
+++ b/digest/src/buffer_macros/fixed.rs
@@ -132,10 +132,10 @@ macro_rules! buffer_fixed {
         ($core_ty:ty);
         AlgorithmName $($trait_name:ident)*;
     ) => {
-        impl$(< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $crate::crypto_common::AlgorithmName for $name$(< $( $lt ),+ >)? {
+        impl$(< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $crate::common::AlgorithmName for $name$(< $( $lt ),+ >)? {
             #[inline]
             fn write_alg_name(f: &mut core::fmt::Formatter<'_>) -> Result<(), core::fmt::Error> {
-                <$core_ty as $crate::crypto_common::AlgorithmName>::write_alg_name(f)
+                <$core_ty as $crate::common::AlgorithmName>::write_alg_name(f)
             }
         }
 
@@ -150,7 +150,7 @@ macro_rules! buffer_fixed {
         BlockSizeUser $($trait_name:ident)*;
     ) => {
         impl$(< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $crate::block_api::BlockSizeUser for $name$(< $( $lt ),+ >)? {
-            type BlockSize = <$core_ty as $crate::crypto_common::BlockSizeUser>::BlockSize;
+            type BlockSize = <$core_ty as $crate::common::BlockSizeUser>::BlockSize;
         }
 
         $crate::buffer_fixed!(impl_inner: $name$(< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)?($core_ty); $($trait_name)*;);
@@ -334,15 +334,15 @@ macro_rules! buffer_fixed {
         ($core_ty:ty);
         InnerInit $($trait_name:ident)*;
     ) => {
-        impl$(< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $crate::crypto_common::InnerUser for $name$(< $( $lt ),+ >)? {
-            type Inner = <$core_ty as $crate::crypto_common::InnerUser>::Inner;
+        impl$(< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $crate::common::InnerUser for $name$(< $( $lt ),+ >)? {
+            type Inner = <$core_ty as $crate::common::InnerUser>::Inner;
         }
 
-        impl$(< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $crate::crypto_common::InnerInit for $name$(< $( $lt ),+ >)? {
+        impl$(< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $crate::common::InnerInit for $name$(< $( $lt ),+ >)? {
             #[inline]
             fn inner_init(inner: Self::Inner) -> Self {
                 Self {
-                    core: <$core_ty as $crate::crypto_common::InnerInit>::inner_init(inner),
+                    core: <$core_ty as $crate::common::InnerInit>::inner_init(inner),
                     buffer: Default::default(),
                 }
             }
@@ -358,8 +358,8 @@ macro_rules! buffer_fixed {
         ($core_ty:ty);
         KeyInit $($trait_name:ident)*;
     ) => {
-        impl$(< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $crate::crypto_common::KeySizeUser for $name$(< $( $lt ),+ >)? {
-            type KeySize = <$core_ty as $crate::crypto_common::KeySizeUser>::KeySize;
+        impl$(< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $crate::common::KeySizeUser for $name$(< $( $lt ),+ >)? {
+            type KeySize = <$core_ty as $crate::common::KeySizeUser>::KeySize;
         }
 
         impl$(< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $crate::KeyInit for $name$(< $( $lt ),+ >)? {
@@ -426,9 +426,9 @@ macro_rules! buffer_fixed {
         ($core_ty:ty);
         SerializableState $($trait_name:ident)*;
     ) => {
-        impl$(< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $crate::crypto_common::hazmat::SerializableState for $name$(< $( $lt ),+ >)? {
+        impl$(< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $crate::common::hazmat::SerializableState for $name$(< $( $lt ),+ >)? {
             type SerializedStateSize = $crate::typenum::Sum<
-                <$core_ty as $crate::crypto_common::hazmat::SerializableState>::SerializedStateSize,
+                <$core_ty as $crate::common::hazmat::SerializableState>::SerializedStateSize,
                 $crate::block_buffer::SerializedBufferSize<
                     <$core_ty as $crate::block_api::BlockSizeUser>::BlockSize,
                     <$core_ty as $crate::block_api::BufferKindUser>::BufferKind,
@@ -436,7 +436,7 @@ macro_rules! buffer_fixed {
             >;
 
             #[inline]
-            fn serialize(&self) -> $crate::crypto_common::hazmat::SerializedState<Self> {
+            fn serialize(&self) -> $crate::common::hazmat::SerializedState<Self> {
                 let serialized_core = self.core.serialize();
                 let serialized_buf = self.buffer.serialize();
                 serialized_core.concat(serialized_buf)
@@ -444,9 +444,9 @@ macro_rules! buffer_fixed {
 
             #[inline]
             fn deserialize(
-                serialized_state: &$crate::crypto_common::hazmat::SerializedState<Self>,
-            ) -> Result<Self, $crate::crypto_common::hazmat::DeserializeStateError> {
-                use $crate::crypto_common::hazmat::{SerializableState, DeserializeStateError};
+                serialized_state: &$crate::common::hazmat::SerializedState<Self>,
+            ) -> Result<Self, $crate::common::hazmat::DeserializeStateError> {
+                use $crate::common::hazmat::{SerializableState, DeserializeStateError};
 
                 let (serialized_core, serialized_buf) = serialized_state
                     .split_ref::<<$core_ty as SerializableState>::SerializedStateSize>();

--- a/digest/src/buffer_macros/variable.rs
+++ b/digest/src/buffer_macros/variable.rs
@@ -30,13 +30,13 @@ macro_rules! buffer_ct_variable {
             }
         }
 
-        impl<$out_size> $crate::crypto_common::AlgorithmName for $name<$out_size>
+        impl<$out_size> $crate::common::AlgorithmName for $name<$out_size>
         where
             $out_size: $crate::array::ArraySize + $crate::typenum::IsLessOrEqual<$max_size, Output = $crate::typenum::True>,
         {
             #[inline]
             fn write_alg_name(f: &mut core::fmt::Formatter<'_>) -> Result<(), core::fmt::Error> {
-                <$core_ty as $crate::crypto_common::AlgorithmName>::write_alg_name(f)
+                <$core_ty as $crate::common::AlgorithmName>::write_alg_name(f)
             }
         }
 
@@ -81,7 +81,7 @@ macro_rules! buffer_ct_variable {
         where
             $out_size: $crate::array::ArraySize + $crate::typenum::IsLessOrEqual<$max_size, Output = $crate::typenum::True>,
         {
-            type BlockSize = <$core_ty as $crate::crypto_common::BlockSizeUser>::BlockSize;
+            type BlockSize = <$core_ty as $crate::common::BlockSizeUser>::BlockSize;
         }
 
         impl<$out_size> $crate::OutputSizeUser for $name<$out_size>
@@ -172,12 +172,12 @@ macro_rules! buffer_ct_variable {
             max_size: $max_size;
         );
 
-        impl<$out_size> $crate::crypto_common::hazmat::SerializableState for $name<$out_size>
+        impl<$out_size> $crate::common::hazmat::SerializableState for $name<$out_size>
         where
             $out_size: $crate::array::ArraySize + $crate::typenum::IsLessOrEqual<$max_size, Output = $crate::typenum::True>,
         {
             type SerializedStateSize = $crate::typenum::Sum<
-                <$core_ty as $crate::crypto_common::hazmat::SerializableState>::SerializedStateSize,
+                <$core_ty as $crate::common::hazmat::SerializableState>::SerializedStateSize,
                 $crate::block_buffer::SerializedBufferSize<
                     <$core_ty as $crate::block_api::BlockSizeUser>::BlockSize,
                     <$core_ty as $crate::block_api::BufferKindUser>::BufferKind,
@@ -185,7 +185,7 @@ macro_rules! buffer_ct_variable {
             >;
 
             #[inline]
-            fn serialize(&self) -> $crate::crypto_common::hazmat::SerializedState<Self> {
+            fn serialize(&self) -> $crate::common::hazmat::SerializedState<Self> {
                 let serialized_core = self.core.serialize();
                 let serialized_buf = self.buffer.serialize();
                 serialized_core.concat(serialized_buf)
@@ -193,9 +193,9 @@ macro_rules! buffer_ct_variable {
 
             #[inline]
             fn deserialize(
-                serialized_state: &$crate::crypto_common::hazmat::SerializedState<Self>,
-            ) -> Result<Self, $crate::crypto_common::hazmat::DeserializeStateError> {
-                use $crate::crypto_common::hazmat::{SerializableState, DeserializeStateError};
+                serialized_state: &$crate::common::hazmat::SerializedState<Self>,
+            ) -> Result<Self, $crate::common::hazmat::DeserializeStateError> {
+                use $crate::common::hazmat::{SerializableState, DeserializeStateError};
 
                 let (serialized_core, serialized_buf) = serialized_state
                     .split_ref::<<$core_ty as SerializableState>::SerializedStateSize>();

--- a/digest/src/buffer_macros/xof.rs
+++ b/digest/src/buffer_macros/xof.rs
@@ -111,10 +111,10 @@ macro_rules! buffer_xof {
         impl_inner: $name:ident($core_ty:ty);
         AlgorithmName $($trait_name:ident)*;
     ) => {
-        impl $crate::crypto_common::AlgorithmName for $name {
+        impl $crate::common::AlgorithmName for $name {
             #[inline]
             fn write_alg_name(f: &mut core::fmt::Formatter<'_>) -> Result<(), core::fmt::Error> {
-                <$core_ty as $crate::crypto_common::AlgorithmName>::write_alg_name(f)
+                <$core_ty as $crate::common::AlgorithmName>::write_alg_name(f)
             }
         }
 
@@ -181,7 +181,7 @@ macro_rules! buffer_xof {
         BlockSizeUser $($trait_name:ident)*;
     ) => {
         impl $crate::block_api::BlockSizeUser for $name {
-            type BlockSize = <$core_ty as $crate::crypto_common::BlockSizeUser>::BlockSize;
+            type BlockSize = <$core_ty as $crate::common::BlockSizeUser>::BlockSize;
         }
 
         $crate::buffer_xof!(impl_inner: $name($core_ty); $($trait_name)*;);
@@ -281,9 +281,9 @@ macro_rules! buffer_xof {
         impl_inner: $name:ident($core_ty:ty);
         SerializableState $($trait_name:ident)*;
     ) => {
-        impl $crate::crypto_common::hazmat::SerializableState for $name {
+        impl $crate::common::hazmat::SerializableState for $name {
             type SerializedStateSize = $crate::typenum::Sum<
-                <$core_ty as $crate::crypto_common::hazmat::SerializableState>::SerializedStateSize,
+                <$core_ty as $crate::common::hazmat::SerializableState>::SerializedStateSize,
                 $crate::block_buffer::SerializedBufferSize<
                     <$core_ty as $crate::block_api::BlockSizeUser>::BlockSize,
                     <$core_ty as $crate::block_api::BufferKindUser>::BufferKind,
@@ -291,7 +291,7 @@ macro_rules! buffer_xof {
             >;
 
             #[inline]
-            fn serialize(&self) -> $crate::crypto_common::hazmat::SerializedState<Self> {
+            fn serialize(&self) -> $crate::common::hazmat::SerializedState<Self> {
                 let serialized_core = self.core.serialize();
                 let serialized_buf = self.buffer.serialize();
                 serialized_core.concat(serialized_buf)
@@ -299,9 +299,9 @@ macro_rules! buffer_xof {
 
             #[inline]
             fn deserialize(
-                serialized_state: &$crate::crypto_common::hazmat::SerializedState<Self>,
-            ) -> Result<Self, $crate::crypto_common::hazmat::DeserializeStateError> {
-                use $crate::crypto_common::hazmat::{SerializableState, DeserializeStateError};
+                serialized_state: &$crate::common::hazmat::SerializedState<Self>,
+            ) -> Result<Self, $crate::common::hazmat::DeserializeStateError> {
+                use $crate::common::hazmat::{SerializableState, DeserializeStateError};
 
                 let (serialized_core, serialized_buf) = serialized_state
                     .split_ref::<<$core_ty as SerializableState>::SerializedStateSize>();

--- a/digest/src/dev.rs
+++ b/digest/src/dev.rs
@@ -57,7 +57,7 @@ macro_rules! hash_serialization_test {
         fn $name() {
             use digest::{
                 Digest,
-                crypto_common::{BlockSizeUser, hazmat::SerializableState},
+                common::{BlockSizeUser, hazmat::SerializableState},
                 typenum::Unsigned,
             };
 
@@ -91,7 +91,7 @@ macro_rules! hash_rt_outsize_serialization_test {
         fn $name() {
             use digest::{
                 Digest, Update, VariableOutput,
-                crypto_common::{BlockSizeUser, hazmat::SerializableState},
+                common::{BlockSizeUser, hazmat::SerializableState},
                 typenum::Unsigned,
             };
             const HASH_OUTPUT_SIZE: usize = <$hasher>::MAX_OUTPUT_SIZE - 1;

--- a/digest/src/dev/mac.rs
+++ b/digest/src/dev/mac.rs
@@ -1,4 +1,4 @@
-use crate::{FixedOutputReset, Mac, crypto_common::KeyInit};
+use crate::{FixedOutputReset, Mac, common::KeyInit};
 
 /// Tag truncation side used in MAC tests
 #[derive(Clone, Copy, Debug)]

--- a/digest/src/digest.rs
+++ b/digest/src/digest.rs
@@ -1,5 +1,5 @@
 use super::{FixedOutput, FixedOutputReset, InvalidBufferSize, Reset, Update};
-use crypto_common::{Output, OutputSizeUser, typenum::Unsigned};
+use common::{Output, OutputSizeUser, typenum::Unsigned};
 
 #[cfg(feature = "alloc")]
 use alloc::boxed::Box;

--- a/digest/src/lib.rs
+++ b/digest/src/lib.rs
@@ -38,7 +38,7 @@
 extern crate alloc;
 
 #[cfg(feature = "rand_core")]
-pub use crypto_common::rand_core;
+pub use common::rand_core;
 
 #[cfg(feature = "zeroize")]
 pub use zeroize;
@@ -59,16 +59,16 @@ mod xof_fixed;
 
 #[cfg(feature = "block-api")]
 pub use block_buffer;
+pub use common;
 #[cfg(feature = "oid")]
 pub use const_oid;
-pub use crypto_common;
 
 #[cfg(feature = "const-oid")]
 pub use crate::digest::DynDigestWithOid;
 pub use crate::digest::{Digest, DynDigest, HashMarker};
 #[cfg(feature = "mac")]
-pub use crypto_common::{InnerInit, InvalidLength, Key, KeyInit};
-pub use crypto_common::{Output, OutputSizeUser, Reset, array, typenum, typenum::consts};
+pub use common::{InnerInit, InvalidLength, Key, KeyInit};
+pub use common::{Output, OutputSizeUser, Reset, array, typenum, typenum::consts};
 #[cfg(feature = "mac")]
 pub use mac::{CtOutput, Mac, MacError, MacMarker};
 pub use xof_fixed::XofFixedWrapper;
@@ -80,8 +80,11 @@ pub use xof_fixed::XofFixedWrapper;
 )]
 pub use block_api as core_api;
 
+#[deprecated(since = "0.11.0", note = "use `digest::common` instead")]
+pub use common as crypto_common;
+
+use common::typenum::Unsigned;
 use core::fmt;
-use crypto_common::typenum::Unsigned;
 
 /// Types which consume data with byte granularity.
 pub trait Update {

--- a/digest/src/mac.rs
+++ b/digest/src/mac.rs
@@ -1,8 +1,8 @@
 use crate::{FixedOutput, FixedOutputReset, Update};
-use crypto_common::{Output, OutputSizeUser, Reset};
+use common::{Output, OutputSizeUser, Reset};
 
+use common::typenum::Unsigned;
 use core::fmt;
-use crypto_common::typenum::Unsigned;
 use subtle::{Choice, ConstantTimeEq};
 
 /// Marker trait for Message Authentication algorithms.

--- a/digest/src/xof_fixed.rs
+++ b/digest/src/xof_fixed.rs
@@ -1,9 +1,9 @@
 use core::fmt;
 use core::marker::PhantomData;
 
-use crypto_common::array::ArraySize;
-use crypto_common::hazmat::SerializableState;
-use crypto_common::{BlockSizeUser, KeyInit, KeySizeUser, OutputSizeUser, Reset};
+use common::array::ArraySize;
+use common::hazmat::SerializableState;
+use common::{BlockSizeUser, KeyInit, KeySizeUser, OutputSizeUser, Reset};
 
 use crate::{
     CollisionResistance, CustomizedInit, ExtendableOutput, ExtendableOutputReset, FixedOutput,
@@ -67,7 +67,7 @@ impl<T: ExtendableOutput + KeySizeUser, S: ArraySize> KeySizeUser for XofFixedWr
 }
 
 impl<T: ExtendableOutput + KeyInit, S: ArraySize> KeyInit for XofFixedWrapper<T, S> {
-    fn new(key: &crypto_common::Key<Self>) -> Self {
+    fn new(key: &common::Key<Self>) -> Self {
         Self {
             hash: T::new(key),
             size: PhantomData,
@@ -92,13 +92,13 @@ impl<T: ExtendableOutput, S: ArraySize> OutputSizeUser for XofFixedWrapper<T, S>
 }
 
 impl<T: ExtendableOutput + Update, S: ArraySize> FixedOutput for XofFixedWrapper<T, S> {
-    fn finalize_into(self, out: &mut crypto_common::Output<Self>) {
+    fn finalize_into(self, out: &mut common::Output<Self>) {
         self.hash.finalize_xof_into(out);
     }
 }
 
 impl<T: ExtendableOutputReset, S: ArraySize> FixedOutputReset for XofFixedWrapper<T, S> {
-    fn finalize_into_reset(&mut self, out: &mut crypto_common::Output<Self>) {
+    fn finalize_into_reset(&mut self, out: &mut common::Output<Self>) {
         self.hash.finalize_xof_reset_into(out);
     }
 }
@@ -137,13 +137,13 @@ impl<T: ExtendableOutput + SerializableState, S: ArraySize> SerializableState
 {
     type SerializedStateSize = T::SerializedStateSize;
 
-    fn serialize(&self) -> crypto_common::hazmat::SerializedState<Self> {
+    fn serialize(&self) -> common::hazmat::SerializedState<Self> {
         self.hash.serialize()
     }
 
     fn deserialize(
-        serialized_state: &crypto_common::hazmat::SerializedState<Self>,
-    ) -> Result<Self, crypto_common::hazmat::DeserializeStateError> {
+        serialized_state: &common::hazmat::SerializedState<Self>,
+    ) -> Result<Self, common::hazmat::DeserializeStateError> {
         T::deserialize(serialized_state).map(|hash| Self {
             hash,
             size: PhantomData,

--- a/digest/tests/dummy_fixed.rs
+++ b/digest/tests/dummy_fixed.rs
@@ -8,8 +8,8 @@ mod block_api {
             AlgorithmName, Block, BlockSizeUser, Buffer, BufferKindUser, FixedOutputCore,
             UpdateCore,
         },
+        common::hazmat::{DeserializeStateError, SerializableState, SerializedState},
         consts::U8,
-        crypto_common::hazmat::{DeserializeStateError, SerializableState, SerializedState},
     };
 
     /// Core of primitive XOR hasher for testing purposes

--- a/universal-hash/CHANGELOG.md
+++ b/universal-hash/CHANGELOG.md
@@ -16,7 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump `hybrid-array` to v0.2.0-pre.8 ([#1438])
 - Bump `crypto-common` and `hybrid-array` ([#1469])
 - Bump `hybrid-array` to v0.2.0-rc.4 ([#1493])
-- bump crypto-common to v0.2.0-pre.5 ([#1496])
+- Bump `crypto-common` to v0.2.0-pre.5 ([#1496])
+- Re-export of `crypto-common` moved to `universal_hash::common` ([#2237])
 
 ### Fixed
 - Fix `missing_debug_implementations` for some crates ([#1407])
@@ -32,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#1493]: https://github.com/RustCrypto/traits/pull/1493
 [#1496]: https://github.com/RustCrypto/traits/pull/1496
 [#1759]: https://github.com/RustCrypto/traits/pull/1759
+[#2237]: https://github.com/RustCrypto/traits/pull/2237
 
 ## 0.5.1 (2023-05-19)
 ### Changed

--- a/universal-hash/Cargo.toml
+++ b/universal-hash/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["cryptography", "no-std"]
 description = "Traits which describe the functionality of universal hash functions (UHFs)"
 
 [dependencies]
-crypto-common = "0.2.0-rc.13"
+common = { version = "0.2.0-rc.13", package = "crypto-common" }
 subtle = { version = "2.4", default-features = false }
 
 [package.metadata.docs.rs]

--- a/universal-hash/src/lib.rs
+++ b/universal-hash/src/lib.rs
@@ -8,13 +8,16 @@
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, missing_debug_implementations)]
 
-pub use crypto_common::{
+pub use common::{
     self, Block, Key, KeyInit, ParBlocks, Reset, array,
     typenum::{self, consts},
 };
 
+#[deprecated(since = "0.6.0", note = "use `universal_hash::common` instead")]
+pub use common as crypto_common;
+
+use common::{BlockSizeUser, BlockSizes, ParBlocksSizeUser, array::Array};
 use core::slice;
-use crypto_common::{BlockSizeUser, BlockSizes, ParBlocksSizeUser, array::Array};
 use subtle::ConstantTimeEq;
 use typenum::Unsigned;
 


### PR DESCRIPTION
Or rather, this imports `crypto-common` as `common` using the `package = crypto-common` syntax in Cargo.toml, then re-exports it, which should hopefully make for better diagnostics.

This is shorter and more convenient for imports.

Where crates were previously exporting `crypto_common`, this adds an alias with a deprecation. Adding such an alias to `digest` was necessary to even get anything to compile.