### PR TITLE
digest: use `dep:` for `block-buffer` and `const-oid`

### DIFF
--- a/digest/Cargo.toml
+++ b/digest/Cargo.toml
@@ -27,14 +27,14 @@ sha2 = "0.11.0-rc.5"
 
 [features]
 default = ["block-api"]
-block-api = ["block-buffer"] # Enable block API traits
+alloc = []
+block-api = ["dep:block-buffer"] # Enable block API traits
+dev = ["blobby"]
+getrandom = ["common/getrandom", "rand_core"]
 mac = ["dep:ctutils"] # Enable MAC traits
 rand_core = ["common/rand_core"] # Enable random key generation methods
-getrandom = ["common/getrandom", "rand_core"]
-oid = ["const-oid"]
+oid = ["dep:const-oid"]
 zeroize = ["dep:zeroize", "block-buffer?/zeroize"]
-alloc = []
-dev = ["blobby"]
 
 [lints]
 workspace = true

--- a/digest/src/digest.rs
+++ b/digest/src/digest.rs
@@ -3,7 +3,7 @@ use common::{Output, OutputSizeUser, typenum::Unsigned};
 
 #[cfg(feature = "alloc")]
 use alloc::boxed::Box;
-#[cfg(feature = "const-oid")]
+#[cfg(feature = "oid")]
 use const_oid::DynAssociatedOid;
 
 /// Marker trait for cryptographic hash functions.
@@ -231,8 +231,8 @@ impl Clone for Box<dyn DynDigest> {
 }
 
 /// Convenience wrapper trait around [DynDigest] and [DynAssociatedOid].
-#[cfg(feature = "const-oid")]
+#[cfg(feature = "oid")]
 pub trait DynDigestWithOid: DynDigest + DynAssociatedOid {}
 
-#[cfg(feature = "const-oid")]
+#[cfg(feature = "oid")]
 impl<T: DynDigest + DynAssociatedOid> DynDigestWithOid for T {}

--- a/digest/src/lib.rs
+++ b/digest/src/lib.rs
@@ -63,7 +63,7 @@ pub use common;
 #[cfg(feature = "oid")]
 pub use const_oid;
 
-#[cfg(feature = "const-oid")]
+#[cfg(feature = "oid")]
 pub use crate::digest::DynDigestWithOid;
 pub use crate::digest::{Digest, DynDigest, HashMarker};
 #[cfg(feature = "mac")]


### PR DESCRIPTION
These were previously implicitly features, even though the actual features that activate them are `block-api` and `oid` respectively.

This commit makes them just dependencies so they have no associated crate features except `block-api` and `oid`.