### PR TITLE
elliptic-curve: `MulVartime` fixups

### DIFF
--- a/elliptic-curve/src/arithmetic.rs
+++ b/elliptic-curve/src/arithmetic.rs
@@ -29,6 +29,8 @@ pub trait CurveArithmetic: Curve {
         + Eq
         + From<NonIdentity<Self::AffinePoint>>
         + Generate
+        + MulVartime<Self::Scalar>
+        + for<'a> MulVartime<&'a Self::Scalar>
         + PartialEq
         + Sized
         + Send
@@ -58,6 +60,8 @@ pub trait CurveArithmetic: Curve {
         + Into<Self::AffinePoint>
         + LinearCombination<[(Self::ProjectivePoint, Self::Scalar)]>
         + LinearCombination<[(Self::ProjectivePoint, Self::Scalar); 2]>
+        + MulVartime<Self::Scalar>
+        + for<'a> MulVartime<&'a Self::Scalar>
         + TryInto<NonIdentity<Self::ProjectivePoint>, Error = Error>
         + CurveGroup<AffineRepr = Self::AffinePoint>
         + Group<Scalar = Self::Scalar>;

--- a/elliptic-curve/src/dev/mock_curve.rs
+++ b/elliptic-curve/src/dev/mock_curve.rs
@@ -274,9 +274,10 @@ impl SubAssign<&Scalar> for Scalar {
     }
 }
 
+crate::scalar_mul_impls!(MockCurve, Scalar);
+
 impl Mul<Scalar> for Scalar {
     type Output = Scalar;
-
     fn mul(self, _other: Scalar) -> Scalar {
         unimplemented!();
     }
@@ -286,62 +287,6 @@ impl Mul<&Scalar> for Scalar {
     type Output = Scalar;
 
     fn mul(self, _other: &Scalar) -> Scalar {
-        unimplemented!();
-    }
-}
-
-impl Mul<AffinePoint> for Scalar {
-    type Output = ProjectivePoint;
-
-    fn mul(self, _other: AffinePoint) -> ProjectivePoint {
-        unimplemented!();
-    }
-}
-
-impl MulVartime<AffinePoint> for Scalar {
-    fn mul_vartime(self, _other: AffinePoint) -> ProjectivePoint {
-        unimplemented!();
-    }
-}
-
-impl Mul<&AffinePoint> for Scalar {
-    type Output = ProjectivePoint;
-
-    fn mul(self, _other: &AffinePoint) -> ProjectivePoint {
-        unimplemented!();
-    }
-}
-
-impl MulVartime<&AffinePoint> for Scalar {
-    fn mul_vartime(self, _other: &AffinePoint) -> ProjectivePoint {
-        unimplemented!();
-    }
-}
-
-impl Mul<ProjectivePoint> for Scalar {
-    type Output = ProjectivePoint;
-
-    fn mul(self, _other: ProjectivePoint) -> ProjectivePoint {
-        unimplemented!();
-    }
-}
-
-impl MulVartime<ProjectivePoint> for Scalar {
-    fn mul_vartime(self, _other: ProjectivePoint) -> ProjectivePoint {
-        unimplemented!();
-    }
-}
-
-impl Mul<&ProjectivePoint> for Scalar {
-    type Output = ProjectivePoint;
-
-    fn mul(self, _other: &ProjectivePoint) -> ProjectivePoint {
-        unimplemented!();
-    }
-}
-
-impl MulVartime<&ProjectivePoint> for Scalar {
-    fn mul_vartime(self, _other: &ProjectivePoint) -> ProjectivePoint {
         unimplemented!();
     }
 }
@@ -619,6 +564,34 @@ impl ToSec1Point<MockCurve> for AffinePoint {
             }
             _ => unimplemented!(),
         }
+    }
+}
+
+impl Mul<Scalar> for AffinePoint {
+    type Output = ProjectivePoint;
+
+    fn mul(self, _scalar: Scalar) -> ProjectivePoint {
+        unimplemented!();
+    }
+}
+
+impl Mul<&Scalar> for AffinePoint {
+    type Output = ProjectivePoint;
+
+    fn mul(self, _scalar: &Scalar) -> ProjectivePoint {
+        unimplemented!();
+    }
+}
+
+impl MulVartime<Scalar> for AffinePoint {
+    fn mul_vartime(self, _scalar: Scalar) -> ProjectivePoint {
+        unimplemented!()
+    }
+}
+
+impl MulVartime<&Scalar> for AffinePoint {
+    fn mul_vartime(self, _scalar: &Scalar) -> ProjectivePoint {
+        unimplemented!()
     }
 }
 
@@ -979,6 +952,26 @@ impl Mul<&Scalar> for ProjectivePoint {
 
     fn mul(self, scalar: &Scalar) -> ProjectivePoint {
         self * *scalar
+    }
+}
+
+impl Mul<&Scalar> for &ProjectivePoint {
+    type Output = ProjectivePoint;
+
+    fn mul(self, _scalar: &Scalar) -> ProjectivePoint {
+        unimplemented!();
+    }
+}
+
+impl MulVartime<Scalar> for ProjectivePoint {
+    fn mul_vartime(self, _scalar: Scalar) -> ProjectivePoint {
+        unimplemented!()
+    }
+}
+
+impl MulVartime<&Scalar> for ProjectivePoint {
+    fn mul_vartime(self, _scalar: &Scalar) -> ProjectivePoint {
+        unimplemented!()
     }
 }
 

--- a/elliptic-curve/src/macros.rs
+++ b/elliptic-curve/src/macros.rs
@@ -69,7 +69,7 @@ macro_rules! scalar_from_impls {
     };
 }
 
-/// Writes a series of `Mul` impls for an elliptic curve's scalar field
+/// Writes a series of `Mul` impls for an elliptic curve's scalar field.
 #[macro_export]
 macro_rules! scalar_mul_impls {
     ($curve:path, $scalar:ty) => {
@@ -142,6 +142,86 @@ macro_rules! scalar_mul_impls {
             #[inline]
             fn mul(self, rhs: &$crate::ProjectivePoint<$curve>) -> $crate::ProjectivePoint<$curve> {
                 rhs * self
+            }
+        }
+
+        impl $crate::ops::MulVartime<$crate::AffinePoint<$curve>> for $scalar {
+            #[inline]
+            fn mul_vartime(
+                self,
+                rhs: $crate::AffinePoint<$curve>,
+            ) -> $crate::ProjectivePoint<$curve> {
+                $crate::ops::MulVartime::mul_vartime(rhs, self)
+            }
+        }
+
+        impl $crate::ops::MulVartime<&$crate::AffinePoint<$curve>> for $scalar {
+            #[inline]
+            fn mul_vartime(
+                self,
+                rhs: &$crate::AffinePoint<$curve>,
+            ) -> $crate::ProjectivePoint<$curve> {
+                $crate::ops::MulVartime::mul_vartime(*rhs, &self)
+            }
+        }
+
+        impl $crate::ops::MulVartime<$crate::AffinePoint<$curve>> for &$scalar {
+            #[inline]
+            fn mul_vartime(
+                self,
+                rhs: $crate::AffinePoint<$curve>,
+            ) -> $crate::ProjectivePoint<$curve> {
+                $crate::ops::MulVartime::mul_vartime(rhs, self)
+            }
+        }
+
+        impl $crate::ops::MulVartime<&$crate::AffinePoint<$curve>> for &$scalar {
+            #[inline]
+            fn mul_vartime(
+                self,
+                rhs: &$crate::AffinePoint<$curve>,
+            ) -> $crate::ProjectivePoint<$curve> {
+                $crate::ops::MulVartime::mul_vartime(*rhs, self)
+            }
+        }
+
+        impl $crate::ops::MulVartime<$crate::ProjectivePoint<$curve>> for $scalar {
+            #[inline]
+            fn mul_vartime(
+                self,
+                rhs: $crate::ProjectivePoint<$curve>,
+            ) -> $crate::ProjectivePoint<$curve> {
+                $crate::ops::MulVartime::mul_vartime(rhs, self)
+            }
+        }
+
+        impl $crate::ops::MulVartime<&$crate::ProjectivePoint<$curve>> for $scalar {
+            #[inline]
+            fn mul_vartime(
+                self,
+                rhs: &$crate::ProjectivePoint<$curve>,
+            ) -> $crate::ProjectivePoint<$curve> {
+                $crate::ops::MulVartime::mul_vartime(*rhs, &self)
+            }
+        }
+
+        impl $crate::ops::MulVartime<$crate::ProjectivePoint<$curve>> for &$scalar {
+            #[inline]
+            fn mul_vartime(
+                self,
+                rhs: $crate::ProjectivePoint<$curve>,
+            ) -> $crate::ProjectivePoint<$curve> {
+                $crate::ops::MulVartime::mul_vartime(rhs, self)
+            }
+        }
+
+        impl $crate::ops::MulVartime<&$crate::ProjectivePoint<$curve>> for &$scalar {
+            #[inline]
+            fn mul_vartime(
+                self,
+                rhs: &$crate::ProjectivePoint<$curve>,
+            ) -> $crate::ProjectivePoint<$curve> {
+                $crate::ops::MulVartime::mul_vartime(*rhs, self)
             }
         }
     };


### PR DESCRIPTION
- Adds `MulVartime` to `AffinePoint` and `ProjectivePoint` bounds
- Adds boilerplate `MulVartime` impls to `scalar_mul_impls!`
- Uses `scalar_mul_impls!` for `MockCurve`