### PR TITLE
refactor: eliminate byte round-trip in NonZeroScalar to ScalarValue conversion

### DIFF
--- a/elliptic-curve/src/scalar/nonzero.rs
+++ b/elliptic-curve/src/scalar/nonzero.rs
@@ -212,7 +212,7 @@ where
     C: CurveArithmetic,
 {
     fn from(scalar: &NonZeroScalar<C>) -> ScalarValue<C> {
-        ScalarValue::from_bytes(&scalar.to_repr()).unwrap()
+        scalar.scalar.into()
     }
 }
 


### PR DESCRIPTION
The `From<&NonZeroScalar<C>>` for `ScalarValue<C>` implementation was converting through a byte representation: `to_repr` -> `from_bytes`, which performs unnecessary encode-decode-validate steps.

Since `CurveArithmetic::Scalar` already has `Into<ScalarValue<Self>>` bound, use it directly instead: `scalar.scalar.into()`. This removes the  intermediate `FieldBytes` round-trip and redundant range check.

before: 
<img width="958" height="607" alt="image" src="https://github.com/user-attachments/assets/96d1a926-583d-4c33-af32-2abf393f9170" />

after: 
<img width="969" height="592" alt="image" src="https://github.com/user-attachments/assets/9254c2b3-27db-4994-89cc-f99339d86033" />

