### PR TITLE
Release crypto-common v0.2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -163,7 +163,7 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "getrandom",
  "hybrid-array",

--- a/crypto-common/CHANGELOG.md
+++ b/crypto-common/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.2.2 (UNRELEASED)
+## 0.2.2 (2026-05-19)
 ### Added
 - `SetIvState` trait ([#2420])
 

--- a/crypto-common/Cargo.toml
+++ b/crypto-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crypto-common"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["RustCrypto Developers"]
 edition = "2024"
 rust-version = "1.85"


### PR DESCRIPTION
### Added
- `SetIvState` trait ([#2420])

[#2420]: https://github.com/RustCrypto/traits/pull/2420