### PR TITLE
kem: `Kem` trait for the whole algorithm type family

### DIFF
--- a/kem/src/lib.rs
+++ b/kem/src/lib.rs
@@ -47,7 +47,7 @@ pub trait Kem: Copy + Clone + Debug + Default + Eq + Ord + Send + Sync + 'static
 
     /// KEM encryption key (i.e. public key) which encrypts shared secrets into ciphertexts which
     /// can be decrypted by [`Kem::DecapsulationKey`].
-    type EncapsulationKey: Encapsulate<Self> + Clone;
+    type EncapsulationKey: Encapsulate<Self> + Clone + Debug + Eq;
 
     /// Size of the shared key/secret returned by both encapsulation and decapsulation.
     type SharedKeySize: ArraySize;
@@ -66,7 +66,7 @@ pub trait Kem: Copy + Clone + Debug + Default + Eq + Ord + Send + Sync + 'static
 
     /// Generate a random KEM keypair using the system's secure RNG.
     #[cfg(feature = "getrandom")]
-    fn generate_keypair(&self) -> (Self::DecapsulationKey, Self::EncapsulationKey) {
+    fn generate_keypair() -> (Self::DecapsulationKey, Self::EncapsulationKey) {
         Self::generate_keypair_from_rng(&mut UnwrapErr(SysRng))
     }
 }


### PR DESCRIPTION
Adds a `Kem` trait intended to be impl'd by ZSTs that describe the whole type family, including the decapsulation key, encapsulation key, and the sizes of the ciphertext and shared secret previously defined on the `KemParams` trait (which this subsumes).

The remaining traits have been changed to be generic around `K: Kem` and now use it to source their constants or relevant types.

`DecapsulationKey<K>` and `EncapsulationKey<K>` type aliases have been added, similar to the ones in `elliptic-curve`, which take care of doing `K as Kem` for you when accessing the associated types.

The design of this trait largely matches the bespoke traits that people were defining different but similarly shaped-versions of in individual crates in https://github.com/RustCrypto/KEMs

cc @rozbb

Edit: companion PR: https://github.com/RustCrypto/KEMs/pull/223