### PR TITLE
cipher: use workspace level `clippy` config

### DIFF
--- a/cipher/Cargo.toml
+++ b/cipher/Cargo.toml
@@ -28,11 +28,13 @@ hex-literal = "1"
 alloc = []
 block-padding = ["inout/block-padding"]
 stream-wrapper = ["block-buffer"]
-# Enable random key and IV generation methods
 getrandom = ["common/getrandom"]
 rand_core = ["common/rand_core"]
 dev = ["blobby"]
 zeroize = ["dep:zeroize", "common/zeroize", "block-buffer?/zeroize"]
+
+[lints]
+workspace = true
 
 [package.metadata.docs.rs]
 all-features = true

--- a/cipher/src/block.rs
+++ b/cipher/src/block.rs
@@ -70,6 +70,7 @@ pub trait BlockCipherEncrypt: BlockSizeUser + Sized {
 
     /// Encrypt blocks buffer-to-buffer.
     ///
+    /// # Errors
     /// Returns [`NotEqualError`] if provided `in_blocks` and `out_blocks`
     /// have different lengths.
     #[inline]
@@ -123,6 +124,7 @@ pub trait BlockCipherDecrypt: BlockSizeUser {
 
     /// Decrypt blocks buffer-to-buffer.
     ///
+    /// # Errors
     /// Returns [`NotEqualError`] if provided `in_blocks` and `out_blocks`
     /// have different lengths.
     #[inline]
@@ -192,6 +194,7 @@ pub trait BlockModeEncrypt: BlockSizeUser + Sized {
 
     /// Encrypt blocks buffer-to-buffer.
     ///
+    /// # Errors
     /// Returns [`NotEqualError`] if provided `in_blocks` and `out_blocks`
     /// have different lengths.
     #[inline]
@@ -206,6 +209,7 @@ pub trait BlockModeEncrypt: BlockSizeUser + Sized {
 
     /// Pad input and encrypt. Returns resulting ciphertext slice.
     ///
+    /// # Errors
     /// Returns [`PadError`] if length of output buffer is not sufficient.
     #[cfg(feature = "block-padding")]
     #[inline]
@@ -223,6 +227,7 @@ pub trait BlockModeEncrypt: BlockSizeUser + Sized {
 
     /// Pad input and encrypt in-place. Returns resulting ciphertext slice.
     ///
+    /// # Errors
     /// Returns [`PadError`] if length of output buffer is not sufficient.
     #[cfg(feature = "block-padding")]
     #[inline]
@@ -233,6 +238,7 @@ pub trait BlockModeEncrypt: BlockSizeUser + Sized {
 
     /// Pad input and encrypt buffer-to-buffer. Returns resulting ciphertext slice.
     ///
+    /// # Errors
     /// Returns [`PadError`] if length of output buffer is not sufficient.
     #[cfg(feature = "block-padding")]
     #[inline]
@@ -262,12 +268,11 @@ pub trait BlockModeEncrypt: BlockSizeUser + Sized {
 
         let pad_type_id = TypeId::of::<P>();
         let buf_blocks_len = if pad_type_id == TypeId::of::<NoPadding>() {
-            if msg_len % bs != 0 {
-                panic!(
-                    "NoPadding is used with a {msg_len}‑byte message,
-                    which is not a multiple of the {bs}‑byte cipher block size"
-                );
-            }
+            assert!(
+                msg_len % bs == 0,
+                "NoPadding is used with a {msg_len}‑byte message,
+                which is not a multiple of the {bs}‑byte cipher block size"
+            );
             msg_len / bs
         } else if pad_type_id == TypeId::of::<ZeroPadding>() {
             msg_len.div_ceil(bs)
@@ -329,6 +334,7 @@ pub trait BlockModeDecrypt: BlockSizeUser + Sized {
 
     /// Decrypt blocks buffer-to-buffer.
     ///
+    /// # Errors
     /// Returns [`NotEqualError`] if provided `in_blocks` and `out_blocks`
     /// have different lengths.
     #[inline]
@@ -343,6 +349,7 @@ pub trait BlockModeDecrypt: BlockSizeUser + Sized {
 
     /// Decrypt input and unpad it. Returns resulting plaintext slice.
     ///
+    /// # Errors
     /// Returns [`block_padding::Error`] if padding is malformed or if input length is
     /// not multiple of `Self::BlockSize`.
     #[cfg(feature = "block-padding")]
@@ -361,6 +368,7 @@ pub trait BlockModeDecrypt: BlockSizeUser + Sized {
 
     /// Decrypt input and unpad it in-place. Returns resulting plaintext slice.
     ///
+    /// # Errors
     /// Returns [`block_padding::Error`] if padding is malformed or if input length is
     /// not multiple of `Self::BlockSize`.
     #[cfg(feature = "block-padding")]
@@ -372,6 +380,7 @@ pub trait BlockModeDecrypt: BlockSizeUser + Sized {
     /// Decrypt input and unpad it buffer-to-buffer. Returns resulting
     /// plaintext slice.
     ///
+    /// # Errors
     /// Returns [`block_padding::Error`] if padding is malformed or if input length is
     /// not multiple of `Self::BlockSize`.
     #[cfg(feature = "block-padding")]
@@ -393,6 +402,7 @@ pub trait BlockModeDecrypt: BlockSizeUser + Sized {
     /// Decrypt input and unpad it in a newly allocated Vec. Returns resulting
     /// plaintext `Vec`.
     ///
+    /// # Errors
     /// Returns [`block_padding::Error`] if padding is malformed or if input length is
     /// not multiple of `Self::BlockSize`.
     #[cfg(all(feature = "block-padding", feature = "alloc"))]

--- a/cipher/src/dev/block_cipher.rs
+++ b/cipher/src/dev/block_cipher.rs
@@ -1,5 +1,7 @@
 //! Development-related functionality for block ciphers
 
+#![allow(clippy::missing_errors_doc)]
+
 use crate::{Block, BlockCipherDecrypt, BlockCipherEncrypt, KeyInit};
 
 /// Block cipher test vector
@@ -24,6 +26,7 @@ fn encrypt_test_inner<C: BlockCipherEncrypt>(
         return Err("single block encryption failure");
     }
 
+    #[allow(clippy::cast_possible_truncation)]
     let mut blocks1: [Block<C>; 101] = core::array::from_fn(|i| {
         let mut block = pt.clone();
         block[0] ^= i as u8;
@@ -54,6 +57,7 @@ fn decrypt_test_inner<C: BlockCipherDecrypt>(
         return Err("single block decryption failure");
     }
 
+    #[allow(clippy::cast_possible_truncation)]
     let mut blocks1: [Block<C>; 101] = core::array::from_fn(|i| {
         let mut block = ct.clone();
         block[0] ^= i as u8;

--- a/cipher/src/dev/block_mode.rs
+++ b/cipher/src/dev/block_mode.rs
@@ -1,5 +1,7 @@
 //! Development-related functionality for block modes
 
+#![allow(clippy::missing_errors_doc)]
+
 use crate::{BlockModeDecrypt, BlockModeEncrypt, KeyIvInit, inout::InOutBuf};
 
 const MAX_MSG_LEN: usize = 1 << 12;

--- a/cipher/src/dev/stream.rs
+++ b/cipher/src/dev/stream.rs
@@ -1,4 +1,7 @@
 //! Development-related functionality for stream ciphers
+
+#![allow(clippy::missing_errors_doc)]
+
 use crate::{KeyIvInit, StreamCipher};
 
 /// Stream cipher test vector

--- a/cipher/src/lib.rs
+++ b/cipher/src/lib.rs
@@ -5,12 +5,6 @@
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg"
 )]
-#![warn(
-    missing_docs,
-    rust_2018_idioms,
-    unused_lifetimes,
-    missing_debug_implementations
-)]
 #![forbid(unsafe_code)]
 
 #[cfg(feature = "alloc")]

--- a/cipher/src/stream/core_api.rs
+++ b/cipher/src/stream/core_api.rs
@@ -92,7 +92,8 @@ pub trait StreamCipherCore: BlockSizeUser + Sized {
     ///
     /// Consumes cipher since it may consume the final keystream block only partially.
     ///
-    /// Returns an error if the number of remaining blocks is not sufficient
+    /// # Errors
+    /// Returns [`StreamCipherError`] if the number of remaining blocks is not sufficient
     /// for processing of the input data.
     #[inline]
     fn try_apply_keystream_partial(
@@ -138,7 +139,8 @@ pub trait StreamCipherCore: BlockSizeUser + Sized {
     /// input data.
     #[inline]
     fn apply_keystream_partial(self, buf: InOutBuf<'_, '_, u8>) {
-        self.try_apply_keystream_partial(buf).unwrap()
+        self.try_apply_keystream_partial(buf)
+            .expect("number of remaining blocks insufficient");
     }
 }
 

--- a/cipher/src/stream/wrapper.rs
+++ b/cipher/src/stream/wrapper.rs
@@ -108,6 +108,7 @@ impl<T: StreamCipherCore> StreamCipher for StreamCipherCoreWrapper<T> {
 }
 
 impl<T: StreamCipherSeekCore> StreamCipherSeek for StreamCipherCoreWrapper<T> {
+    #[allow(clippy::unwrap_in_result)]
     fn try_current_pos<SN: SeekNum>(&self) -> Result<SN, OverflowError> {
         let pos = u8::try_from(self.buffer.get_pos())
             .expect("buffer position is always smaller than 256");
@@ -175,8 +176,8 @@ impl<T: StreamCipherCore + ZeroizeOnDrop> ZeroizeOnDrop for StreamCipherCoreWrap
 // Assert that `ReadBuffer` implements `ZeroizeOnDrop`
 #[cfg(feature = "zeroize")]
 const _: () = {
-    #[allow(dead_code)]
+    #[allow(dead_code, trivial_casts)]
     fn check_buffer<BS: crate::array::ArraySize>(v: &ReadBuffer<BS>) {
-        let _ = v as &dyn crate::zeroize::ZeroizeOnDrop;
+        let _ = v as &dyn ZeroizeOnDrop;
     }
 };

--- a/cipher/src/tweak/zero.rs
+++ b/cipher/src/tweak/zero.rs
@@ -65,7 +65,7 @@ where
         self.f.call(&BackendWrapper {
             backend,
             _pd: PhantomData,
-        })
+        });
     }
 }
 
@@ -78,7 +78,7 @@ where
         self.f.call(&BackendWrapper {
             backend,
             _pd: PhantomData,
-        })
+        });
     }
 }
 

--- a/cipher/tests/stream.rs
+++ b/cipher/tests/stream.rs
@@ -1,3 +1,5 @@
+//! Stream cipher tests.
+
 use cipher::{
     BlockSizeUser, IvSizeUser, KeyIvInit, KeySizeUser, ParBlocksSizeUser, StreamCipherBackend,
     StreamCipherClosure, StreamCipherCore, StreamCipherSeekCore,
@@ -9,6 +11,8 @@ const KEY: [u8; 4] = hex!("00010203");
 const IV: [u8; 4] = hex!("04050607");
 
 /// Core of dummy insecure stream cipher.
+#[derive(Debug)]
+#[allow(missing_copy_implementations)]
 pub struct DummyStreamCipherCore {
     key_iv: u64,
     pos: u64,


### PR DESCRIPTION
Enables the workspace-level config added in #2270 and fixes violations