### PR TITLE
elliptic-curve: bump `crypto-bigint` to v0.7 final release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,9 +170,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-bigint"
-version = "0.7.0-rc.28"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96dacf199529fb801ae62a9aafdc01b189e9504c0d1ee1512a4c16bcd8666a93"
+checksum = "4f438b626cb7c9dd48a613a9826e6bad9db71097f9d628f7237af2f6bc13c0ec"
 dependencies = [
  "cpubits",
  "ctutils",

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -16,14 +16,9 @@ and traits for representing various elliptic curve forms, scalars, points,
 and public/secret keys composed thereof.
 """
 
-[dependencies.bigint]
-package = "crypto-bigint"
-version = "0.7.0-rc.27"
-default-features = false
-features = ["hybrid-array", "rand_core", "subtle", "zeroize"]
-
 [dependencies]
 array = { package = "hybrid-array", version = "0.4", default-features = false, features = ["zeroize"] }
+bigint = { package = "crypto-bigint", version = "0.7", default-features = false, features = ["hybrid-array", "rand_core", "subtle", "zeroize"] }
 base16ct = "1"
 common = { package = "crypto-common", version = "0.2", features = ["rand_core"] }
 rand_core = { version = "0.10", default-features = false }


### PR DESCRIPTION
Release PR: RustCrypto/crypto-bigint#1218