### PR TITLE
elliptic-curve: bump `crypto-bigint` to v0.7.0-rc.24

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,6 +134,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
+name = "cpubits"
+version = "0.1.0-rc.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11a8c0210fa48ba3ea04ac1e9c6e72ae66009db3b1f1745635d4ff2e58eaadd0"
+
+[[package]]
 name = "critical-section"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -155,10 +161,11 @@ dependencies = [
 
 [[package]]
 name = "crypto-bigint"
-version = "0.7.0-rc.23"
+version = "0.7.0-rc.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dfcb32a163d341e53eedc34a7e319139731821bb268dc9d278ce60a527c4bd2"
+checksum = "51312f2b7fae18a144261dcc5c32b0de4bc7e50225d1c0b5a30e0312831da20d"
 dependencies = [
+ "cpubits",
  "ctutils",
  "getrandom",
  "hybrid-array",
@@ -212,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.14.0-rc.26"
+version = "0.14.0-rc.27"
 dependencies = [
  "base16ct",
  "crypto-bigint",

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elliptic-curve"
-version = "0.14.0-rc.26"
+version = "0.14.0-rc.27"
 authors = ["RustCrypto Developers"]
 edition = "2024"
 rust-version = "1.85"
@@ -18,7 +18,7 @@ and public/secret keys composed thereof.
 
 [dependencies.bigint]
 package = "crypto-bigint"
-version = "0.7.0-rc.23"
+version = "0.7.0-rc.24"
 default-features = false
 features = ["hybrid-array", "rand_core", "subtle", "zeroize"]
 
@@ -34,11 +34,11 @@ zeroize = { version = "1.7", default-features = false }
 digest = { version = "0.11.0-rc.8", optional = true }
 ff = { version = "=0.14.0-pre.1", package = "rustcrypto-ff", optional = true, default-features = false }
 group = { version = "=0.14.0-pre.1", package = "rustcrypto-group", optional = true, default-features = false }
-hkdf = { version = "0.13.0-rc.3", optional = true, default-features = false }
+hkdf = { version = "0.13.0-rc.4", optional = true, default-features = false }
 hex-literal = { version = "1", optional = true }
 once_cell = { version = "1.21", optional = true, default-features = false }
 pem-rfc7468 = { version = "1", optional = true, features = ["alloc"] }
-pkcs8 = { version = "0.11.0-rc.9", optional = true, default-features = false }
+pkcs8 = { version = "0.11.0-rc.10", optional = true, default-features = false }
 sec1 = { version = "0.8.0-rc.13", optional = true, features = ["ctutils", "subtle", "zeroize"] }
 serdect = { version = "0.4", optional = true, default-features = false, features = ["alloc"] }
 


### PR DESCRIPTION
Uses `cpubits` for 32/64-bit detection