### PR TITLE
universal-hash: enable and fix workspace-level lints

### DIFF
--- a/universal-hash/Cargo.toml
+++ b/universal-hash/Cargo.toml
@@ -16,5 +16,8 @@ description = "Traits which describe the functionality of universal hash functio
 common = { version = "0.2", package = "crypto-common" }
 subtle = { version = "2.4", default-features = false }
 
+[lints]
+workspace = true
+
 [package.metadata.docs.rs]
 all-features = true

--- a/universal-hash/src/lib.rs
+++ b/universal-hash/src/lib.rs
@@ -129,6 +129,9 @@ pub trait UniversalHash: BlockSizeUser + Sized {
     ///
     /// This is useful when constructing Message Authentication Codes (MACs)
     /// from universal hash functions.
+    ///
+    /// # Errors
+    /// If the `expected` value does not match the computed one.
     #[inline]
     fn verify(self, expected: &Block<Self>) -> Result<(), Error> {
         if self.finalize().ct_eq(expected).into() {


### PR DESCRIPTION
Note: lint config was added in #2270