### PR TITLE
Fix `wnaf_table` overallocation

### DIFF
--- a/elliptic-curve/src/arithmetic/wnaf.rs
+++ b/elliptic-curve/src/arithmetic/wnaf.rs
@@ -13,7 +13,7 @@
 //! such that no two consecutive digits are non-zero.
 //!
 //! A configurable window size trades memory for speed: a larger window precomputes more multiples
-//! of the base point (a table of `2^(w-1)` entries) but requires fewer group additions per-bit of
+//! of the base point (a table of `2^(w-2)` entries) but requires fewer group additions per-bit of
 //! the scalar.
 //!
 //! # RustCrypto Notes
@@ -39,13 +39,18 @@ pub trait WnafGroup: Group {
 }
 
 /// Replaces the contents of `table` with a w-NAF window table for the given window size.
+///
+/// For a window of size `w`, non-zero wNAF digits are odd and have magnitude at most
+/// `2^(w-1) - 1`. The table is indexed by `|digit| / 2`, so the required size is
+/// `(2^(w-1) - 1) / 2 + 1 = 2^(w-2)` entries.
 pub(crate) fn wnaf_table<G: Group>(table: &mut Vec<G>, mut base: G, window: usize) {
+    let table_len = 1 << (window - 2);
     table.clear();
-    table.reserve(1 << (window - 1));
+    table.reserve(table_len);
 
     let dbl = base.double();
 
-    for _ in 0..(1 << (window - 1)) {
+    for _ in 0..table_len {
         table.push(base);
         base.add_assign(&dbl);
     }


### PR DESCRIPTION
For window size `w`, wNAF digits have max magnitude `2^(w-1) - 1`. The table is indexed by `|digit| / 2`, so the maximum index is `(2^(w-1) - 1) / 2 = 2^(w-2) - 1`, requiring `2^(w-2)` entries.

The previous `2^(w-1)` allocation computed twice as many odd multiples as needed, wasting point additions during table setup.


Ran the `k256` Schnorr signing and verifying benches and gave around 20% improvements for hot paths, however
@tarcieri please note my benchmarks were ran against [this branch](https://github.com/RustCrypto/elliptic-curves/pull/1745#issuecomment-4481531980)  that does GLV decomposition + shared doublings, where the larger table + extra allocations actually hurt. 

While the fix is provably correct, the current vendored wNAF path only allocates a single table, so the effects a not really measurable. 

| Stage | wNAF tables built per verify | `2^(w-2)` (fix) | `2^(w-1)` (no fix) | Fix's contribution |
  | --- | --- | --- | --- | --- |
  | Pre-wNAF base | 0 (constant-time `lincomb`) | — | — | 0% (can't apply) |
  | GLV wNAF, separate ladders  | 2 (only P; G uses basepoint table) | 53.2 µs | 57.6 µs | ~7% |
  | GLV + shared doublings  | 4 (G via wNAF too, fused) | 50.6 µs | 59.8 µs | ~19% |

