### PR TITLE
Bump `rand_core` to v0.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -519,9 +519,9 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand_core"
-version = "0.10.0-rc-6"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70765ff7112b0fb2d272d24d9a2f907fc206211304328fe58b2db15a5649ef28"
+checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
 
 [[package]]
 name = "rustcrypto-ff"

--- a/crypto-common/Cargo.toml
+++ b/crypto-common/Cargo.toml
@@ -17,7 +17,7 @@ hybrid-array = "0.4"
 
 # optional dependencies
 getrandom = { version = "0.4.0-rc.1", optional = true, features = ["sys_rng"] }
-rand_core = { version = "0.10.0-rc-6", optional = true }
+rand_core = { version = "0.10", optional = true }
 
 [features]
 getrandom = ["rand_core", "dep:getrandom"]

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -26,7 +26,7 @@ features = ["hybrid-array", "rand_core", "subtle", "zeroize"]
 array = { package = "hybrid-array", version = "0.4", default-features = false, features = ["zeroize"] }
 base16ct = "1"
 common = { package = "crypto-common", version = "0.2.0-rc.13", features = ["rand_core"] }
-rand_core = { version = "0.10.0-rc-6", default-features = false }
+rand_core = { version = "0.10", default-features = false }
 subtle = { version = "2.6", default-features = false }
 zeroize = { version = "1.7", default-features = false }
 

--- a/kem/Cargo.toml
+++ b/kem/Cargo.toml
@@ -18,7 +18,7 @@ Traits for Key Encapsulation Mechanisms (KEMs): public-key cryptosystems designe
 
 [dependencies]
 common = { package = "crypto-common", version = "0.2.0-rc.13", features = ["rand_core"] }
-rand_core = "0.10.0-rc-6"
+rand_core = "0.10"
 
 [features]
 getrandom = ["common/getrandom"]

--- a/password-hash/Cargo.toml
+++ b/password-hash/Cargo.toml
@@ -19,7 +19,7 @@ formats (e.g. Modular Crypt Format)
 [dependencies]
 getrandom = { version = "0.4.0-rc.1", optional = true, default-features = false }
 phc = { version = "0.6.0-rc.1", optional = true, default-features = false }
-rand_core = { version = "0.10.0-rc-6", optional = true, default-features = false }
+rand_core = { version = "0.10", optional = true, default-features = false }
 
 [features]
 alloc = ["phc?/alloc"]

--- a/signature/Cargo.toml
+++ b/signature/Cargo.toml
@@ -14,7 +14,7 @@ description = "Traits for cryptographic signature algorithms (e.g. ECDSA, Ed2551
 
 [dependencies]
 digest = { version = "0.11.0-rc.8", optional = true, default-features = false }
-rand_core = { version = "0.10.0-rc-6", optional = true, default-features = false }
+rand_core = { version = "0.10", optional = true, default-features = false }
 
 [features]
 alloc = []


### PR DESCRIPTION
- Release PR: https://github.com/rust-random/rand_core/pull/64
- Release notes: https://github.com/rust-random/rand_core/releases/tag/v0.10.0

Closes #2048