### PR TITLE
kem v0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -378,7 +378,7 @@ version = "0.1.0"
 
 [[package]]
 name = "kem"
-version = "0.3.0-rc.6"
+version = "0.3.0"
 dependencies = [
  "crypto-common",
  "rand_core",

--- a/kem/CHANGELOG.md
+++ b/kem/CHANGELOG.md
@@ -4,7 +4,39 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.3.0 (UNRELEASED)
+## 0.3.0 (2026-02-04)
+
+This release is effectively a complete rewrite of the `kem` crate. Any similarities between trait
+names in this release and previous releases is coincidental. The log below highlights some of the
+new parts of the API but will provide an incomplete picture of changes.
+
+### Added
+- `Encapsulate` and `Decapsulate` traits ([#1509])
+- `getrandom` feature ([#2140])
+- Re-exports from `crypto-common` ([#2222])
+  - re-exports `crypto-common` itself as `common`
+  - re-exports `KeyInit`, which is useful for seeds
+  - re-exports `Key` as the type for representing serialized encapsulation and decapsulation keys
+  - re-exports `InvalidKey` as the error when `TryKeyInit` fails
+- `TryDecapsulate` trait ([#2220], [#2235])
+- `Kem` trait for the whole algorithm type family ([#2243])
+- `FromSeed` trait and `Seed` type alias ([#2284])
+
+### Changed
+- `Decapsulator` trait replaced with new implementation ([#2282])
+
+### Removed
+- Previous implementation ([#1509])
+
+[#1509]: https://github.com/RustCrypto/traits/pull/1509
+[#2140]: https://github.com/RustCrypto/traits/pull/2140
+[#2140]: https://github.com/RustCrypto/traits/pull/2140
+[#2222]: https://github.com/RustCrypto/traits/pull/2222
+[#2220]: https://github.com/RustCrypto/traits/pull/2220
+[#2235]: https://github.com/RustCrypto/traits/pull/2235
+[#2243]: https://github.com/RustCrypto/traits/pull/2243
+[#2284]: https://github.com/RustCrypto/traits/pull/2284
+
 ### Changed
 - Edition changed to 2024 and MSRV bumped to 1.85 ([#1759])
 - Bump `rand_core` to v0.10 ([#2250])

--- a/kem/Cargo.toml
+++ b/kem/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kem"
-version = "0.3.0-rc.6"
+version = "0.3.0"
 authors = ["RustCrypto Developers"]
 edition = "2024"
 rust-version = "1.85"

--- a/kem/LICENSE-MIT
+++ b/kem/LICENSE-MIT
@@ -1,4 +1,4 @@
-Copyright (c) 2021-2025 RustCrypto Developers
+Copyright (c) 2021-2026 RustCrypto Developers
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated


### PR DESCRIPTION
This release is effectively a complete rewrite of the `kem` crate. Any similarities between trait names in this release and previous releases is coincidental. The log below highlights some of the new parts of the API but will provide an incomplete picture of changes.

## Added
- `Encapsulate` and `Decapsulate` traits ([#1509])
- `getrandom` feature ([#2140])
- Re-exports from `crypto-common` ([#2222])
  - re-exports `crypto-common` itself as `common`
  - re-exports `KeyInit`, which is useful for seeds
  - re-exports `Key` as the type for representing serialized encapsulation and decapsulation keys
  - re-exports `InvalidKey` as the error when `TryKeyInit` fails
- `TryDecapsulate` trait ([#2220], [#2235])
- `Kem` trait for the whole algorithm type family ([#2243])
- `FromSeed` trait and `Seed` type alias ([#2284])

## Changed
- `Decapsulator` trait replaced with new implementation ([#2282])

## Removed
- Previous implementation ([#1509])

[#1509]: https://github.com/RustCrypto/traits/pull/1509
[#2140]: https://github.com/RustCrypto/traits/pull/2140
[#2140]: https://github.com/RustCrypto/traits/pull/2140
[#2222]: https://github.com/RustCrypto/traits/pull/2222
[#2220]: https://github.com/RustCrypto/traits/pull/2220
[#2235]: https://github.com/RustCrypto/traits/pull/2235
[#2243]: https://github.com/RustCrypto/traits/pull/2243
[#2284]: https://github.com/RustCrypto/traits/pull/2284