### PR TITLE
Revert "elliptic-curve: deliberately don't enable `group/alloc` (#2443)"

### DIFF
--- a/elliptic-curve/Cargo.toml
+++ b/elliptic-curve/Cargo.toml
@@ -43,6 +43,7 @@ default = ["arithmetic"]
 alloc = [
     "base16ct/alloc",
     "ff?/alloc",
+    "group?/alloc",
     "array/alloc",
     "pkcs8?/alloc",
     "sec1?/alloc",


### PR DESCRIPTION
This reverts commit 6678e1a70a16078260bbf1cf0373d99743bff8f7.

Since we're using a variable-time path through our existing scalar multiplication implementation instead of w-NAF, which needs more optimization work to be competitive, this change no longer makes sense