### PR TITLE
digest: add `TryCustomizedInit` trait

### DIFF
--- a/digest/CHANGELOG.md
+++ b/digest/CHANGELOG.md
@@ -8,8 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## 0.11.3 (UNRELEASED)
 ### Added
 - `dev::initialized_mac_test` function ([#2367])
+- `TryCustomizedInit` trait ([#2395])
 
 [#2367]: https://github.com/RustCrypto/traits/pull/2367
+[#2395]: https://github.com/RustCrypto/traits/pull/2395
 
 ## 0.11.2 (2026-03-13)
 ### Changed

--- a/digest/src/lib.rs
+++ b/digest/src/lib.rs
@@ -218,6 +218,14 @@ pub trait TryCustomizedInit: Sized {
     fn try_new_customized(customization: &[u8]) -> Result<Self, Self::Error>;
 }
 
+impl<T: CustomizedInit> TryCustomizedInit for T {
+    type Error = core::convert::Infallible;
+
+    fn try_new_customized(customization: &[u8]) -> Result<Self, Self::Error> {
+        Ok(Self::new_customized(customization))
+    }
+}
+
 /// Types with a certain collision resistance.
 pub trait CollisionResistance {
     /// Collision resistance in bytes.

--- a/digest/src/lib.rs
+++ b/digest/src/lib.rs
@@ -205,6 +205,19 @@ pub trait CustomizedInit: Sized {
     fn new_customized(customization: &[u8]) -> Self;
 }
 
+/// Trait for hash functions with customization string for domain separation which place
+/// restrictions on customization strings.
+pub trait TryCustomizedInit: Sized {
+    /// Error returned for invalid customization strings.
+    type Error;
+
+    /// Create new hasher instance with the given customization string.
+    ///
+    /// # Errors
+    /// If the provided customization string is not valid for the hash function.
+    fn try_new_customized(customization: &[u8]) -> Result<Self, Self::Error>;
+}
+
 /// Types with a certain collision resistance.
 pub trait CollisionResistance {
     /// Collision resistance in bytes.


### PR DESCRIPTION
Some algorithms (e.g. Ascon-CXOF128 and `bash-prg-hash`) place restrictions on customization strings, so with the current version of `digest` we either have to panic on invalid strings or use inherent methods. This PR amends this by introducing a fallible variant of `CustomizedInit` with the blanket impl to act as a bridge between the traits.