### PR TITLE
kem v0.3.0-rc.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -378,7 +378,7 @@ version = "0.1.0"
 
 [[package]]
 name = "kem"
-version = "0.3.0-rc.4"
+version = "0.3.0-rc.5"
 dependencies = [
  "crypto-common",
  "rand_core",

--- a/kem/Cargo.toml
+++ b/kem/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kem"
-version = "0.3.0-rc.4"
+version = "0.3.0-rc.5"
 authors = ["RustCrypto Developers"]
 edition = "2024"
 rust-version = "1.85"


### PR DESCRIPTION
Includes `Decapsulate`/`Encapsulate` changes from #2282

This should hopefully be the last `.rc` before a final stable release, as I'm otherwise happy with the API now