### PR TITLE
kem v0.3.0-rc.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -378,7 +378,7 @@ version = "0.1.0"
 
 [[package]]
 name = "kem"
-version = "0.3.0-rc.5"
+version = "0.3.0-rc.6"
 dependencies = [
  "crypto-common",
  "rand_core",

--- a/kem/Cargo.toml
+++ b/kem/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kem"
-version = "0.3.0-rc.5"
+version = "0.3.0-rc.6"
 authors = ["RustCrypto Developers"]
 edition = "2024"
 rust-version = "1.85"


### PR DESCRIPTION
One more release for the `FromSeed` trait (#2284), but this should really hopefully be it, with every part of KEMs as a construction now finally covered