### PR TITLE
aead: remove lints from `lib.rs`

### DIFF
--- a/aead/src/lib.rs
+++ b/aead/src/lib.rs
@@ -6,12 +6,6 @@
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg"
 )]
 #![forbid(unsafe_code)]
-#![warn(
-    clippy::unwrap_used,
-    missing_docs,
-    rust_2018_idioms,
-    missing_debug_implementations
-)]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;


### PR DESCRIPTION
These are being sourced from the workspace-level as of #2306