### PR TITLE
Cut new prereleases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,7 +15,7 @@ dependencies = [
 
 [[package]]
 name = "aead"
-version = "0.6.0-rc.8"
+version = "0.6.0-rc.9"
 dependencies = [
  "arrayvec",
  "blobby",
@@ -111,7 +111,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cipher"
-version = "0.5.0-rc.6"
+version = "0.5.0-rc.7"
 dependencies = [
  "blobby",
  "block-buffer",
@@ -170,7 +170,7 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.0-rc.13"
+version = "0.2.0-rc.14"
 dependencies = [
  "getrandom",
  "hybrid-array",
@@ -200,7 +200,7 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.11.0-rc.9"
+version = "0.11.0-rc.10"
 dependencies = [
  "blobby",
  "block-buffer",
@@ -362,7 +362,7 @@ version = "0.1.0-pre.1"
 
 [[package]]
 name = "kem"
-version = "0.3.0-rc.3"
+version = "0.3.0-rc.4"
 dependencies = [
  "crypto-common",
  "rand_core",
@@ -433,7 +433,7 @@ dependencies = [
 
 [[package]]
 name = "password-hash"
-version = "0.6.0-rc.11"
+version = "0.6.0-rc.12"
 dependencies = [
  "getrandom",
  "phc",
@@ -636,7 +636,7 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "3.0.0-rc.9"
+version = "3.0.0-rc.10"
 dependencies = [
  "digest",
  "rand_core",
@@ -706,7 +706,7 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "universal-hash"
-version = "0.6.0-rc.8"
+version = "0.6.0-rc.9"
 dependencies = [
  "crypto-common",
  "subtle",

--- a/aead/Cargo.toml
+++ b/aead/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aead"
-version = "0.6.0-rc.8"
+version = "0.6.0-rc.9"
 authors = ["RustCrypto Developers"]
 edition = "2024"
 rust-version = "1.85"
@@ -16,7 +16,7 @@ such as AES-GCM as ChaCha20Poly1305, which provide a high-level API
 """
 
 [dependencies]
-common = { version = "0.2.0-rc.13", package = "crypto-common" }
+common = { version = "0.2.0-rc.14", package = "crypto-common" }
 inout = "0.2.2"
 
 # optional dependencies

--- a/cipher/Cargo.toml
+++ b/cipher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cipher"
-version = "0.5.0-rc.6"
+version = "0.5.0-rc.7"
 authors = ["RustCrypto Developers"]
 edition = "2024"
 rust-version = "1.85"
@@ -13,7 +13,7 @@ categories = ["cryptography", "no-std"]
 description = "Traits for describing block ciphers and stream ciphers"
 
 [dependencies]
-common = { version = "0.2.0-rc.13", package = "crypto-common" }
+common = { version = "0.2.0-rc.14", package = "crypto-common" }
 inout = "0.2.2"
 
 # optional dependencies

--- a/crypto-common/CHANGELOG.md
+++ b/crypto-common/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - `BlockUser::BlockSize` is now bounded by the `BlockSizes` trait
 - Edition changed to 2024 and MSRV bumped to 1.85 ([#1759])
+- Bump `rand_core` to v0.10 ([#2250])
 
 ### Removed
 - `generate_*` and `try_generate_*` methods from KeyInit and KeyIvInit traits.
@@ -22,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#1759]: https://github.com/RustCrypto/traits/pull/1759
 [#2096]: https://github.com/RustCrypto/traits/pull/2096
 [#2213]: https://github.com/RustCrypto/traits/pull/2213
+[#2250]: https://github.com/RustCrypto/traits/pull/2250
 
 ## 0.1.7 (2025-11-12)
 ### Changed

--- a/crypto-common/Cargo.toml
+++ b/crypto-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crypto-common"
-version = "0.2.0-rc.13"
+version = "0.2.0-rc.14"
 authors = ["RustCrypto Developers"]
 edition = "2024"
 rust-version = "1.85"

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["cryptography", "no-std"]
 description = "Facade crate for all of the RustCrypto traits (e.g. `aead`, `cipher`, `digest`)"
 
 [dependencies]
-common = { version = "0.2.0-rc.13", package = "crypto-common", path = "../crypto-common", default-features = false }
+common = { version = "0.2.0-rc.14", package = "crypto-common", path = "../crypto-common", default-features = false }
 
 # optional dependencies
 aead = { version = "0.6.0-rc.5", path = "../aead", optional = true }

--- a/digest/Cargo.toml
+++ b/digest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "digest"
-version = "0.11.0-rc.9"
+version = "0.11.0-rc.10"
 authors = ["RustCrypto Developers"]
 edition = "2024"
 rust-version = "1.85"
@@ -13,7 +13,7 @@ categories = ["cryptography", "no-std"]
 description = "Traits for cryptographic hash functions and message authentication codes"
 
 [dependencies]
-common = { version = "0.2.0-rc.13", package = "crypto-common" }
+common = { version = "0.2.0-rc.14", package = "crypto-common" }
 
 # optional dependencies
 block-buffer = { version = "0.11", optional = true }

--- a/elliptic-curve/CHANGELOG.md
+++ b/elliptic-curve/CHANGELOG.md
@@ -8,9 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Edition changed to 2024 and MSRV bumped to 1.85 ([#1759])
 - Accept mixed-case hex-encoded strings in `FromStr` impl for `ScalarValue` ([#2037])
+- Bump `rand_core` to v0.10 ([#2250])
 
 [#1759]: https://github.com/RustCrypto/traits/pull/1759
 [#2037]: https://github.com/RustCrypto/traits/pull/2037
+[#2250]: https://github.com/RustCrypto/traits/pull/2250
 
 ## 0.13.8 (2023-11-18)
 ### Changed

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -25,7 +25,7 @@ features = ["hybrid-array", "rand_core", "subtle", "zeroize"]
 [dependencies]
 array = { package = "hybrid-array", version = "0.4", default-features = false, features = ["zeroize"] }
 base16ct = "1"
-common = { package = "crypto-common", version = "0.2.0-rc.13", features = ["rand_core"] }
+common = { package = "crypto-common", version = "0.2.0-rc.14", features = ["rand_core"] }
 rand_core = { version = "0.10", default-features = false }
 subtle = { version = "2.6", default-features = false }
 zeroize = { version = "1.7", default-features = false }

--- a/kem/CHANGELOG.md
+++ b/kem/CHANGELOG.md
@@ -7,8 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## 0.3.0 (UNRELEASED)
 ### Changed
 - Edition changed to 2024 and MSRV bumped to 1.85 ([#1759])
+- Bump `rand_core` to v0.10 ([#2250])
 
 [#1759]: https://github.com/RustCrypto/traits/pull/1759
+[#2250]: https://github.com/RustCrypto/traits/pull/2250
 
 ## 0.2.0 (2022-05-26)
 ### Added

--- a/kem/Cargo.toml
+++ b/kem/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kem"
-version = "0.3.0-rc.3"
+version = "0.3.0-rc.4"
 authors = ["RustCrypto Developers"]
 edition = "2024"
 rust-version = "1.85"
@@ -17,7 +17,7 @@ Traits for Key Encapsulation Mechanisms (KEMs): public-key cryptosystems designe
 """
 
 [dependencies]
-common = { package = "crypto-common", version = "0.2.0-rc.13", features = ["rand_core"] }
+common = { package = "crypto-common", version = "0.2.0-rc.14", features = ["rand_core"] }
 rand_core = "0.10"
 
 [features]

--- a/password-hash/CHANGELOG.md
+++ b/password-hash/CHANGELOG.md
@@ -8,8 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## 0.6.0 (UNRELEASED)
 ### Changed
 - Edition changed to 2024 and MSRV bumped to 1.85 ([#1759])
+- Bump `rand_core` to v0.10 ([#2250])
 
 [#1759]: https://github.com/RustCrypto/traits/pull/1759
+[#2250]: https://github.com/RustCrypto/traits/pull/2250
 
 ## 0.5.0 (2023-03-04)
 ### Added

--- a/password-hash/Cargo.toml
+++ b/password-hash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "password-hash"
-version = "0.6.0-rc.11"
+version = "0.6.0-rc.12"
 authors = ["RustCrypto Developers"]
 edition = "2024"
 rust-version = "1.85"

--- a/signature/CHANGELOG.md
+++ b/signature/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Edition changed to 2024 and MSRV bumped to 1.85 ([#1759])
+- Bump `rand_core` to v0.10 ([#2250])
 
 ### Removed
 - `std` feature - replaced with `core::error::Error`
@@ -19,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [#1448]: https://github.com/RustCrypto/traits/pull/1448
 [#1759]: https://github.com/RustCrypto/traits/pull/1759
+[#2250]: https://github.com/RustCrypto/traits/pull/2250
 
 ## 2.2.0 (2023-11-12)
 ### Changed

--- a/signature/Cargo.toml
+++ b/signature/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "signature"
-version = "3.0.0-rc.9"
+version = "3.0.0-rc.10"
 authors = ["RustCrypto Developers"]
 edition = "2024"
 rust-version = "1.85"

--- a/universal-hash/CHANGELOG.md
+++ b/universal-hash/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump `crypto-common` to v0.2.0-pre.5 ([#1496])
 - Re-export of `crypto-common` moved to `universal_hash::common` ([#2237])
 
+
 ### Fixed
 - Fix `missing_debug_implementations` for some crates ([#1407])
 

--- a/universal-hash/Cargo.toml
+++ b/universal-hash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "universal-hash"
-version = "0.6.0-rc.8"
+version = "0.6.0-rc.9"
 authors = ["RustCrypto Developers"]
 edition = "2024"
 rust-version = "1.85"
@@ -13,7 +13,7 @@ categories = ["cryptography", "no-std"]
 description = "Traits which describe the functionality of universal hash functions (UHFs)"
 
 [dependencies]
-common = { version = "0.2.0-rc.13", package = "crypto-common" }
+common = { version = "0.2.0-rc.14", package = "crypto-common" }
 subtle = { version = "2.4", default-features = false }
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
Releases the following, which (in some cases transitively) depend on the final `rand_core` v0.10 release:

- `aead` v0.6.0-rc.9
- `cipher` v0.5.0-rc.7
- `crypto-common` v0.2.0-rc.14
- `digest` v0.11.0-rc.10
- `kem` v0.3.0-rc.4
- `password-hash` v0.6.0-rc.12
- `signature` v3.0.0-rc.10
- `universal-hash` v0.6.0-rc.9

Another `elliptic-curve` release is deferred until `crypto-bigint` can be updated