### PR TITLE
Release `digest` v0.11.2

### DIFF
--- a/digest/CHANGELOG.md
+++ b/digest/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.11.2 (UNRELEASED)
+## 0.11.2 (2026-03-13)
 ### Changed
 - Do not implement `Clone` as part of `(Reset)MacTraits` in the `buffer_fixed!` macro ([#2341])
 - `EagerHash` trait to be a sub-trait of `Clone` ([#2341])


### PR DESCRIPTION
Note: v0.11.1 was yanked because v0.11.2 introduces minor breaking changes affecting only pre-release versions of downstream crates.

### Changed
- Do not implement `Clone` as part of `(Reset)MacTraits` in the `buffer_fixed!` macro ([#2341])
- `EagerHash` trait to be a sub-trait of `Clone` ([#2341])

[#2341]: https://github.com/RustCrypto/traits/pull/2341