### PR TITLE
elliptic-curve: move `Double` to `ops`

### DIFF
--- a/elliptic-curve/src/ops.rs
+++ b/elliptic-curve/src/ops.rs
@@ -31,6 +31,19 @@ pub trait BatchInvert: Field {
     }
 }
 
+/// Perform a doubling (i.e. `self + self`).
+pub trait Double: Sized {
+    /// Double this value, returning the doubled result.
+    #[must_use]
+    fn double(&self) -> Self;
+
+    /// Double this value in-place, assigning `self + self` to `self`.
+    #[inline]
+    fn double_in_place(&mut self) {
+        *self = self.double();
+    }
+}
+
 /// Linear combination.
 ///
 /// This trait enables optimized implementations of linear combinations (e.g. Shamir's Trick).

--- a/elliptic-curve/src/point.rs
+++ b/elliptic-curve/src/point.rs
@@ -54,19 +54,6 @@ pub trait BatchNormalize<Points: ?Sized> {
     fn batch_normalize(points: &Points) -> <Self as BatchNormalize<Points>>::Output;
 }
 
-/// Double a point (i.e. add it to itself)
-pub trait Double: Sized {
-    /// Double this point.
-    #[must_use]
-    fn double(&self) -> Self;
-
-    /// Double this point in-place.
-    #[inline]
-    fn double_in_place(&mut self) {
-        *self = self.double();
-    }
-}
-
 /// Decompress an elliptic curve point.
 ///
 /// Point decompression recovers an original curve point from its x-coordinate


### PR DESCRIPTION
It was previously in `point`, but I kept looking for it in `ops` which seems like a better location for it.

While points are one of the main things we double, it could also potentially be used on field elements as well, so it seems more like `ops` than `points`.