### PR TITLE
elliptic-curve: rename `*EncodedPoint` => `*Sec1Point`

### DIFF
--- a/elliptic-curve/src/sec1.rs
+++ b/elliptic-curve/src/sec1.rs
@@ -17,60 +17,59 @@ pub type CompressedPoint<C> = Array<u8, CompressedPointSize<C>>;
 /// Size of a compressed elliptic curve point.
 pub type CompressedPointSize<C> = <FieldBytesSize<C> as ModulusSize>::CompressedPointSize;
 
-/// Encoded elliptic curve point sized appropriately for a given curve.
-pub type EncodedPoint<C> = ::sec1::point::EncodedPoint<FieldBytesSize<C>>;
-
 /// Encoded elliptic curve point *without* point compression.
 pub type UncompressedPoint<C> = Array<u8, UncompressedPointSize<C>>;
 
 /// Size of an uncompressed elliptic curve point.
 pub type UncompressedPointSize<C> = <FieldBytesSize<C> as ModulusSize>::UncompressedPointSize;
 
+/// SEC1-encoded elliptic curve point sized appropriately for a given curve.
+pub type Sec1Point<C> = ::sec1::point::EncodedPoint<FieldBytesSize<C>>;
+
+/// DEPRECATED: legacy name for [`Sec1Point`].
+#[deprecated(since = "0.14.0", note = "use `Sec1Point` instead")]
+pub type EncodedPoint<C> = Sec1Point<C>;
+
 /// Decode curve point using the `Octet-String-to-Elliptic-Curve-Point` conversion described in
 /// [SEC 1: Elliptic Curve Cryptography (Version 2.0)](https://www.secg.org/sec1-v2.pdf)
 /// §2.3.4 (page 11).
-pub trait FromEncodedPoint<C>
+pub trait FromSec1Point<C>
 where
     Self: Sized,
     C: Curve,
     FieldBytesSize<C>: ModulusSize,
 {
-    /// Decode curve point from a SEC1 [`EncodedPoint`].
-    fn from_encoded_point(point: &EncodedPoint<C>) -> CtOption<Self>;
+    /// Decode curve point from a SEC1 [`Sec1Point`].
+    fn from_sec1_point(point: &Sec1Point<C>) -> CtOption<Self>;
 
     /// Decode curve point from the provided SEC1 encoding (compressed, uncompressed, or
     /// identity) using the `Octet-String-to-Elliptic-Curve-Point` conversion.
     fn from_sec1_bytes(bytes: &[u8]) -> Result<Self> {
-        let point = EncodedPoint::<C>::from_bytes(bytes)?;
-        Self::from_encoded_point(&point).into_option().ok_or(Error)
+        let point = Sec1Point::<C>::from_bytes(bytes)?;
+        Self::from_sec1_point(&point).into_option().ok_or(Error)
+    }
+
+    /// DEPRECATED: legacy name for [`FromSec1Point::from_sec1_point`].
+    #[deprecated(
+        since = "0.14.0",
+        note = "use `FromSec1Point::from_sec1_point` instead"
+    )]
+    fn from_encoded_point(point: &Sec1Point<C>) -> CtOption<Self> {
+        Self::from_sec1_point(point)
     }
 }
 
 /// Encode curve point using the `Elliptic-Curve-Point-to-Octet-String` conversion described in
 /// [SEC 1: Elliptic Curve Cryptography (Version 2.0)](https://www.secg.org/sec1-v2.pdf)
 /// §2.3.3 (page 10).
-pub trait ToEncodedPoint<C>
+pub trait ToSec1Point<C>
 where
     C: Curve,
     FieldBytesSize<C>: ModulusSize,
 {
-    /// Serialize curve point as a SEC1 [`EncodedPoint`], optionally applying point compression
+    /// Serialize curve point as a SEC1 [`Sec1Point`], optionally applying point compression
     /// according to the `compress` flag.
-    fn to_encoded_point(&self, compress: bool) -> EncodedPoint<C>;
-
-    /// Serialize curve point as a [`CompressedPoint`].
-    fn to_compressed_point(&self) -> CompressedPoint<C> {
-        let mut ret = CompressedPoint::<C>::default();
-        ret.copy_from_slice(self.to_encoded_point(true).as_bytes());
-        ret
-    }
-
-    /// Serialize curve point as a [`CompressedPoint`].
-    fn to_uncompressed_point(&self) -> UncompressedPoint<C> {
-        let mut ret = UncompressedPoint::<C>::default();
-        ret.copy_from_slice(self.to_encoded_point(false).as_bytes());
-        ret
-    }
+    fn to_sec1_point(&self, compress: bool) -> Sec1Point<C>;
 
     /// Encode curve point using the `Elliptic-Curve-Point-to-Octet-String` conversion and the
     /// point compression default for this curve as specified by the [`PointCompression`] trait.
@@ -79,24 +78,81 @@ where
     where
         C: PointCompression,
     {
-        self.to_encoded_point(C::COMPRESS_POINTS).to_bytes()
+        self.to_sec1_point(C::COMPRESS_POINTS).to_bytes()
     }
+
+    /// Serialize curve point as a [`CompressedPoint`].
+    fn to_compressed_point(&self) -> CompressedPoint<C> {
+        let mut ret = CompressedPoint::<C>::default();
+        ret.copy_from_slice(self.to_sec1_point(true).as_bytes());
+        ret
+    }
+
+    /// Serialize curve point as a [`CompressedPoint`].
+    fn to_uncompressed_point(&self) -> UncompressedPoint<C> {
+        let mut ret = UncompressedPoint::<C>::default();
+        ret.copy_from_slice(self.to_sec1_point(false).as_bytes());
+        ret
+    }
+
+    /// DEPRECATED: legacy name for [`ToSec1Point::to_sec1_point`].
+    #[deprecated(since = "0.14.0", note = "use `ToSec1Point::to_sec1_point` instead")]
+    fn to_encoded_point(&self, compress: bool) -> Sec1Point<C> {
+        self.to_sec1_point(compress)
+    }
+}
+
+/// DEPRECATED: stub trait to help discover the new name for [`FromSec1Point`].
+#[deprecated(since = "0.14.0", note = "use `FromSec1Point` instead")]
+pub trait FromEncodedPoint<C>: FromSec1Point<C>
+where
+    Self: Sized,
+    C: Curve,
+    FieldBytesSize<C>: ModulusSize,
+{
+}
+
+#[allow(deprecated)]
+impl<P, C> FromEncodedPoint<C> for P
+where
+    Self: FromSec1Point<C> + Sized,
+    C: Curve,
+    FieldBytesSize<C>: ModulusSize,
+{
+}
+
+/// DEPRECATED: stub trait to help discover the new name for [`ToSec1Point`].
+#[deprecated(since = "0.14.0", note = "use `ToSec1Point` instead")]
+pub trait ToEncodedPoint<C>: ToSec1Point<C>
+where
+    C: Curve,
+    FieldBytesSize<C>: ModulusSize,
+{
+}
+
+#[allow(deprecated)]
+impl<T, C> ToEncodedPoint<C> for T
+where
+    Self: ToSec1Point<C>,
+    C: Curve,
+    FieldBytesSize<C>: ModulusSize,
+{
 }
 
 /// Trait for serializing a value to a SEC1 encoded curve point with compaction.
 ///
 /// This is intended for use with the `AffinePoint` type for a given elliptic curve.
-pub trait ToCompactEncodedPoint<C>
+pub trait ToCompactSec1Point<C>
 where
     C: Curve,
     FieldBytesSize<C>: ModulusSize,
 {
-    /// Serialize this value as a SEC1 [`EncodedPoint`], optionally applying
+    /// Serialize this value as a SEC1 [`Sec1Point`], optionally applying
     /// point compression.
-    fn to_compact_encoded_point(&self) -> CtOption<EncodedPoint<C>>;
+    fn to_compact_encoded_point(&self) -> CtOption<Sec1Point<C>>;
 }
 
-/// Validate that the given [`EncodedPoint`] represents the encoded public key
+/// Validate that the given [`Sec1Point`] represents the encoded public key
 /// value of the given secret.
 ///
 /// Curve implementations which also impl [`CurveArithmetic`] will receive
@@ -106,12 +162,12 @@ where
     Self: Curve,
     FieldBytesSize<Self>: ModulusSize,
 {
-    /// Validate that the given [`EncodedPoint`] is a valid public key for the
+    /// Validate that the given [`Sec1Point`] is a valid public key for the
     /// provided secret value.
     #[allow(unused_variables)]
     fn validate_public_key(
         secret_key: &SecretKey<Self>,
-        public_key: &EncodedPoint<Self>,
+        public_key: &Sec1Point<Self>,
     ) -> Result<()> {
         // Provide a default "always succeeds" implementation.
         // This is the intended default for curve implementations which
@@ -128,13 +184,13 @@ where
 impl<C> ValidatePublicKey for C
 where
     C: CurveArithmetic,
-    AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
+    AffinePoint<C>: FromSec1Point<C> + ToSec1Point<C>,
     FieldBytesSize<C>: ModulusSize,
 {
-    fn validate_public_key(secret_key: &SecretKey<C>, public_key: &EncodedPoint<C>) -> Result<()> {
+    fn validate_public_key(secret_key: &SecretKey<C>, public_key: &Sec1Point<C>) -> Result<()> {
         let pk = secret_key
             .public_key()
-            .to_encoded_point(public_key.is_compressed());
+            .to_sec1_point(public_key.is_compressed());
 
         if public_key == &pk {
             Ok(())

--- a/elliptic-curve/src/secret_key/pkcs8.rs
+++ b/elliptic-curve/src/secret_key/pkcs8.rs
@@ -14,7 +14,7 @@ use sec1::EcPrivateKey;
 use {
     crate::{
         AffinePoint, CurveArithmetic,
-        sec1::{FromEncodedPoint, ToEncodedPoint},
+        sec1::{FromSec1Point, ToSec1Point},
     },
     pkcs8::{
         EncodePrivateKey,
@@ -63,7 +63,7 @@ where
 impl<C> EncodePrivateKey for SecretKey<C>
 where
     C: AssociatedOid + CurveArithmetic,
-    AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
+    AffinePoint<C>: FromSec1Point<C> + ToSec1Point<C>,
     FieldBytesSize<C>: ModulusSize,
 {
     fn to_pkcs8_der(&self) -> pkcs8::Result<der::SecretDocument> {
@@ -73,7 +73,7 @@ where
         };
 
         let private_key_bytes = Zeroizing::new(self.to_bytes());
-        let public_key_bytes = self.public_key().to_encoded_point(false);
+        let public_key_bytes = self.public_key().to_sec1_point(false);
 
         let ec_private_key = Zeroizing::new(
             EcPrivateKey {

--- a/elliptic-curve/tests/pkcs8.rs
+++ b/elliptic-curve/tests/pkcs8.rs
@@ -5,7 +5,7 @@
 use elliptic_curve::{
     dev::{PublicKey, SecretKey},
     pkcs8::{DecodePrivateKey, DecodePublicKey, EncodePrivateKey},
-    sec1::ToEncodedPoint,
+    sec1::ToSec1Point,
 };
 use hex_literal::hex;
 use pkcs8::der;
@@ -43,7 +43,7 @@ fn decode_pkcs8_public_key_from_der() {
         "041CACFFB55F2F2CEFD89D89EB374B2681152452802DEEA09916068137D839CF7FC481A44492304D7EF66AC117BEFE83A8D08F155F2B52F9F618DD447029048E0F"
     );
     assert_eq!(
-        public_key.to_encoded_point(false).as_bytes(),
+        public_key.to_sec1_point(false).as_bytes(),
         &expected_sec1_point[..]
     );
 }


### PR DESCRIPTION
There are a lot of point encodings! Especially as we start to support non-prime-order curves like `ed448-goldilocks` that don't use SEC1 encoding at all, we should use a more distinctive name that actually identifies the point encoding as SEC1.

Renames the following (with deprecations):
- `EncodedPoint` => `Sec1Point`
- `FromEncodedPoint` => `FromSec1Point`
  - `FromEncodedPoint::from_encoded_point` => `::from_sec1_point`
- `ToEncodedPoint` => `ToSec1Point`
  - `ToEncodedPoint::to_encoded_point` => `::to_sec1_point`