### PR TITLE
aead v0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "aead"
-version = "0.6.0-rc.10"
+version = "0.6.0"
 dependencies = [
  "arrayvec",
  "blobby",

--- a/aead/CHANGELOG.md
+++ b/aead/CHANGELOG.md
@@ -5,48 +5,43 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## 0.6.0 (2026-06-08)
 ### Added
+- Enable `missing_debug_implementations` lint and add `Debug` impls ([#1411])
+- `AeadCore::TAG_POSITION` and `TagPosition` enum ([#1798])
 - Re-export `crypto_common` as `common` ([#2237])
+
+### Changed
+- Replace `generic-array` with `hybrid-array` ([#1384])
+- Edition changed to 2024 and MSRV bumped to 1.85 ([#1759])
+- Replace `AeadInPlace` with `AeadInOut` ([#1793])
+- Split `new_test!` into `new_pass_test!` and `new_fail_test!` ([#2019])
+- Bump `crypto-common` to v0.2 ([#2276])
+
+### Removed
+- `AeadCore::CiphertextOverhead` constant ([#1737])
+- Stateful AEAD traits: `AeadMut*` ([#1740])
+- `stream` module - extracted into `aead-stream` crate ([#1801])
+- `heapless` support - will be added back in a future patch release ([#1999])
+- Nonce generation APIs - use `Generate` trait instead ([#2098])
 
 ### Fixed
 - Minor documentation error in `AeadCore::TagSize` ([#1351])
-- Fixup `hybrid-array` migration ([#1531])
-
-### Changed
-- Edition changed to 2024 and MSRV bumped to 1.85 ([#1759])
-- Migrate to `doc_auto_cfg` ([#1370])
-- Exclude pre-1.60 crates from workspace ([#1380])
-- Bump `crypto-common` to v0.2.0-pre; MSRV 1.65 ([#1384])
-- Bump `hybrid-array` to v0.2.0-pre.6 ([#1432])
-- Bump `crypto-common` to v0.2.0-pre.1 ([#1433])
-- Bump `crypto-common` to v0.2.0-pre.2 ([#1436])
-- Bump `hybrid-array` to v0.2.0-pre.8 ([#1438])
-- Bump `crypto-common` and `hybrid-array` ([#1469])
-- Bump `crypto-common` to v0.2.0-pre.5 ([#1496])
-
-### Added
-- Enable `missing_debug_implementations` lint and add `Debug` impls ([#1411])
-
-### Removed
-- `heapless` support (will be added back in v0.6.1) ([#1999])
-
 
 [#1351]: https://github.com/RustCrypto/traits/pull/1351
-[#1370]: https://github.com/RustCrypto/traits/pull/1370
-[#1380]: https://github.com/RustCrypto/traits/pull/1380
 [#1384]: https://github.com/RustCrypto/traits/pull/1384
 [#1411]: https://github.com/RustCrypto/traits/pull/1411
-[#1432]: https://github.com/RustCrypto/traits/pull/1432
-[#1433]: https://github.com/RustCrypto/traits/pull/1433
-[#1436]: https://github.com/RustCrypto/traits/pull/1436
-[#1438]: https://github.com/RustCrypto/traits/pull/1438
-[#1469]: https://github.com/RustCrypto/traits/pull/1469
-[#1496]: https://github.com/RustCrypto/traits/pull/1496
-[#1531]: https://github.com/RustCrypto/traits/pull/1531
+[#1737]: https://github.com/RustCrypto/traits/pull/1737
+[#1740]: https://github.com/RustCrypto/traits/pull/1740
 [#1759]: https://github.com/RustCrypto/traits/pull/1759
+[#1793]: https://github.com/RustCrypto/traits/pull/1793
+[#1798]: https://github.com/RustCrypto/traits/pull/1798
+[#1801]: https://github.com/RustCrypto/traits/pull/1801
 [#1999]: https://github.com/RustCrypto/traits/pull/1999
+[#2019]: https://github.com/RustCrypto/traits/pull/2019
+[#2098]: https://github.com/RustCrypto/traits/pull/2098
 [#2237]: https://github.com/RustCrypto/traits/pull/2237
+[#2276]: https://github.com/RustCrypto/traits/pull/2276
 
 ## 0.5.2 (2023-04-02)
 ### Added

--- a/aead/Cargo.toml
+++ b/aead/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aead"
-version = "0.6.0-rc.10"
+version = "0.6.0"
 authors = ["RustCrypto Developers"]
 edition = "2024"
 rust-version = "1.85"

--- a/aead/LICENSE-MIT
+++ b/aead/LICENSE-MIT
@@ -1,4 +1,4 @@
-Copyright (c) 2019-2025 The RustCrypto Project Developers
+Copyright (c) 2019-2026 The RustCrypto Project Developers
 Copyright (c) 2019 MobileCoin, LLC
 
 Permission is hereby granted, free of charge, to any


### PR DESCRIPTION
## Added
- Enable `missing_debug_implementations` lint and add `Debug` impls ([#1411])
- `AeadCore::TAG_POSITION` and `TagPosition` enum ([#1798])
- Re-export `crypto_common` as `common` ([#2237])

## Changed
- Replace `generic-array` with `hybrid-array` ([#1384])
- Edition changed to 2024 and MSRV bumped to 1.85 ([#1759])
- Replace `AeadInPlace` with `AeadInOut` ([#1793])
- Split `new_test!` into `new_pass_test!` and `new_fail_test!` ([#2019])
- Bump `crypto-common` to v0.2 - ([#2276])

## Removed
- `AeadCore::CiphertextOverhead` constant ([#1737])
- Stateful AEAD traits: `AeadMut*` ([#1740])
- `stream` module - extracted into `aead-stream` crate ([#1801])
- `heapless` support - will be added back in a future patch release ([#1999])
- Nonce generation APIs - use `Generate` trait instead ([#2098])

## Fixed
- Minor documentation error in `AeadCore::TagSize` ([#1351])

[#1351]: https://github.com/RustCrypto/traits/pull/1351
[#1384]: https://github.com/RustCrypto/traits/pull/1384
[#1411]: https://github.com/RustCrypto/traits/pull/1411
[#1737]: https://github.com/RustCrypto/traits/pull/1737
[#1740]: https://github.com/RustCrypto/traits/pull/1740
[#1759]: https://github.com/RustCrypto/traits/pull/1759
[#1793]: https://github.com/RustCrypto/traits/pull/1793
[#1798]: https://github.com/RustCrypto/traits/pull/1798
[#1801]: https://github.com/RustCrypto/traits/pull/1801
[#1999]: https://github.com/RustCrypto/traits/pull/1999
[#2019]: https://github.com/RustCrypto/traits/pull/2019
[#2098]: https://github.com/RustCrypto/traits/pull/2098
[#2237]: https://github.com/RustCrypto/traits/pull/2237
[#2276]: https://github.com/RustCrypto/traits/pull/2276