### PR TITLE
elliptic-curve: upgrade to `ff`/`group` v0.14.0 API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -487,8 +487,7 @@ checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 [[package]]
 name = "rustcrypto-ff"
 version = "0.14.0-rc.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd2a8adb347447693cd2ba0d218c4b66c62da9b0a5672b17b981e4291ec65ff6"
+source = "git+https://github.com/RustCrypto/ff#064c5a7418576641bd58ae244a8eea1c9592f577"
 dependencies = [
  "rand_core",
  "subtle",
@@ -497,7 +496,7 @@ dependencies = [
 [[package]]
 name = "rustcrypto-group"
 version = "0.14.0-rc.1"
-source = "git+https://github.com/RustCrypto/group#d5ef2775cb66a10085c9ec48432c51cad4e7b3ee"
+source = "git+https://github.com/RustCrypto/group#2f1ea2e4f65d8a117d2445190357f841f9381db9"
 dependencies = [
  "rand_core",
  "rustcrypto-ff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,4 +58,5 @@ crypto-common = { path = "crypto-common" }
 digest = { path = "digest" }
 signature = { path = "signature" }
 
+rustcrypto-ff = { git = "https://github.com/RustCrypto/ff" }
 rustcrypto-group = { git = "https://github.com/RustCrypto/group" }

--- a/elliptic-curve/src/arithmetic.rs
+++ b/elliptic-curve/src/arithmetic.rs
@@ -1,7 +1,8 @@
 //! Elliptic curve arithmetic traits.
 
 use crate::{
-    Curve, CurveGroup, Error, FieldBytes, Group, NonZeroScalar, PrimeCurve, ScalarValue,
+    Curve, CurveAffine, CurveGroup, Error, FieldBytes, Group, NonZeroScalar, PrimeCurve,
+    ScalarValue,
     ctutils::{CtEq, CtSelect},
     ops::{Invert, LinearCombination, Mul, MulByGeneratorVartime, MulVartime, Reduce},
     point::{AffineCoordinates, NonIdentity},
@@ -23,6 +24,7 @@ pub trait CurveArithmetic: Curve {
         + ConstantTimeEq
         + CtEq
         + CtSelect
+        + CurveAffine<Curve = Self::ProjectivePoint, Scalar = Self::Scalar>
         + Debug
         + Default
         + DefaultIsZeroes
@@ -64,7 +66,7 @@ pub trait CurveArithmetic: Curve {
         + MulVartime<Self::Scalar>
         + for<'a> MulVartime<&'a Self::Scalar>
         + TryInto<NonIdentity<Self::ProjectivePoint>, Error = Error>
-        + CurveGroup<AffineRepr = Self::AffinePoint>
+        + CurveGroup<Affine = Self::AffinePoint>
         + Group<Scalar = Self::Scalar>;
 
     /// Scalar field modulo this curve's order.

--- a/elliptic-curve/src/dev/mock_curve.rs
+++ b/elliptic-curve/src/dev/mock_curve.rs
@@ -5,7 +5,8 @@
 //! generically over curves without having to pull in a complete curve implementation.
 
 use crate::{
-    BatchNormalize, Curve, CurveArithmetic, CurveGroup, FieldBytesEncoding, Generate, PrimeCurve,
+    BatchNormalize, Curve, CurveAffine, CurveArithmetic, CurveGroup, FieldBytesEncoding, Generate,
+    PrimeCurve,
     array::typenum::U32,
     bigint::{Limb, Odd, U256, modular::Retrieve},
     ctutils,
@@ -92,7 +93,7 @@ impl Field for Scalar {
     const ZERO: Self = Self(ScalarValue::ZERO);
     const ONE: Self = Self(ScalarValue::ONE);
 
-    fn try_from_rng<R: TryRng + ?Sized>(rng: &mut R) -> core::result::Result<Self, R::Error> {
+    fn try_random<R: TryRng + ?Sized>(rng: &mut R) -> core::result::Result<Self, R::Error> {
         let mut bytes = FieldBytes::default();
 
         loop {
@@ -464,6 +465,27 @@ impl AffineCoordinates for AffinePoint {
     }
 }
 
+impl CurveAffine for AffinePoint {
+    type Curve = ProjectivePoint;
+    type Scalar = Scalar;
+
+    fn identity() -> Self {
+        Self::Identity
+    }
+
+    fn generator() -> Self {
+        Self::Generator
+    }
+
+    fn is_identity(&self) -> Choice {
+        unimplemented!();
+    }
+
+    fn to_curve(&self) -> ProjectivePoint {
+        unimplemented!();
+    }
+}
+
 impl ConstantTimeEq for AffinePoint {
     fn ct_eq(&self, other: &Self) -> Choice {
         match (self, other) {
@@ -576,6 +598,14 @@ impl Mul<NonZeroScalar> for AffinePoint {
     type Output = AffinePoint;
 
     fn mul(self, _scalar: NonZeroScalar) -> Self {
+        unimplemented!();
+    }
+}
+
+impl Neg for AffinePoint {
+    type Output = Self;
+
+    fn neg(self) -> Self {
         unimplemented!();
     }
 }
@@ -709,7 +739,7 @@ impl TryFrom<ProjectivePoint> for NonIdentity<ProjectivePoint> {
 impl group::Group for ProjectivePoint {
     type Scalar = Scalar;
 
-    fn try_from_rng<R: TryRng + ?Sized>(_rng: &mut R) -> core::result::Result<Self, R::Error> {
+    fn try_random<R: TryRng + ?Sized>(_rng: &mut R) -> core::result::Result<Self, R::Error> {
         unimplemented!();
     }
 
@@ -775,7 +805,7 @@ impl group::GroupEncoding for ProjectivePoint {
 }
 
 impl CurveGroup for ProjectivePoint {
-    type AffineRepr = AffinePoint;
+    type Affine = AffinePoint;
 
     fn to_affine(&self) -> AffinePoint {
         match self {

--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -111,7 +111,7 @@ pub use {
         scalar::{NonZeroScalar, Scalar},
     },
     ff::{self, Field, PrimeField},
-    group::{self, Curve as CurveGroup, Group},
+    group::{self, Curve as CurveGroup, CurveAffine, Group},
 };
 
 #[cfg(any(feature = "pkcs8", feature = "sec1"))]

--- a/elliptic-curve/src/point/basepoint_table.rs
+++ b/elliptic-curve/src/point/basepoint_table.rs
@@ -180,7 +180,7 @@ pub(super) mod vartime {
                     .map(|(_, scalar)| WnafScalar::new(scalar)),
             );
 
-            WnafBase::multiscalar_mul(scalars.iter(), bases.iter())
+            WnafBase::multiscalar_mul(scalars, bases)
         }
     }
 

--- a/elliptic-curve/src/point/non_identity.rs
+++ b/elliptic-curve/src/point/non_identity.rs
@@ -111,7 +111,7 @@ where
     }
 
     /// Converts this element into its affine representation.
-    pub fn to_affine(self) -> NonIdentity<P::AffineRepr> {
+    pub fn to_affine(self) -> NonIdentity<P::Affine> {
         NonIdentity {
             point: self.point.to_affine(),
         }
@@ -148,11 +148,11 @@ impl<P> AsRef<P> for NonIdentity<P> {
 
 impl<const N: usize, P> BatchNormalize<[Self; N]> for NonIdentity<P>
 where
-    P: CurveGroup + BatchNormalize<[P; N], Output = [P::AffineRepr; N]>,
+    P: CurveGroup + BatchNormalize<[P; N], Output = [P::Affine; N]>,
 {
-    type Output = [NonIdentity<P::AffineRepr>; N];
+    type Output = [NonIdentity<P::Affine>; N];
 
-    fn batch_normalize(points: &[Self; N]) -> [NonIdentity<P::AffineRepr>; N] {
+    fn batch_normalize(points: &[Self; N]) -> [NonIdentity<P::Affine>; N] {
         let points = Self::array_as_inner::<N>(points);
         let affine_points = <P as BatchNormalize<_>>::batch_normalize(points);
         affine_points.map(|point| NonIdentity { point })
@@ -162,11 +162,11 @@ where
 #[cfg(feature = "alloc")]
 impl<P> BatchNormalize<[Self]> for NonIdentity<P>
 where
-    P: CurveGroup + BatchNormalize<[P], Output = Vec<P::AffineRepr>>,
+    P: CurveGroup + BatchNormalize<[P], Output = Vec<P::Affine>>,
 {
-    type Output = Vec<NonIdentity<P::AffineRepr>>;
+    type Output = Vec<NonIdentity<P::Affine>>;
 
-    fn batch_normalize(points: &[Self]) -> Vec<NonIdentity<P::AffineRepr>> {
+    fn batch_normalize(points: &[Self]) -> Vec<NonIdentity<P::Affine>> {
         let points = Self::slice_as_inner(points);
         let affine_points = <P as BatchNormalize<_>>::batch_normalize(points);
         affine_points


### PR DESCRIPTION
This uses new versions of `rustcrypto-ff`/`rustcrypto-group` which are based on the `ff`/`group` v0.14.0 releases.

The main notable change was the introduction of the `CurveAffine` trait in zkcrypto/group#48.

There aren't releases of these crates yet as I'd like to get the entire stack upgraded first in git repos so I can release everything at once.