### PR TITLE
crypto-common: apply workspace-level lints

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,0 +1,2 @@
+allow-unwrap-in-consts = true
+allow-unwrap-in-tests = true

--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: RustCrypto/actions/cargo-cache@master
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.87.0
+          toolchain: 1.93.0
           components: clippy
       - run: cargo clippy --all --all-features --tests -- -D warnings
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,46 @@ members = [
     "signature",
 ]
 
+[workspace.lints.clippy]
+borrow_as_ptr = "warn"
+cast_lossless = "warn"
+cast_possible_truncation = "warn"
+cast_possible_wrap = "warn"
+cast_precision_loss = "warn"
+cast_sign_loss = "warn"
+checked_conversions = "warn"
+doc_markdown = "warn"
+from_iter_instead_of_collect = "warn"
+implicit_saturating_sub = "warn"
+manual_assert = "warn"
+map_unwrap_or = "warn"
+missing_errors_doc = "warn"
+missing_panics_doc = "warn"
+mod_module_files = "warn"
+must_use_candidate = "warn"
+needless_range_loop = "allow"
+ptr_as_ptr = "warn"
+redundant_closure_for_method_calls = "warn"
+ref_as_ptr = "warn"
+return_self_not_must_use = "warn"
+semicolon_if_nothing_returned = "warn"
+trivially_copy_pass_by_ref = "warn"
+std_instead_of_alloc = "warn"
+std_instead_of_core = "warn"
+undocumented_unsafe_blocks = "warn"
+unnecessary_safety_comment = "warn"
+unwrap_in_result = "warn"
+unwrap_used = "warn"
+
+[workspace.lints.rust]
+missing_copy_implementations = "warn"
+missing_debug_implementations = "warn"
+missing_docs = "warn"
+trivial_casts = "warn"
+trivial_numeric_casts = "warn"
+unused_lifetimes = "warn"
+unused_qualifications = "warn"
+
 [patch.crates-io]
 crypto-common = { path = "crypto-common" }
 digest = { path = "digest" }

--- a/crypto-common/Cargo.toml
+++ b/crypto-common/Cargo.toml
@@ -24,5 +24,8 @@ getrandom = ["rand_core", "dep:getrandom"]
 rand_core = ["dep:rand_core"]
 zeroize = ["hybrid-array/zeroize"]
 
+[lints]
+workspace = true
+
 [package.metadata.docs.rs]
 all-features = true

--- a/crypto-common/src/generate.rs
+++ b/crypto-common/src/generate.rs
@@ -7,9 +7,13 @@ use getrandom::{SysRng, rand_core::UnwrapErr};
 /// Secure random generation.
 pub trait Generate: Sized {
     /// Generate random key using the provided [`TryCryptoRng`].
+    ///
+    /// # Errors
+    /// Returns `R::Error` in the event the provided RNG `R` experiences an internal failure.
     fn try_generate_from_rng<R: TryCryptoRng + ?Sized>(rng: &mut R) -> Result<Self, R::Error>;
 
     /// Generate random key using the provided [`CryptoRng`].
+    #[must_use]
     fn generate_from_rng<R: CryptoRng + ?Sized>(rng: &mut R) -> Self {
         let Ok(ret) = Self::try_generate_from_rng(rng);
         ret
@@ -35,6 +39,7 @@ pub trait Generate: Sized {
     ///
     /// This shouldn't happen on most modern operating systems.
     #[cfg(feature = "getrandom")]
+    #[must_use]
     fn generate() -> Self {
         Self::generate_from_rng(&mut UnwrapErr(SysRng))
     }

--- a/crypto-common/src/hazmat.rs
+++ b/crypto-common/src/hazmat.rs
@@ -1,5 +1,5 @@
 use crate::array::{
-    self, Array, ArraySize,
+    Array, ArraySize, sizes,
     typenum::{Diff, Prod, Sum, U1, U2, U4, U8, U16, Unsigned},
 };
 use core::{convert::TryInto, default::Default, fmt};
@@ -49,7 +49,11 @@ where
 
     /// Serialize and return internal state.
     fn serialize(&self) -> SerializedState<Self>;
+
     /// Create an object from serialized internal state.
+    ///
+    /// # Errors
+    /// If the serialized state could not be deserialized successfully.
     fn deserialize(serialized_state: &SerializedState<Self>)
     -> Result<Self, DeserializeStateError>;
 }
@@ -79,10 +83,10 @@ impl_seializable_state_unsigned!(u64, U8);
 impl_seializable_state_unsigned!(u128, U16);
 
 macro_rules! impl_serializable_state_u8_array {
-    ($($n: ty),*) => {
+    ($($n: ident),*) => {
         $(
-            impl SerializableState for [u8; <$n>::USIZE] {
-                type SerializedStateSize = $n;
+            impl SerializableState for [u8; sizes::$n::USIZE] {
+                type SerializedStateSize = sizes::$n;
 
                 fn serialize(&self) -> SerializedState<Self> {
                     (*self).into()
@@ -99,9 +103,9 @@ macro_rules! impl_serializable_state_u8_array {
 }
 
 macro_rules! impl_serializable_state_type_array {
-    ($type: ty, $type_size: ty, $n: ty) => {
-        impl SerializableState for [$type; <$n>::USIZE] {
-            type SerializedStateSize = Prod<$n, $type_size>;
+    ($type: ty, $type_size: ty, $n: ident) => {
+        impl SerializableState for [$type; sizes::$n::USIZE] {
+            type SerializedStateSize = Prod<sizes::$n, $type_size>;
 
             fn serialize(&self) -> SerializedState<Self> {
                 let mut serialized_state = SerializedState::<Self>::default();
@@ -118,7 +122,7 @@ macro_rules! impl_serializable_state_type_array {
             fn deserialize(
                 serialized_state: &SerializedState<Self>,
             ) -> Result<Self, DeserializeStateError> {
-                let mut array = [0; <$n>::USIZE];
+                let mut array = [0; sizes::$n::USIZE];
                 for (val, chunk) in array
                     .iter_mut()
                     .zip(serialized_state.chunks_exact(<$type_size>::USIZE))
@@ -132,7 +136,7 @@ macro_rules! impl_serializable_state_type_array {
 }
 
 macro_rules! impl_serializable_state_u16_array {
-    ($($n: ty),*) => {
+    ($($n: ident),*) => {
         $(
             impl_serializable_state_type_array!(u16, U2, $n);
         )*
@@ -140,7 +144,7 @@ macro_rules! impl_serializable_state_u16_array {
 }
 
 macro_rules! impl_serializable_state_u32_array {
-    ($($n: ty),*) => {
+    ($($n: ident),*) => {
         $(
             impl_serializable_state_type_array!(u32, U4, $n);
         )*
@@ -148,7 +152,7 @@ macro_rules! impl_serializable_state_u32_array {
 }
 
 macro_rules! impl_serializable_state_u64_array {
-    ($($n: ty),*) => {
+    ($($n: ident),*) => {
         $(
             impl_serializable_state_type_array!(u64, U8, $n);
         )*
@@ -156,7 +160,7 @@ macro_rules! impl_serializable_state_u64_array {
 }
 
 macro_rules! impl_serializable_state_u128_array {
-    ($($n: ty),*) => {
+    ($($n: ident),*) => {
         $(
             impl_serializable_state_type_array!(u128, U8, $n);
         )*
@@ -164,196 +168,196 @@ macro_rules! impl_serializable_state_u128_array {
 }
 
 impl_serializable_state_u8_array! {
-    array::typenum::U1,
-    array::typenum::U2,
-    array::typenum::U3,
-    array::typenum::U4,
-    array::typenum::U5,
-    array::typenum::U6,
-    array::typenum::U7,
-    array::typenum::U8,
-    array::typenum::U9,
-    array::typenum::U10,
-    array::typenum::U11,
-    array::typenum::U12,
-    array::typenum::U13,
-    array::typenum::U14,
-    array::typenum::U15,
-    array::typenum::U16,
-    array::typenum::U17,
-    array::typenum::U18,
-    array::typenum::U19,
-    array::typenum::U20,
-    array::typenum::U21,
-    array::typenum::U22,
-    array::typenum::U23,
-    array::typenum::U24,
-    array::typenum::U25,
-    array::typenum::U26,
-    array::typenum::U27,
-    array::typenum::U28,
-    array::typenum::U29,
-    array::typenum::U30,
-    array::typenum::U31,
-    array::typenum::U32,
-    array::typenum::U33,
-    array::typenum::U34,
-    array::typenum::U35,
-    array::typenum::U36,
-    array::typenum::U37,
-    array::typenum::U38,
-    array::typenum::U39,
-    array::typenum::U40,
-    array::typenum::U41,
-    array::typenum::U42,
-    array::typenum::U43,
-    array::typenum::U44,
-    array::typenum::U45,
-    array::typenum::U46,
-    array::typenum::U47,
-    array::typenum::U48,
-    array::typenum::U49,
-    array::typenum::U50,
-    array::typenum::U51,
-    array::typenum::U52,
-    array::typenum::U53,
-    array::typenum::U54,
-    array::typenum::U55,
-    array::typenum::U56,
-    array::typenum::U57,
-    array::typenum::U58,
-    array::typenum::U59,
-    array::typenum::U60,
-    array::typenum::U61,
-    array::typenum::U62,
-    array::typenum::U63,
-    array::typenum::U64,
-    array::typenum::U96,
-    array::typenum::U128,
-    array::typenum::U192,
-    array::typenum::U256,
-    array::typenum::U384,
-    array::typenum::U448,
-    array::typenum::U512,
-    array::typenum::U768,
-    array::typenum::U896,
-    array::typenum::U1024,
-    array::typenum::U2048,
-    array::typenum::U4096,
-    array::typenum::U8192
+    U1,
+    U2,
+    U3,
+    U4,
+    U5,
+    U6,
+    U7,
+    U8,
+    U9,
+    U10,
+    U11,
+    U12,
+    U13,
+    U14,
+    U15,
+    U16,
+    U17,
+    U18,
+    U19,
+    U20,
+    U21,
+    U22,
+    U23,
+    U24,
+    U25,
+    U26,
+    U27,
+    U28,
+    U29,
+    U30,
+    U31,
+    U32,
+    U33,
+    U34,
+    U35,
+    U36,
+    U37,
+    U38,
+    U39,
+    U40,
+    U41,
+    U42,
+    U43,
+    U44,
+    U45,
+    U46,
+    U47,
+    U48,
+    U49,
+    U50,
+    U51,
+    U52,
+    U53,
+    U54,
+    U55,
+    U56,
+    U57,
+    U58,
+    U59,
+    U60,
+    U61,
+    U62,
+    U63,
+    U64,
+    U96,
+    U128,
+    U192,
+    U256,
+    U384,
+    U448,
+    U512,
+    U768,
+    U896,
+    U1024,
+    U2048,
+    U4096,
+    U8192
 }
 
 impl_serializable_state_u16_array! {
-    array::typenum::U1,
-    array::typenum::U2,
-    array::typenum::U3,
-    array::typenum::U4,
-    array::typenum::U5,
-    array::typenum::U6,
-    array::typenum::U7,
-    array::typenum::U8,
-    array::typenum::U9,
-    array::typenum::U10,
-    array::typenum::U11,
-    array::typenum::U12,
-    array::typenum::U13,
-    array::typenum::U14,
-    array::typenum::U15,
-    array::typenum::U16,
-    array::typenum::U17,
-    array::typenum::U18,
-    array::typenum::U19,
-    array::typenum::U20,
-    array::typenum::U21,
-    array::typenum::U22,
-    array::typenum::U23,
-    array::typenum::U24,
-    array::typenum::U25,
-    array::typenum::U26,
-    array::typenum::U27,
-    array::typenum::U28,
-    array::typenum::U29,
-    array::typenum::U30,
-    array::typenum::U31,
-    array::typenum::U32,
-    array::typenum::U48,
-    array::typenum::U96,
-    array::typenum::U128,
-    array::typenum::U192,
-    array::typenum::U256,
-    array::typenum::U384,
-    array::typenum::U448,
-    array::typenum::U512,
-    array::typenum::U2048,
-    array::typenum::U4096
+    U1,
+    U2,
+    U3,
+    U4,
+    U5,
+    U6,
+    U7,
+    U8,
+    U9,
+    U10,
+    U11,
+    U12,
+    U13,
+    U14,
+    U15,
+    U16,
+    U17,
+    U18,
+    U19,
+    U20,
+    U21,
+    U22,
+    U23,
+    U24,
+    U25,
+    U26,
+    U27,
+    U28,
+    U29,
+    U30,
+    U31,
+    U32,
+    U48,
+    U96,
+    U128,
+    U192,
+    U256,
+    U384,
+    U448,
+    U512,
+    U2048,
+    U4096
 }
 
 impl_serializable_state_u32_array! {
-    array::typenum::U1,
-    array::typenum::U2,
-    array::typenum::U3,
-    array::typenum::U4,
-    array::typenum::U5,
-    array::typenum::U6,
-    array::typenum::U7,
-    array::typenum::U8,
-    array::typenum::U9,
-    array::typenum::U10,
-    array::typenum::U11,
-    array::typenum::U12,
-    array::typenum::U13,
-    array::typenum::U14,
-    array::typenum::U15,
-    array::typenum::U16,
-    array::typenum::U24,
-    array::typenum::U32,
-    array::typenum::U48,
-    array::typenum::U64,
-    array::typenum::U96,
-    array::typenum::U128,
-    array::typenum::U192,
-    array::typenum::U256,
-    array::typenum::U512,
-    array::typenum::U1024,
-    array::typenum::U2048
+    U1,
+    U2,
+    U3,
+    U4,
+    U5,
+    U6,
+    U7,
+    U8,
+    U9,
+    U10,
+    U11,
+    U12,
+    U13,
+    U14,
+    U15,
+    U16,
+    U24,
+    U32,
+    U48,
+    U64,
+    U96,
+    U128,
+    U192,
+    U256,
+    U512,
+    U1024,
+    U2048
 }
 
 impl_serializable_state_u64_array! {
-    array::typenum::U1,
-    array::typenum::U2,
-    array::typenum::U3,
-    array::typenum::U4,
-    array::typenum::U5,
-    array::typenum::U6,
-    array::typenum::U7,
-    array::typenum::U8,
-    array::typenum::U12,
-    array::typenum::U16,
-    array::typenum::U24,
-    array::typenum::U32,
-    array::typenum::U48,
-    array::typenum::U64,
-    array::typenum::U96,
-    array::typenum::U128,
-    array::typenum::U256,
-    array::typenum::U512,
-    array::typenum::U1024
+    U1,
+    U2,
+    U3,
+    U4,
+    U5,
+    U6,
+    U7,
+    U8,
+    U12,
+    U16,
+    U24,
+    U32,
+    U48,
+    U64,
+    U96,
+    U128,
+    U256,
+    U512,
+    U1024
 }
 
 impl_serializable_state_u128_array! {
-    array::typenum::U1,
-    array::typenum::U2,
-    array::typenum::U3,
-    array::typenum::U4,
-    array::typenum::U6,
-    array::typenum::U8,
-    array::typenum::U12,
-    array::typenum::U16,
-    array::typenum::U24,
-    array::typenum::U32,
-    array::typenum::U48,
-    array::typenum::U64,
-    array::typenum::U128,
-    array::typenum::U256,
-    array::typenum::U512
+    U1,
+    U2,
+    U3,
+    U4,
+    U6,
+    U8,
+    U12,
+    U16,
+    U24,
+    U32,
+    U48,
+    U64,
+    U128,
+    U256,
+    U512
 }

--- a/crypto-common/src/lib.rs
+++ b/crypto-common/src/lib.rs
@@ -64,6 +64,7 @@ pub trait BlockSizeUser {
 
     /// Return block size in bytes.
     #[inline(always)]
+    #[must_use]
     fn block_size() -> usize {
         Self::BlockSize::USIZE
     }
@@ -103,6 +104,7 @@ pub trait OutputSizeUser {
 
     /// Return output size in bytes.
     #[inline(always)]
+    #[must_use]
     fn output_size() -> usize {
         Self::OutputSize::USIZE
     }
@@ -117,6 +119,7 @@ pub trait KeySizeUser {
 
     /// Return key size in bytes.
     #[inline(always)]
+    #[must_use]
     fn key_size() -> usize {
         Self::KeySize::USIZE
     }
@@ -131,6 +134,7 @@ pub trait IvSizeUser {
 
     /// Return IV size in bytes.
     #[inline(always)]
+    #[must_use]
     fn iv_size() -> usize {
         Self::IvSize::USIZE
     }
@@ -153,6 +157,10 @@ pub trait Reset {
 /// Trait which stores algorithm name constant, used in `Debug` implementations.
 pub trait AlgorithmName {
     /// Write algorithm name into `f`.
+    ///
+    /// # Errors
+    /// `fmt::Result` is only intended for cases where an error occurs writing to the underlying
+    /// I/O stream.
     fn write_alg_name(f: &mut fmt::Formatter<'_>) -> fmt::Result;
 }
 
@@ -168,6 +176,10 @@ pub trait KeyInit: KeySizeUser + Sized {
     fn new(key: &Key<Self>) -> Self;
 
     /// Create new value from variable size key.
+    ///
+    /// # Errors
+    /// Returns [`InvalidLength`] in the event the length of the provided slice is not equal to
+    /// `<Self as KeySizeUser>::KeySize::USIZE`.
     #[inline]
     fn new_from_slice(key: &[u8]) -> Result<Self, InvalidLength> {
         <&Key<Self>>::try_from(key)
@@ -198,6 +210,9 @@ pub trait KeyIvInit: KeySizeUser + IvSizeUser + Sized {
     fn new(key: &Key<Self>, iv: &Iv<Self>) -> Self;
 
     /// Create new value from variable length key and nonce.
+    ///
+    /// # Errors
+    /// Returns [`InvalidLength`] in the event that `key` and/or `iv` are not the expected length.
     #[inline]
     fn new_from_slices(key: &[u8], iv: &[u8]) -> Result<Self, InvalidLength> {
         let key = <&Key<Self>>::try_from(key).map_err(|_| InvalidLength)?;
@@ -295,6 +310,9 @@ pub trait InnerIvInit: InnerUser + IvSizeUser + Sized {
     fn inner_iv_init(inner: Self::Inner, iv: &Iv<Self>) -> Self;
 
     /// Initialize value using `inner` and `iv` slice.
+    ///
+    /// # Errors
+    /// Returns [`InvalidLength`]  in the event that `iv` is not the expected length.
     #[inline]
     fn inner_iv_slice_init(inner: Self::Inner, iv: &[u8]) -> Result<Self, InvalidLength> {
         let iv = <&Iv<Self>>::try_from(iv).map_err(|_| InvalidLength)?;


### PR DESCRIPTION
Adds the workspace-level config from RustCrypto/utils#1411 to this repo and applies it to `crypto-common`.