### PR TITLE
password-hash: remove `McfHasher` trait

### DIFF
--- a/password-hash/src/lib.rs
+++ b/password-hash/src/lib.rs
@@ -224,26 +224,6 @@ where
     }
 }
 
-/// Trait for password hashing algorithms which support the legacy
-/// [Modular Crypt Format (MCF)][MCF].
-///
-/// [MCF]: https://passlib.readthedocs.io/en/stable/modular_crypt_format.html
-#[cfg(feature = "phc")]
-pub trait McfHasher {
-    /// Upgrade an MCF hash to a PHC hash. MCF follow this rough format:
-    ///
-    /// ```text
-    /// $<id>$<content>
-    /// ```
-    ///
-    /// MCF hashes are otherwise largely unstructured and parsed according to
-    /// algorithm-specific rules so hashers must parse a raw string themselves.
-    ///
-    /// # Errors
-    /// Returns errors if the the hash couldn't be converted
-    fn upgrade_mcf_hash(&self, hash: &str) -> Result<phc::PasswordHash>;
-}
-
 /// Generate a random salt value of the recommended length using the system's secure RNG.
 ///
 /// # Panics


### PR DESCRIPTION
The crate is now generic around password hash string formats, so having an MCF-specific trait like this doesn't make sense.

The functionality for upgrading MCF hashes to PHC hashes using algorithm-specific rules is worth retaining, but we can probably move this trait or add a similarly shaped one to e.g. the `mcf` crate which is better equipped to deal with MCF-specific concerns.