### PR TITLE
aead: bump `bytes` dependency to v1.11.1

### DIFF
--- a/aead/Cargo.toml
+++ b/aead/Cargo.toml
@@ -22,7 +22,7 @@ inout = "0.2.2"
 # optional dependencies
 arrayvec = { version = "0.7", optional = true, default-features = false }
 blobby = { version = "0.4", optional = true }
-bytes = { version = "1", optional = true, default-features = false }
+bytes = { version = "1.11.1", optional = true, default-features = false }
 
 [features]
 default = ["rand_core"]


### PR DESCRIPTION
The lower versions are subject to [RUSTSEC-2026-0007], which results in a warning from deps.rs.

[RUSTSEC-2026-0007]: https://rustsec.org/advisories/RUSTSEC-2026-0007.html