### PR TITLE
crypto-common: bump `hybrid-array` to v0.4.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -319,9 +319,9 @@ dependencies = [
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b41fb3dc24fe72c2e3a4685eed55917c2fb228851257f4a8f2d985da9443c3e5"
+checksum = "e1b229d73f5803b562cc26e4da0396c8610a4ee209f4fac8fa4f8d709166dc45"
 dependencies = [
  "subtle",
  "typenum",

--- a/crypto-common/Cargo.toml
+++ b/crypto-common/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["cryptography", "no-std"]
 description = "Common cryptographic traits"
 
 [dependencies]
-hybrid-array = "0.4"
+hybrid-array = "0.4.7"
 
 # optional dependencies
 getrandom = { version = "0.4", optional = true, features = ["sys_rng"] }


### PR DESCRIPTION
Ensures every crate depending on `crypto-common` gets the functionality of this release at a baseline (e.g. in a `minimal-versions` scenario)