### PR TITLE
Cut new prereleases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,7 +15,7 @@ dependencies = [
 
 [[package]]
 name = "aead"
-version = "0.6.0-rc.9"
+version = "0.6.0-rc.10"
 dependencies = [
  "arrayvec",
  "blobby",
@@ -111,7 +111,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cipher"
-version = "0.5.0-rc.7"
+version = "0.5.0-rc.8"
 dependencies = [
  "blobby",
  "block-buffer",
@@ -207,7 +207,7 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.11.0-rc.10"
+version = "0.11.0-rc.11"
 dependencies = [
  "blobby",
  "block-buffer",
@@ -712,7 +712,7 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "universal-hash"
-version = "0.6.0-rc.9"
+version = "0.6.0-rc.10"
 dependencies = [
  "crypto-common",
  "subtle",

--- a/aead/Cargo.toml
+++ b/aead/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aead"
-version = "0.6.0-rc.9"
+version = "0.6.0-rc.10"
 authors = ["RustCrypto Developers"]
 edition = "2024"
 rust-version = "1.85"

--- a/cipher/Cargo.toml
+++ b/cipher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cipher"
-version = "0.5.0-rc.7"
+version = "0.5.0-rc.8"
 authors = ["RustCrypto Developers"]
 edition = "2024"
 rust-version = "1.85"

--- a/digest/Cargo.toml
+++ b/digest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "digest"
-version = "0.11.0-rc.10"
+version = "0.11.0-rc.11"
 authors = ["RustCrypto Developers"]
 edition = "2024"
 rust-version = "1.85"

--- a/universal-hash/Cargo.toml
+++ b/universal-hash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "universal-hash"
-version = "0.6.0-rc.9"
+version = "0.6.0-rc.10"
 authors = ["RustCrypto Developers"]
 edition = "2024"
 rust-version = "1.85"


### PR DESCRIPTION
Releases the following, which now depend on `crypto-common` v0.2.0-rc.15 which includes a `getrandom` v0.4 bump:

- `aead` v0.6.0-rc.10
- `cipher` v0.5.0-rc.8
- `digest` v0.11.0-rc.11
- `universal-hash` v0.6.0-rc.10

Note that these releses also remove the re-exports of `crypto_common` in favor of just `common`.