### PR TITLE
digest: add blanket-impls feature to gate blanket Digest impl

### DIFF
--- a/digest/Cargo.toml
+++ b/digest/Cargo.toml
@@ -26,9 +26,10 @@ zeroize = { version = "1.7", optional = true, default-features = false }
 sha2 = "0.11.0-rc.5"
 
 [features]
-default = ["block-api"]
+default = ["block-api", "blanket-impls"]
 alloc = []
 block-api = ["dep:block-buffer"] # Enable block API traits
+blanket-impls = [] # Enable blanket implementations of Digest and other traits
 dev = ["blobby"]
 getrandom = ["common/getrandom", "rand_core"]
 mac = ["dep:ctutils"] # Enable MAC traits

--- a/digest/src/digest.rs
+++ b/digest/src/digest.rs
@@ -56,6 +56,7 @@ pub trait Digest: OutputSizeUser {
     fn digest(data: impl AsRef<[u8]>) -> Output<Self>;
 }
 
+#[cfg(feature = "blanket-impls")]
 impl<D: FixedOutput + Default + Update + HashMarker> Digest for D {
     #[inline]
     fn new() -> Self {


### PR DESCRIPTION
## Summary

This PR adds a `blanket-impls` feature flag (enabled by default) to the `digest` crate that gates the blanket implementation:

```rust
impl<D: FixedOutput + Default + Update + HashMarker> Digest for D { ... }
```

## Motivation

I am working on a formally verified hash function and want to implement the `Digest` trait for it. For formal verification, it is desirable to express the hasher as a single pure function rather than splitting it across the `Update` + `FixedOutput` trait hierarchy, as the incremental update model does not map cleanly to the verification model.

Currently this is impossible due to coherence: the always-present blanket impl conflicts with any manual `Digest` implementation at compile time, with no way to opt out.

Gating the blanket impl behind a feature flag unblocks this use case. Crates that need a manual implementation can opt out with `default-features = false`, while all existing users are unaffected.

## Compatibility

Non-breaking. The feature is on by default, so existing users and downstream crates are unaffected.