### PR TITLE
Implement SecretKey::from_pem to decode variety of keys

### DIFF
--- a/elliptic-curve/src/secret_key.rs
+++ b/elliptic-curve/src/secret_key.rs
@@ -297,7 +297,7 @@ where
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum PemParseError {
     ///Indicates invalid PEM string
-    Pem(pem::Error),
+    Pem(der::Error),
     ///Indicates invalid pkcs8 EC key
     Pkcs8(::pkcs8::Error),
     ///Indicates invalid Sec1 EC key
@@ -307,9 +307,9 @@ pub enum PemParseError {
 }
 
 #[cfg(feature = "pem")]
-impl From<pem::Error> for PemParseError {
+impl From<der::Error> for PemParseError {
     #[inline(always)]
-    fn from(error: pem::Error) -> Self {
+    fn from(error: der::Error) -> Self {
         Self::Pem(error)
     }
 }
@@ -363,13 +363,13 @@ where
     /// - If label is valid, but unable to decode DER content of the PEM file
     #[cfg(feature = "pem")]
     pub fn from_pem(pem: &str) -> ::core::result::Result<Self, PemParseError> {
-        let (label, der_bytes) = pem::decode_vec(pem.as_bytes()).map_err(PemParseError::Pem)?;
+        let (label, document) = der::SecretDocument::from_pem(pem).map_err(PemParseError::Pem)?;
 
-        if label == sec1::EcPrivateKey::PEM_LABEL {
-            return ::sec1::DecodeEcPrivateKey::from_sec1_der(&der_bytes)
+        if ::sec1::EcPrivateKey::validate_pem_label(label).is_ok() {
+            return ::sec1::DecodeEcPrivateKey::from_sec1_der(document.as_bytes())
                 .map_err(PemParseError::Sec1);
         } else if ::pkcs8::PrivateKeyInfoRef::validate_pem_label(label).is_ok() {
-            return ::pkcs8::DecodePrivateKey::from_pkcs8_der(&der_bytes)
+            return ::pkcs8::DecodePrivateKey::from_pkcs8_der(document.as_bytes())
                 .map_err(PemParseError::Pkcs8);
         }
 

--- a/elliptic-curve/src/secret_key.rs
+++ b/elliptic-curve/src/secret_key.rs
@@ -342,7 +342,7 @@ impl fmt::Display for PemParseError {
     }
 }
 
-#[cfg(all(feature = "std", feature = "pem"))]
+#[cfg(feature = "pem")]
 impl core::error::Error for PemParseError {}
 
 #[cfg(feature = "pem")]

--- a/elliptic-curve/src/secret_key.rs
+++ b/elliptic-curve/src/secret_key.rs
@@ -365,12 +365,12 @@ where
     pub fn from_pem(pem: &str) -> ::core::result::Result<Self, PemParseError> {
         let (label, document) = der::SecretDocument::from_pem(pem).map_err(PemParseError::Pem)?;
 
-        if ::sec1::EcPrivateKey::validate_pem_label(label).is_ok() {
-            return ::sec1::DecodeEcPrivateKey::from_sec1_der(document.as_bytes())
-                .map_err(PemParseError::Sec1);
-        } else if ::pkcs8::PrivateKeyInfoRef::validate_pem_label(label).is_ok() {
+        if ::pkcs8::PrivateKeyInfoRef::validate_pem_label(label).is_ok() {
             return ::pkcs8::DecodePrivateKey::from_pkcs8_der(document.as_bytes())
                 .map_err(PemParseError::Pkcs8);
+        } else if ::sec1::EcPrivateKey::validate_pem_label(label).is_ok() {
+            return ::sec1::DecodeEcPrivateKey::from_sec1_der(document.as_bytes())
+                .map_err(PemParseError::Sec1);
         }
 
         Err(PemParseError::UnknownLabel)

--- a/elliptic-curve/src/secret_key.rs
+++ b/elliptic-curve/src/secret_key.rs
@@ -297,7 +297,7 @@ where
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum PemParseError {
     ///Indicates invalid PEM string
-    Pem(der::Error),
+    Pem(pem_rfc7468::Error),
     ///Indicates invalid pkcs8 EC key
     Pkcs8(::pkcs8::Error),
     ///Indicates invalid Sec1 EC key
@@ -307,9 +307,9 @@ pub enum PemParseError {
 }
 
 #[cfg(feature = "pem")]
-impl From<der::Error> for PemParseError {
+impl From<pem_rfc7468::Error> for PemParseError {
     #[inline(always)]
-    fn from(error: der::Error) -> Self {
+    fn from(error: pem_rfc7468::Error) -> Self {
         Self::Pem(error)
     }
 }
@@ -363,14 +363,12 @@ where
     /// - If label is valid, but unable to decode DER content of the PEM file
     #[cfg(feature = "pem")]
     pub fn from_pem(pem: &str) -> ::core::result::Result<Self, PemParseError> {
-        let (label, document) = der::SecretDocument::from_pem(pem).map_err(PemParseError::Pem)?;
+        let label = pem_rfc7468::decode_label(pem.as_bytes()).map_err(PemParseError::Pem)?;
 
         if ::pkcs8::PrivateKeyInfoRef::validate_pem_label(label).is_ok() {
-            return ::pkcs8::DecodePrivateKey::from_pkcs8_der(document.as_bytes())
-                .map_err(PemParseError::Pkcs8);
+            return ::pkcs8::DecodePrivateKey::from_pkcs8_pem(pem).map_err(PemParseError::Pkcs8);
         } else if ::sec1::EcPrivateKey::validate_pem_label(label).is_ok() {
-            return ::sec1::DecodeEcPrivateKey::from_sec1_der(document.as_bytes())
-                .map_err(PemParseError::Sec1);
+            return ::sec1::DecodeEcPrivateKey::from_sec1_pem(pem).map_err(PemParseError::Sec1);
         }
 
         Err(PemParseError::UnknownLabel)

--- a/elliptic-curve/src/secret_key.rs
+++ b/elliptic-curve/src/secret_key.rs
@@ -293,6 +293,90 @@ where
     }
 }
 
+#[cfg(feature = "pem")]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum PemParseError {
+    ///Indicates invalid PEM string
+    Pem(pem::Error),
+    ///Indicates invalid pkcs8 EC key
+    Pkcs8(::pkcs8::Error),
+    ///Indicates invalid Sec1 EC key
+    Sec1(::sec1::Error),
+    ///Unable to recognize document label
+    UnknownLabel,
+}
+
+#[cfg(feature = "pem")]
+impl From<pem::Error> for PemParseError {
+    #[inline(always)]
+    fn from(error: pem::Error) -> Self {
+        Self::Pem(error)
+    }
+}
+
+#[cfg(feature = "pem")]
+impl From<::pkcs8::Error> for PemParseError {
+    #[inline(always)]
+    fn from(error: ::pkcs8::Error) -> Self {
+        Self::Pkcs8(error)
+    }
+}
+
+#[cfg(feature = "pem")]
+impl From<::sec1::Error> for PemParseError {
+    #[inline(always)]
+    fn from(error: ::sec1::Error) -> Self {
+        Self::Sec1(error)
+    }
+}
+
+#[cfg(feature = "pem")]
+impl fmt::Display for PemParseError {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Pem(error) => fmt.write_fmt(format_args!("Failed to parse PEM: {error}")),
+            Self::UnknownLabel => fmt.write_str("Unrecognized key label"),
+            Self::Pkcs8(error) => fmt.write_fmt(format_args!("Faoled to parse Pkcs8 key: {error}")),
+            Self::Sec1(error) => fmt.write_fmt(format_args!("Faoled to parse SEC1 key: {error}")),
+        }
+    }
+}
+
+#[cfg(all(feature = "std", feature = "pem"))]
+impl core::error::Error for PemParseError {}
+
+#[cfg(feature = "pem")]
+impl<C> SecretKey<C>
+where
+    C: AssociatedOid + Curve + ValidatePublicKey,
+    FieldBytesSize<C>: ModulusSize,
+{
+    /// Parse [`SecretKey`] from PEM-encoded private key.
+    ///
+    /// Supported formats:
+    /// - `SEC1` - requires feature `sec1`
+    /// - `PKCS #8` - requires feature `pkcs8`
+    ///
+    /// # Errors
+    /// - If `pem` is not valid PEM encoded private key
+    /// - If label within `pem` is not known valid label
+    /// - If label is valid, but unable to decode DER content of the PEM file
+    #[cfg(feature = "pem")]
+    pub fn from_pem(pem: &str) -> ::core::result::Result<Self, PemParseError> {
+        let (label, der_bytes) = pem::decode_vec(pem.as_bytes()).map_err(PemParseError::Pem)?;
+
+        if label == sec1::EcPrivateKey::PEM_LABEL {
+            return ::sec1::DecodeEcPrivateKey::from_sec1_der(&der_bytes)
+                .map_err(PemParseError::Sec1);
+        } else if ::pkcs8::PrivateKeyInfoRef::validate_pem_label(label).is_ok() {
+            return ::pkcs8::DecodePrivateKey::from_pkcs8_der(&der_bytes)
+                .map_err(PemParseError::Pkcs8);
+        }
+
+        Err(PemParseError::UnknownLabel)
+    }
+}
+
 impl<C> ConstantTimeEq for SecretKey<C>
 where
     C: Curve,

--- a/elliptic-curve/tests/pkcs8.rs
+++ b/elliptic-curve/tests/pkcs8.rs
@@ -23,17 +23,34 @@ const EXAMPLE_SCALAR: [u8; 32] =
     hex!("AABBCCDDEEFF0000000000000000000000000000000000000000000000000001");
 
 /// Example PKCS#8 private key
-fn example_private_key() -> der::SecretDocument {
+fn example_private_key_der() -> der::SecretDocument {
     SecretKey::from_slice(&EXAMPLE_SCALAR)
         .unwrap()
         .to_pkcs8_der()
         .unwrap()
 }
 
+#[cfg(feature = "pem")]
+/// Example PKCS#8 private key
+fn example_private_key_pem() -> impl AsRef<str> {
+    SecretKey::from_slice(&EXAMPLE_SCALAR)
+        .unwrap()
+        .to_pkcs8_pem(Default::default())
+        .unwrap()
+}
+
 #[test]
 fn decode_pkcs8_private_key_from_der() {
-    dbg!(example_private_key().as_bytes());
-    let secret_key = SecretKey::from_pkcs8_der(example_private_key().as_bytes()).unwrap();
+    dbg!(example_private_key_der().as_bytes());
+    let secret_key = SecretKey::from_pkcs8_der(example_private_key_der().as_bytes()).unwrap();
+    assert_eq!(secret_key.to_bytes().as_slice(), &EXAMPLE_SCALAR);
+}
+
+#[cfg(feature = "pem")]
+#[test]
+fn decode_pkcs8_private_key_from_pem() {
+    dbg!(example_private_key_pem().as_ref());
+    let secret_key = SecretKey::from_pem(example_private_key_pem().as_ref()).unwrap();
     assert_eq!(secret_key.to_bytes().as_slice(), &EXAMPLE_SCALAR);
 }
 


### PR DESCRIPTION
As suggested in https://github.com/RustCrypto/signatures/pull/1305 created API to decode SecretKey from variety of PEM encodings