### PR TITLE
aead v0.6.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "aead"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "arrayvec",
  "blobby",

--- a/aead/CHANGELOG.md
+++ b/aead/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.6.1 (2026-06-17)
+### Changed
+- Have `getrandom` feature enable `rand_core` ([#2452])
+
+[#2452]: https://github.com/RustCrypto/traits/pull/2452
+
 ## 0.6.0 (2026-06-08)
 ### Added
 - Enable `missing_debug_implementations` lint and add `Debug` impls ([#1411])

--- a/aead/Cargo.toml
+++ b/aead/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aead"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["RustCrypto Developers"]
 edition = "2024"
 rust-version = "1.85"


### PR DESCRIPTION
## Changed
- Have `getrandom` feature enable `rand_core` ([#2452])

[#2452]: https://github.com/RustCrypto/traits/pull/2452