### PR TITLE
elliptic-curve: bump `sec1` to v0.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -579,9 +579,9 @@ dependencies = [
 
 [[package]]
 name = "sec1"
-version = "0.8.0-rc.13"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2400ed44a13193820aa528a19f376c3843141a8ce96ff34b11104cc79763f2"
+checksum = "f46b9a5ab87780a3189a1d704766579517a04ad59de653b7aad7d38e8a15f7dc"
 dependencies = [
  "base16ct",
  "ctutils",

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -34,7 +34,7 @@ hex-literal = { version = "1", optional = true }
 once_cell = { version = "1.21", optional = true, default-features = false }
 pem-rfc7468 = { version = "1", optional = true, features = ["alloc"] }
 pkcs8 = { version = "0.11.0-rc.10", optional = true, default-features = false }
-sec1 = { version = "0.8.0-rc.13", optional = true, features = ["ctutils", "subtle", "zeroize"] }
+sec1 = { version = "0.8", optional = true, features = ["ctutils", "subtle", "zeroize"] }
 serdect = { version = "0.4", optional = true, default-features = false, features = ["alloc"] }
 
 [dev-dependencies]


### PR DESCRIPTION
Release PR: RustCrypto/formats#2259