### PR TITLE
aead: remove broken dyn-compatibility tests

### DIFF
--- a/aead/src/lib.rs
+++ b/aead/src/lib.rs
@@ -484,17 +484,3 @@ impl<const N: usize> Buffer for arrayvec::ArrayVec<u8, N> {
         arrayvec::ArrayVec::truncate(self, len);
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    /// Ensure that `Aead` is `dyn`-compatible
-    #[cfg(feature = "alloc")]
-    #[allow(dead_code)]
-    type DynAead<N, T> = dyn Aead<NonceSize = N, TagSize = T>;
-
-    /// Ensure that `AeadInOut` is `dyn`-compatible
-    #[allow(dead_code)]
-    type DynAeadInOut<N, T> = dyn AeadInOut<NonceSize = N, TagSize = T>;
-}


### PR DESCRIPTION
The "tests" fail on Nightly and did nothing on existing stable toolchains. It looks like specifying prefix using associated constants completely breaks dyn-compatibility since it's currently impossible to pin associated constant in the same way as we do with associated types.

I will open a separate issue to discuss how to fix dyn-compatibility.