### PR TITLE
ci: remove `async-signature` from publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,6 @@ on:
   push:
     tags: [
       'aead-v*',
-      'async-signature-v*',
       'cipher-v*',
       'crypto-common-v*',
       'crypto-v*',


### PR DESCRIPTION
The crate is deprecated and will not have any new releases.