### PR TITLE
universal-hash v0.6.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -733,7 +733,7 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "universal-hash"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "crypto-common",
  "ctutils",

--- a/universal-hash/CHANGELOG.md
+++ b/universal-hash/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.6.1 (2026-02-27)
+### Changed
+- Replaced `subtle` with `ctutils` ([#2324])
+
+[#2324]: https://github.com/RustCrypto/traits/pull/2324
+
 ## 0.6.0 (2026-02-27)
 ### Changed
 - Edition changed to 2024 and MSRV bumped to 1.85 ([#1759])

--- a/universal-hash/Cargo.toml
+++ b/universal-hash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "universal-hash"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["RustCrypto Developers"]
 edition = "2024"
 rust-version = "1.85"


### PR DESCRIPTION
## Changed
- Replaced `subtle` with `ctutils` ([#2324])

[#2324]: https://github.com/RustCrypto/traits/pull/2324