### PR TITLE
elliptic-curve: shorten name of `mul_by_generator_and_mul_add_vartime`

### DIFF
--- a/elliptic-curve/src/ops.rs
+++ b/elliptic-curve/src/ops.rs
@@ -219,11 +219,7 @@ pub trait MulByGeneratorVartime: Group + for<'a> MulVartime<&'a Self::Scalar> {
     /// `P` multiplied by the scalar `b`, i.e. compute `aG + bP`.
     ///
     /// This operation is the core of many signature verification algorithms.
-    fn mul_by_generator_and_mul_add_point_vartime(
-        a: &Self::Scalar,
-        b: &Self::Scalar,
-        p: &Self,
-    ) -> Self {
+    fn mul_by_generator_and_mul_add_vartime(a: &Self::Scalar, b: &Self::Scalar, p: &Self) -> Self {
         Self::mul_by_generator_vartime(a) + p.mul_vartime(b)
     }
 }


### PR DESCRIPTION
It's already obnoxiously long, but this removes `*_point_*` from the previous `mul_by_generator_and_mul_add_point_vartime`.

The RHS of the addition (`bP`) is a point-scalar multiplication, so just "point" alone doesn't add much additional clarity, and also the operation is already defined on e.g. `ProjectivePoint` making it somewhat redundant.