### PR TITLE
elliptic-curve: deliberately don't enable `group/alloc`

### DIFF
--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -45,7 +45,6 @@ default = ["arithmetic"]
 alloc = [
     "base16ct/alloc",
     "ff?/alloc",
-    "group?/alloc",
     "array/alloc",
     "pkcs8?/alloc",
     "sec1?/alloc",


### PR DESCRIPTION
The main thing this feature enables is the w-NAF implementation in the `group` crate, which is currently incompatible with our curves due to the big endian field serializations.

This instead should help direct people to use the implementation from the `wnaf` crate instead, re-exported as `elliptic_curve::wnaf`