### PR TITLE
elliptic-curve: add `Double::double_in_place`

### DIFF
--- a/elliptic-curve/src/point.rs
+++ b/elliptic-curve/src/point.rs
@@ -55,10 +55,16 @@ pub trait BatchNormalize<Points: ?Sized> {
 }
 
 /// Double a point (i.e. add it to itself)
-pub trait Double {
+pub trait Double: Sized {
     /// Double this point.
     #[must_use]
     fn double(&self) -> Self;
+
+    /// Double this point in-place.
+    #[inline]
+    fn double_in_place(&mut self) {
+        *self = self.double();
+    }
 }
 
 /// Decompress an elliptic curve point.


### PR DESCRIPTION
Most of the time this is what we're doing anyway, and the functional style is a bit more awkward.

Also bounds `Double` on `Sized`.