### PR TITLE
elliptic-curve: add `ops::MulVartime` trait and bound `Scalar`

### DIFF
--- a/elliptic-curve/src/arithmetic.rs
+++ b/elliptic-curve/src/arithmetic.rs
@@ -3,7 +3,7 @@
 use crate::{
     Curve, CurveGroup, Error, FieldBytes, Group, NonZeroScalar, PrimeCurve, ScalarValue,
     ctutils::{CtEq, CtSelect},
-    ops::{Invert, LinearCombination, Mul, Reduce},
+    ops::{Invert, LinearCombination, Mul, MulVartime, Reduce},
     point::{AffineCoordinates, NonIdentity},
     scalar::{FromUintUnchecked, IsHigh},
 };
@@ -88,9 +88,13 @@ pub trait CurveArithmetic: Curve {
         + Invert<Output = CtOption<Self::Scalar>>
         + IsHigh
         + Mul<Self::AffinePoint, Output = Self::ProjectivePoint>
+        + MulVartime<Self::AffinePoint>
         + for<'a> Mul<&'a Self::AffinePoint, Output = Self::ProjectivePoint>
+        + for<'a> MulVartime<&'a Self::AffinePoint>
         + Mul<Self::ProjectivePoint, Output = Self::ProjectivePoint>
+        + MulVartime<Self::ProjectivePoint>
         + for<'a> Mul<&'a Self::ProjectivePoint, Output = Self::ProjectivePoint>
+        + for<'a> MulVartime<&'a Self::ProjectivePoint>
         + PartialOrd
         + Reduce<Self::Uint>
         + Reduce<FieldBytes<Self>>

--- a/elliptic-curve/src/dev/mock_curve.rs
+++ b/elliptic-curve/src/dev/mock_curve.rs
@@ -10,7 +10,10 @@ use crate::{
     bigint::{Limb, Odd, U256, modular::Retrieve},
     ctutils,
     error::{Error, Result},
-    ops::{Invert, LinearCombination, Reduce, ShrAssign},
+    ops::{
+        Add, AddAssign, Invert, LinearCombination, Mul, MulAssign, MulVartime, Neg, Reduce,
+        ShrAssign, Sub, SubAssign,
+    },
     point::{AffineCoordinates, NonIdentity},
     rand_core::{TryCryptoRng, TryRng},
     scalar::{FromUintUnchecked, IsHigh},
@@ -21,7 +24,6 @@ use crate::{
 use core::{
     array,
     iter::{Product, Sum},
-    ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign},
 };
 use ff::{Field, PrimeField};
 use hex_literal::hex;
@@ -296,10 +298,22 @@ impl Mul<AffinePoint> for Scalar {
     }
 }
 
+impl MulVartime<AffinePoint> for Scalar {
+    fn mul_vartime(self, _other: AffinePoint) -> ProjectivePoint {
+        unimplemented!();
+    }
+}
+
 impl Mul<&AffinePoint> for Scalar {
     type Output = ProjectivePoint;
 
     fn mul(self, _other: &AffinePoint) -> ProjectivePoint {
+        unimplemented!();
+    }
+}
+
+impl MulVartime<&AffinePoint> for Scalar {
+    fn mul_vartime(self, _other: &AffinePoint) -> ProjectivePoint {
         unimplemented!();
     }
 }
@@ -312,10 +326,22 @@ impl Mul<ProjectivePoint> for Scalar {
     }
 }
 
+impl MulVartime<ProjectivePoint> for Scalar {
+    fn mul_vartime(self, _other: ProjectivePoint) -> ProjectivePoint {
+        unimplemented!();
+    }
+}
+
 impl Mul<&ProjectivePoint> for Scalar {
     type Output = ProjectivePoint;
 
     fn mul(self, _other: &ProjectivePoint) -> ProjectivePoint {
+        unimplemented!();
+    }
+}
+
+impl MulVartime<&ProjectivePoint> for Scalar {
+    fn mul_vartime(self, _other: &ProjectivePoint) -> ProjectivePoint {
         unimplemented!();
     }
 }

--- a/elliptic-curve/src/ops.rs
+++ b/elliptic-curve/src/ops.rs
@@ -183,6 +183,21 @@ where
     }
 }
 
+/// Variable-time equivalent of the [`Mul`] trait.
+///
+/// Should always compute the same results as [`Mul`], but may provide a faster implementation.
+///
+/// <div class="warning">
+/// <b>Security Warning</b>
+///
+/// Variable-time operations should only be used on non-secret values, and may potentially leak
+/// secret values!
+/// </div>
+pub trait MulVartime<Rhs = Self>: Mul<Rhs> {
+    /// Multiply `self` by `rhs` in variable-time.
+    fn mul_vartime(self, rhs: Rhs) -> <Self as Mul<Rhs>>::Output;
+}
+
 /// Modular reduction to a non-zero output.
 ///
 /// This trait is primarily intended for use by curve implementations such


### PR DESCRIPTION
Adds a variable-time equivalent of the `Mul` trait with a corresponding `mul_vartime` method. This provides a place to plug in wNAF which is otherwise always available (and can fall back on constant-time operations if the `alloc` feature isn't enabled).

The trait has been added to the bounds for `CurveArithmetic::Scalar`, with requirements to support variable-time multiplication for affine and projective points.