### PR TITLE
elliptic-curve: bump `pkcs8` to v0.11.0-rc.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -479,9 +479,9 @@ dependencies = [
 
 [[package]]
 name = "pkcs8"
-version = "0.11.0-rc.11"
+version = "0.11.0-rc.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12922b6296c06eb741b02d7b5161e3aaa22864af38dfa025a1a3ba3f68c84577"
+checksum = "9d71d6da5a0e652b5c694049095a52f5e564012b8ee5001cf10d84a4ca9a7f9d"
 dependencies = [
  "der",
  "spki",

--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -33,7 +33,7 @@ hkdf = { version = "0.13", optional = true, default-features = false }
 hex-literal = { version = "1", optional = true }
 once_cell = { version = "1.21", optional = true, default-features = false }
 pem-rfc7468 = { version = "1", optional = true, features = ["alloc"] }
-pkcs8 = { version = "0.11.0-rc.10", optional = true, default-features = false }
+pkcs8 = { version = "0.11.0-rc.12", optional = true, default-features = false }
 sec1 = { version = "0.8", optional = true, features = ["ctutils", "subtle", "zeroize"] }
 serdect = { version = "0.4", optional = true, default-features = false, features = ["alloc"] }
 


### PR DESCRIPTION
Looks like there weren't any breaking changes here