### PR TITLE
password-hash: bump `phc` dependency to v0.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -467,14 +467,14 @@ dependencies = [
 
 [[package]]
 name = "phc"
-version = "0.6.0-rc.1"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71d390c5fe8d102c2c18ff39f1e72b9ad5996de282c2d831b0312f56910f5508"
+checksum = "44dc769b75f93afdddd8c7fa12d685292ddeff1e66f7f0f3a234cf1818afe892"
 dependencies = [
  "base64ct",
+ "ctutils",
  "getrandom",
  "rand_core",
- "subtle",
 ]
 
 [[package]]

--- a/password-hash/Cargo.toml
+++ b/password-hash/Cargo.toml
@@ -18,7 +18,7 @@ formats (e.g. Modular Crypt Format)
 
 [dependencies]
 getrandom = { version = "0.4", optional = true, default-features = false }
-phc = { version = "0.6.0-rc.1", optional = true, default-features = false }
+phc = { version = "0.6", optional = true, default-features = false }
 rand_core = { version = "0.10", optional = true, default-features = false }
 
 [features]


### PR DESCRIPTION
Release PR: RustCrypto/formats#2255