### PR TITLE
elliptic-curve: add `hazmat` module with `FieldArithmetic`

### DIFF
--- a/elliptic-curve/src/arithmetic.rs
+++ b/elliptic-curve/src/arithmetic.rs
@@ -107,7 +107,6 @@ pub trait CurveArithmetic: Curve {
         + Reduce<FieldBytes<Self>>
         + Retrieve<Output = Self::Uint>
         + TryInto<NonZeroScalar<Self>, Error = Error>
-        + ff::Field
         + ff::PrimeField<Repr = FieldBytes<Self>>;
 }
 

--- a/elliptic-curve/src/hazmat.rs
+++ b/elliptic-curve/src/hazmat.rs
@@ -1,0 +1,42 @@
+//! Hazardous materials (a.k.a. "hazmat"): low-level primitives.
+//!
+//! <div class="warning">
+//! <b>Security️ Warning</b>
+//!
+//! YOU PROBABLY DON'T WANT TO USE THESE!
+//!
+//! If you are an end user / non-expert in cryptography, do not use these!
+//! Failure to use them correctly can lead to catastrophic failures.
+//! </div>
+
+use crate::{
+    CurveArithmetic, FieldBytes, Generate,
+    ops::{BatchInvert, Invert, Retrieve},
+};
+use ff::PrimeField;
+use subtle::CtOption;
+
+/// Access to a curve's base field element type.
+///
+/// This trait is bounded on [`CurveArithmetic`] to provide a complete arithmetic implementation,
+/// and also make the associated `FieldElement` type completely inaccessible unless this trait
+/// is in scope, having been imported from this `hazmat` module so that text appears in the import.
+/// We also explicitly recommend against re-exporting it so the `hazmat` keyword is easy to
+/// search for.
+///
+/// <div class="warning">
+/// <b>Security Warning</b>
+///
+/// Field elements are easily misused, unlike group-based abstractions. Some elliptic curves utilize
+/// lazy normalization, meaning that field elements may be non-canonical leading to miscomputations.
+/// We strongly recommend you avoid using this trait except for use cases that are truly dependent
+/// on coordinates, such as curve point encodings or hash2curve.
+/// </div>
+pub trait FieldArithmetic: CurveArithmetic {
+    /// Base field element type.
+    type FieldElement: BatchInvert
+        + Generate
+        + Invert<Output = CtOption<Self::FieldElement>>
+        + PrimeField<Repr = FieldBytes<Self>>
+        + Retrieve<Output = Self::Uint>;
+}

--- a/elliptic-curve/src/lib.rs
+++ b/elliptic-curve/src/lib.rs
@@ -64,27 +64,27 @@ extern crate alloc;
 #[cfg(feature = "std")]
 extern crate std;
 
-pub mod field;
-pub mod point;
-pub mod scalar;
-
 #[cfg(feature = "dev")]
 pub mod dev;
 #[cfg(feature = "ecdh")]
 pub mod ecdh;
+pub mod field;
+#[cfg(feature = "arithmetic")]
+pub mod hazmat;
 #[cfg(feature = "arithmetic")]
 pub mod ops;
+pub mod point;
+pub mod scalar;
 #[cfg(feature = "sec1")]
 pub mod sec1;
 
-mod error;
-mod macros;
-mod secret_key;
-
 #[cfg(feature = "arithmetic")]
 mod arithmetic;
+mod error;
+mod macros;
 #[cfg(feature = "arithmetic")]
 mod public_key;
+mod secret_key;
 
 pub use crate::{
     error::{Error, Result},

--- a/elliptic-curve/src/ops.rs
+++ b/elliptic-curve/src/ops.rs
@@ -1,6 +1,6 @@
 //! Traits for arithmetic operations on elliptic curve field elements.
 
-pub use bigint::{Invert, Reduce};
+pub use bigint::{Invert, Reduce, modular::Retrieve};
 pub use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Shr, ShrAssign, Sub, SubAssign};
 
 use crate::CurveGroup;
@@ -10,6 +10,9 @@ use group::Group;
 /// Perform a batched inversion on a slice of field elements (i.e. base field elements or scalars)
 /// at an amortized cost that should be practically as efficient as a single inversion, writing
 /// the field element inversions into `element`, and utilizing `scratch` as temporary storage.
+///
+/// Note: the [`ff`] crate also provides [`ff::BatchInvert`], however that trait has a hard
+/// requirement on `alloc` whereas this one is always available, even in `no_alloc` contexts.
 ///
 /// # Panics
 /// If `elements` and `scratch` are not the same length.


### PR DESCRIPTION
We've generally tried to hide base field element types from the public API, but this has lead to a litany of poorly composing workarounds since there's no way to generically access the base field element type whatsoever.

Instead we have the `field` module (and formerly the `FieldBytesEncoding` trait) along with `FieldBytes` and `FieldBytesSize` with the latter an alias to `Curve::FieldBytesSize`. Without a central place to hang that type-level information and trait bounds, things have gotten somewhat messy.

`primeorder` ended up defining its own associated `FieldElement` type as part of `PrimeCurveParams`.

This commit effectively vendors that associated type into a new `hazmat` module, similar to the modules we have in other crates e.g. `ecdsa`, as a new `FieldArithmetic` trait with an associated `FieldElement` type, which `primeorder` can switch to using.

We can then remove features like `export-field` which re-export `FieldElement` at the toplevel of crates, mixing it in with other types like `Scalar` and `AffinePoint`/`ProjectivePoint` as opposed to keeping it at a separate level of abstraction. Anyone wanting field element access no longer needs to futz with features, but *does* need to import this `hazmat` trait.