### PR TITLE
crypto-common: add `MaybeBox`

### DIFF
--- a/.github/workflows/crypto-common.yml
+++ b/.github/workflows/crypto-common.yml
@@ -41,6 +41,10 @@ jobs:
           toolchain: ${{ matrix.rust }}
           targets: ${{ matrix.target }}
       - run: cargo build --target ${{ matrix.target }}
+      - run: cargo build --target ${{ matrix.target }} --features alloc
+      - run: cargo build --target ${{ matrix.target }} --features rand_core
+      - run: cargo build --target ${{ matrix.target }} --features zeroize
+      - run: cargo build --target ${{ matrix.target }} --features alloc,rand_core,zeroize
 
   minimal-versions:
     uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master

--- a/crypto-common/Cargo.toml
+++ b/crypto-common/Cargo.toml
@@ -20,6 +20,7 @@ getrandom = { version = "0.4", optional = true, features = ["sys_rng"] }
 rand_core = { version = "0.10", optional = true }
 
 [features]
+alloc = []
 getrandom = ["rand_core", "dep:getrandom"]
 rand_core = ["dep:rand_core"]
 zeroize = ["hybrid-array/zeroize"]

--- a/crypto-common/src/lib.rs
+++ b/crypto-common/src/lib.rs
@@ -7,15 +7,21 @@
 )]
 #![forbid(unsafe_code)]
 
+#[cfg(feature = "alloc")]
+extern crate alloc;
+
 /// Hazardous materials.
 pub mod hazmat;
 
 /// Secure random generation.
 #[cfg(feature = "rand_core")]
 mod generate;
+/// `Box`-like type with `no_alloc` fallback.
+mod maybe_box;
 
 pub use hybrid_array as array;
 pub use hybrid_array::typenum;
+pub use maybe_box::MaybeBox;
 
 #[cfg(feature = "getrandom")]
 pub use getrandom;

--- a/crypto-common/src/maybe_box.rs
+++ b/crypto-common/src/maybe_box.rs
@@ -1,0 +1,56 @@
+use core::ops::{Deref, DerefMut};
+
+/// `Box`-like type providing opportunistic heap allocation when the `alloc` feature is available
+/// that falls back to stack allocation when it's unavailable.
+#[derive(Clone, Debug, PartialEq)]
+pub struct MaybeBox<T> {
+    #[cfg(not(feature = "alloc"))]
+    inner: T,
+    #[cfg(feature = "alloc")]
+    inner: alloc::boxed::Box<T>,
+}
+
+impl<T> MaybeBox<T> {
+    /// Create a new `MaybeBox`, using `Box` if `alloc` is available.
+    #[inline]
+    pub fn new(inner: T) -> Self {
+        #[cfg(not(feature = "alloc"))]
+        {
+            Self { inner }
+        }
+        #[cfg(feature = "alloc")]
+        Self {
+            inner: alloc::boxed::Box::new(inner),
+        }
+    }
+
+    /// Move the contents out of a [`MaybeBox`].
+    ///
+    /// This emulates the compiler magic that allows moving out of a box with `*my_box`.
+    #[inline]
+    #[must_use]
+    pub fn into_inner(self) -> T {
+        #[cfg(not(feature = "alloc"))]
+        {
+            self.inner
+        }
+        #[cfg(feature = "alloc")]
+        {
+            *self.inner
+        }
+    }
+}
+
+impl<T> Deref for MaybeBox<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl<T> DerefMut for MaybeBox<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}


### PR DESCRIPTION
Adds a type which is always available, but when the newly added `alloc` feature is enabled, provides opportunistic heap allocation with `Box`, falling back on stack allocation if it is not.

Originally added to the `ml-dsa` crate in RustCrypto/signatures#1320 to address the large size of post-quantum keys and signatures while still retaining `no_alloc` support.

However, it is generally useful anywhere we work with secret values to e.g. prevent moves from making copies of them on the stack, even if they aren't excessively large.