### PR TITLE
elliptic-curve v0.14.0-rc.28

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.14.0-rc.27"
+version = "0.14.0-rc.28"
 dependencies = [
  "base16ct",
  "crypto-bigint",

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elliptic-curve"
-version = "0.14.0-rc.27"
+version = "0.14.0-rc.28"
 authors = ["RustCrypto Developers"]
 edition = "2024"
 rust-version = "1.85"


### PR DESCRIPTION
Includes `getrandom` v0.4 bump and `*EncodedPoint` => `*Sec1Point` changes