### PR TITLE
Make get_random feature dependent on rand_core

### DIFF
--- a/aead/Cargo.toml
+++ b/aead/Cargo.toml
@@ -28,7 +28,7 @@ bytes = { version = "1.11.1", optional = true, default-features = false }
 default = ["rand_core"]
 alloc = []
 dev = ["blobby", "alloc"]
-getrandom = ["common/getrandom"]
+getrandom = ["common/getrandom, rand_core"]
 rand_core = ["common/rand_core"]
 
 [lints]


### PR DESCRIPTION
Fixes [AEADs Issue#755](https://github.com/RustCrypto/AEADs/issues/755). See also alternative solution, [AEADs PR#833](https://github.com/RustCrypto/AEADs/pull/833).

The `Generate` trait is used by rustdoc code demonstrating various AEADs `getrandom` feature, but the `Generate` trait is gated by the `rand_core` feature, which is not always enabled when `getrandom` is enabled. This is causing compilation errors for rustdoc tests that use `Generate` for Nonce generation.