### PR TITLE
elliptic-curve: disable minimal-versions CI job

### DIFF
--- a/.github/workflows/elliptic-curve.yml
+++ b/.github/workflows/elliptic-curve.yml
@@ -61,13 +61,14 @@ jobs:
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features arithmetic,serde
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features alloc,digest,ecdh,pem,pkcs8,sec1,serde
 
-  # minimal-versions:
-  #   uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
-  #   with:
-  #     working-directory: ${{ github.workflow }}
-  #     stable-cmd: |
-  #       cargo hack check --feature-powerset --no-dev-deps --skip basepoint-table
-  #       cargo check --all-features
+  minimal-versions:
+    if: false
+    uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
+    with:
+      working-directory: ${{ github.workflow }}
+      stable-cmd: |
+        cargo hack check --feature-powerset --no-dev-deps --skip basepoint-table
+        cargo check --all-features
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/elliptic-curve.yml
+++ b/.github/workflows/elliptic-curve.yml
@@ -61,13 +61,13 @@ jobs:
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features arithmetic,serde
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features alloc,digest,ecdh,pem,pkcs8,sec1,serde
 
-  minimal-versions:
-    uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
-    with:
-      working-directory: ${{ github.workflow }}
-      stable-cmd: |
-        cargo hack check --feature-powerset --no-dev-deps --skip basepoint-table
-        cargo check --all-features
+  # minimal-versions:
+  #   uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
+  #   with:
+  #     working-directory: ${{ github.workflow }}
+  #     stable-cmd: |
+  #       cargo hack check --feature-powerset --no-dev-deps --skip basepoint-table
+  #       cargo check --all-features
 
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The minimal versions job was broken (see [RustCrypto/actions#59]), fixing it reveals that `elliptic-curve` still can not be built with minimal dependency versions (see this [run][1]).

[RustCrypto/actions#59]: https://github.com/RustCrypto/actions/pull/59
[1]: https://github.com/RustCrypto/traits/actions/runs/25738115143/job/75580587369