### PR TITLE
elliptic-curve: add `mul_by_generator(_vartime)` benchmarks

### DIFF
--- a/elliptic-curve/src/dev.rs
+++ b/elliptic-curve/src/dev.rs
@@ -14,7 +14,7 @@ pub use mock_curve::*;
 /// Write a series of `criterion`-based benchmarks for arithmetic on a projective curve point.
 #[macro_export]
 macro_rules! bench_projective {
-    ($name:ident, $desc:expr, $point_a:expr, $point_b:expr, $scalar:expr) => {
+    ($name:ident, $point_type:ty, $point_a:expr, $point_b:expr, $scalar:expr) => {
         fn bench_add<M: ::criterion::measurement::Measurement>(
             group: &mut ::criterion::BenchmarkGroup<'_, M>,
         ) {
@@ -38,20 +38,35 @@ macro_rules! bench_projective {
             group.bench_function("neg", |b| b.iter(|| -x));
         }
 
-        fn bench_scalar_mul<M: ::criterion::measurement::Measurement>(
+        fn bench_point_mul<M: ::criterion::measurement::Measurement>(
             group: &mut ::criterion::BenchmarkGroup<'_, M>,
         ) {
             let p = core::hint::black_box($point_a);
             let s = core::hint::black_box($scalar);
-            group.bench_function("scalar mul", |b| b.iter(|| p * s));
+            group.bench_function("point-scalar mul", |b| b.iter(|| p * s));
+        }
+
+        fn bench_point_mul_by_generator<M: ::criterion::measurement::Measurement>(
+            group: &mut ::criterion::BenchmarkGroup<'_, M>,
+        ) {
+            use $crate::{group::Group, ops::MulByGeneratorVartime};
+
+            let s = core::hint::black_box($scalar);
+            group.bench_function("generator-scalar mul", |b| {
+                b.iter(|| ProjectivePoint::mul_by_generator(&s))
+            });
+            group.bench_function("generator-scalar mul (variable-time)", |b| {
+                b.iter(|| ProjectivePoint::mul_by_generator_vartime(&s))
+            });
         }
 
         pub fn $name(c: &mut ::criterion::Criterion) {
-            let mut group = c.benchmark_group($desc);
+            let mut group = c.benchmark_group(stringify!($point_type));
             bench_add(&mut group);
             bench_sub(&mut group);
             bench_neg(&mut group);
-            bench_scalar_mul(&mut group);
+            bench_point_mul(&mut group);
+            bench_point_mul_by_generator(&mut group);
             group.finish();
         }
     };


### PR DESCRIPTION
These are helpful for seeing the speedups when we add basepoint tables