### PR TITLE
elliptic-curve: bump `hkdf` dependency to v0.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -311,17 +311,18 @@ checksum = "e712f64ec3850b98572bffac52e2c6f282b29fe6c5fa6d42334b30be438d95c1"
 
 [[package]]
 name = "hkdf"
-version = "0.13.0-rc.5"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbb55385998ae66b8d2d5143c05c94b9025ab863966f0c94ce7a5fde30105092"
+checksum = "4aaa26c720c68b866f2c96ef5c1264b3e6f473fe5d4ce61cd44bbe913e553018"
 dependencies = [
  "hmac",
 ]
 
 [[package]]
 name = "hmac"
-version = "0.13.0-rc.5"
-source = "git+https://github.com/RustCrypto/MACs#2c51e3b76e6f50c13d85577c3faac7df66e24306"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
  "digest",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,4 +57,3 @@ unused_qualifications = "warn"
 crypto-common = { path = "crypto-common" }
 digest = { path = "digest" }
 signature = { path = "signature" }
-hmac = { git = "https://github.com/RustCrypto/MACs" }

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -29,7 +29,7 @@ zeroize = { version = "1.7", default-features = false }
 digest = { version = "0.11", optional = true }
 ff = { version = "0.14.0-rc.0", package = "rustcrypto-ff", optional = true, default-features = false }
 group = { version = "0.14.0-rc.0", package = "rustcrypto-group", optional = true, default-features = false }
-hkdf = { version = "0.13.0-rc.5", optional = true, default-features = false }
+hkdf = { version = "0.13", optional = true, default-features = false }
 hex-literal = { version = "1", optional = true }
 once_cell = { version = "1.21", optional = true, default-features = false }
 pem-rfc7468 = { version = "1", optional = true, features = ["alloc"] }


### PR DESCRIPTION
Release PR: RustCrypto/KDFs#195