### PR TITLE
elliptic-curve: fix missing `le_repr` conversion

### DIFF
--- a/elliptic-curve/src/arithmetic/wnaf.rs
+++ b/elliptic-curve/src/arithmetic/wnaf.rs
@@ -446,7 +446,7 @@ impl<F: PrimeField, const WINDOW_SIZE: usize> WnafScalar<F, WINDOW_SIZE> {
         let mut wnaf = vec![];
 
         // Compute the w-NAF form of the scalar.
-        wnaf_form(&mut wnaf, scalar.to_repr(), WINDOW_SIZE);
+        wnaf_form(&mut wnaf, le_repr(scalar), WINDOW_SIZE);
 
         WnafScalar {
             wnaf,


### PR DESCRIPTION
This was missed from #2431