### PR TITLE
elliptic-curve: optimize ScalarValue parsing by using from_bytes directly

### DIFF
--- a/elliptic-curve/src/scalar/value.rs
+++ b/elliptic-curve/src/scalar/value.rs
@@ -451,7 +451,7 @@ where
     fn from_str(hex: &str) -> Result<Self> {
         let mut bytes = FieldBytes::<C>::default();
         base16ct::mixed::decode(hex, &mut bytes)?;
-        Self::from_slice(&bytes)
+        Self::from_bytes(&bytes).into_option().ok_or(Error)
     }
 }
 
@@ -479,6 +479,8 @@ where
     {
         let mut bytes = FieldBytes::<C>::default();
         serdect::array::deserialize_hex_or_bin(&mut bytes, deserializer)?;
-        Self::from_slice(&bytes).map_err(|_| de::Error::custom("scalar out of range"))
+        Self::from_bytes(&bytes)
+            .into_option()
+            .ok_or_else(|| de::Error::custom("scalar out of range"))
     }
 }


### PR DESCRIPTION
Previously, FromStr and Deserialize impls for ScalarValue were calling from_slice(&bytes) even though bytes was already a FieldBytes<C> array.
This caused unnecessary runtime length checks via Array::try_from(), which always succeeds for fixed-size arrays.
 
Change both impls to use from_bytes(&bytes).into_option().ok_or(...) directly, eliminating the redundant check and aligning with the pattern used in NonZeroScalar and SecretKey.