### PR TITLE
elliptic-curve: add `WnafScalar::from_le_bytes`

### DIFF
--- a/elliptic-curve/src/arithmetic/wnaf.rs
+++ b/elliptic-curve/src/arithmetic/wnaf.rs
@@ -458,6 +458,38 @@ impl<F: PrimeField, const WINDOW_SIZE: usize> WnafScalar<F, WINDOW_SIZE> {
             field: PhantomData,
         }
     }
+
+    /// Computes the w-NAF representation directly from raw little-endian bytes.
+    ///
+    /// `bytes` is interpreted as a little-endian unsigned integer (trailing zero bytes may be
+    /// omitted), and the resulting [`WnafScalar`] evaluates to that integer times the base.
+    /// Because the number of w-NAF digits — and therefore the number of doublings in the
+    /// evaluation loop — is proportional to `bytes.len() * 8`, passing a slice shorter than the
+    /// field's canonical representation produces a faster scalar.
+    ///
+    /// This is intended for callers that have already decomposed a scalar into a value provably
+    /// smaller than the field modulus, e.g. the ~128-bit half-scalars produced by a GLV
+    /// endomorphism decomposition.
+    ///
+    /// Returns `None` if `bytes` is longer than the field's canonical representation. Note that
+    /// no reduction modulo the field order is performed: the caller is responsible for ensuring
+    /// the encoded integer is the intended representative.
+    #[must_use]
+    pub fn from_le_bytes(bytes: &[u8]) -> Option<Self> {
+        if bytes.len() > F::Repr::default().as_ref().len() {
+            return None;
+        }
+
+        let mut wnaf = vec![];
+
+        // Compute the w-NAF form directly from the provided little-endian bytes.
+        wnaf_form(&mut wnaf, bytes, WINDOW_SIZE);
+
+        Some(WnafScalar {
+            wnaf,
+            field: PhantomData,
+        })
+    }
 }
 
 /// A fixed window table for a group element, precomputed to improve the speed of scalar

--- a/elliptic-curve/src/arithmetic/wnaf.rs
+++ b/elliptic-curve/src/arithmetic/wnaf.rs
@@ -31,6 +31,8 @@ use core::ops::Mul;
 use ff::PrimeField;
 use group::Group;
 
+use crate::{Error, Result};
+
 /// Extension trait on a [`Group`] that provides helpers used by [`Wnaf`].
 pub trait WnafGroup: Group {
     /// Recommends a wNAF window size given the number of scalars you intend to multiply
@@ -467,17 +469,38 @@ impl<F: PrimeField, const WINDOW_SIZE: usize> WnafScalar<F, WINDOW_SIZE> {
     /// evaluation loop — is proportional to `bytes.len() * 8`, passing a slice shorter than the
     /// field's canonical representation produces a faster scalar.
     ///
-    /// This is intended for callers that have already decomposed a scalar into a value provably
-    /// smaller than the field modulus, e.g. the ~128-bit half-scalars produced by a GLV
-    /// endomorphism decomposition.
+    /// This is intended for callers that have already decomposed a scalar into a value smaller
+    /// than the field modulus, e.g. the ~128-bit half-scalars produced by a GLV endomorphism
+    /// decomposition.
     ///
-    /// Returns `None` if `bytes` is longer than the field's canonical representation. Note that
-    /// no reduction modulo the field order is performed: the caller is responsible for ensuring
-    /// the encoded integer is the intended representative.
-    #[must_use]
-    pub fn from_le_bytes(bytes: &[u8]) -> Option<Self> {
-        if bytes.len() > F::Repr::default().as_ref().len() {
-            return None;
+    /// The encoded integer is validated to be a canonical field element: it must be strictly
+    /// less than the field modulus. No modular reduction is performed — a value that is not
+    /// already in range is rejected rather than reduced, so the returned [`WnafScalar`] always
+    /// evaluates to the integer `bytes` encodes.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error`] if `bytes` is longer than the field's canonical representation, or if
+    /// the encoded integer is greater than or equal to the field modulus.
+    pub fn from_le_bytes(bytes: &[u8]) -> Result<Self> {
+        // Validate that `bytes` encodes a canonical field element by round-tripping it through
+        // `F::from_repr`, which returns `None` for any integer greater than or equal to the
+        // modulus. `from_repr` consumes the canonical representation, assumed big-endian to match
+        // `le_repr` below, so reverse the little-endian input into a zero-extended `F::Repr`.
+        let mut repr = F::Repr::default();
+        let repr_len = repr.as_ref().len();
+
+        // Anything wider than the canonical representation is necessarily out of range.
+        if bytes.len() > repr_len {
+            return Err(Error);
+        }
+
+        for (i, &byte) in bytes.iter().enumerate() {
+            repr.as_mut()[repr_len - 1 - i] = byte;
+        }
+
+        if bool::from(F::from_repr(repr).is_none()) {
+            return Err(Error);
         }
 
         let mut wnaf = vec![];
@@ -485,7 +508,7 @@ impl<F: PrimeField, const WINDOW_SIZE: usize> WnafScalar<F, WINDOW_SIZE> {
         // Compute the w-NAF form directly from the provided little-endian bytes.
         wnaf_form(&mut wnaf, bytes, WINDOW_SIZE);
 
-        Some(WnafScalar {
+        Ok(WnafScalar {
             wnaf,
             field: PhantomData,
         })


### PR DESCRIPTION
Adds a constructor that builds a `WnafScalar` directly from raw little-endian scalar bytes, bypassing the full-width field representation used by `WnafScalar::new`.

This is useful when the scalar has already been decomposed into a value smaller than the field modulus — e.g. the ~128-bit half-scalars produced by a GLV endomorphism decomposition. Passing the shorter byte slice yields a shorter w-NAF, which halves the number of doublings in the evaluation loop relative to feeding the full-width scalar.

`bytes` is interpreted as a little-endian unsigned integer (trailing zero bytes may be omitted); over-length input returns `None`. The existing `wnaf_form` already zero-extends short inputs and emits a trailing carry digit, so values near the top of the byte range remain exact.