### PR TITLE
Remove deprecated `crypto_common` re-exports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,7 +177,7 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.0-rc.14"
+version = "0.2.0-rc.15"
 dependencies = [
  "getrandom",
  "hybrid-array",

--- a/cipher/src/lib.rs
+++ b/cipher/src/lib.rs
@@ -50,6 +50,3 @@ pub use common::{
     typenum::{self, consts},
 };
 pub use inout::{InOut, InOutBuf};
-
-#[deprecated(since = "0.5.0", note = "use `cipher::common` instead")]
-pub use common as crypto_common;

--- a/digest/src/lib.rs
+++ b/digest/src/lib.rs
@@ -73,16 +73,6 @@ pub use common::{Output, OutputSizeUser, Reset, array, typenum, typenum::consts}
 pub use mac::{CtOutput, Mac, MacError, MacMarker};
 pub use xof_fixed::XofFixedWrapper;
 
-#[cfg(feature = "block-api")]
-#[deprecated(
-    since = "0.11.0",
-    note = "`digest::core_api` has been replaced by `digest::block_api`"
-)]
-pub use block_api as core_api;
-
-#[deprecated(since = "0.11.0", note = "use `digest::common` instead")]
-pub use common as crypto_common;
-
 use common::typenum::Unsigned;
 use core::fmt;
 

--- a/universal-hash/src/lib.rs
+++ b/universal-hash/src/lib.rs
@@ -13,9 +13,6 @@ pub use common::{
     typenum::{self, consts},
 };
 
-#[deprecated(since = "0.6.0", note = "use `universal_hash::common` instead")]
-pub use common as crypto_common;
-
 use common::{BlockSizeUser, BlockSizes, ParBlocksSizeUser, array::Array};
 use core::slice;
 use subtle::ConstantTimeEq;


### PR DESCRIPTION
It was re-exported as `common` from `aead`, `cipher`, and `universal-hash` in #2237, with the old name re-exported and "deprecated".

Unfortuntaely, those deprecations don't work as expected, e.g.

```rust
#![allow(unused_imports)]
use digest::core_api::EagerHash;
use digest::crypto_common::OutputSizeUser;
```

This compiles without warnings:

```console
Compiling crypto-common v0.2.0-rc.15
Compiling digest v0.11.0-rc.10
Compiling foobar v0.1.0 (/private/tmp/foobar)
Finished `test` profile [unoptimized + debuginfo] target(s) in 2.05s
```

Even if we change the re-export to use a deprecated module, ala:

```rust
#[deprecated(...)
pub mod crypto_common {
    pub use ::common::*;
}
```

...that still doesn't work. Unfortunately deprecations only seem to apply to the individual items, and not their imports or the modules they're imported through.

This removes the "deprecated" re-exports (including `digest::core_api`) since the deprecations don't work, so we might as well migrate to the new names wholesale.