### PR TITLE
elliptic-curve: add vartime `BatchInvert`/`BatchNormalize` methods

### DIFF
--- a/elliptic-curve/src/ops.rs
+++ b/elliptic-curve/src/ops.rs
@@ -29,6 +29,18 @@ pub trait BatchInvert: Field {
     fn batch_invert_in_place(elements: &mut [Self], scratch_space: &mut [Self]) -> Self {
         BatchInverter::invert_with_external_scratch(elements, scratch_space)
     }
+
+    /// Variable-time batch inversion.
+    ///
+    /// <div class="warning">
+    /// <b>Security Warning</b>
+    ///
+    /// This should NOT be used on secret values!
+    /// </b>
+    fn batch_invert_in_place_vartime(elements: &mut [Self], scratch_space: &mut [Self]) -> Self {
+        // Call the constant-time implementation by default
+        Self::batch_invert_in_place(elements, scratch_space)
+    }
 }
 
 /// Perform a doubling (i.e. `self + self`).

--- a/elliptic-curve/src/point.rs
+++ b/elliptic-curve/src/point.rs
@@ -51,7 +51,20 @@ pub trait BatchNormalize<Points: ?Sized> {
     /// Perform a batched conversion to affine representation on a sequence of projective points
     /// at an amortized cost that should be practically as efficient as a single conversion.
     /// Internally, implementors should rely upon `InvertBatch`.
-    fn batch_normalize(points: &Points) -> <Self as BatchNormalize<Points>>::Output;
+    fn batch_normalize(points: &Points) -> Self::Output;
+
+    /// Perform a batched conversion to affine representation on a sequence of projective points
+    /// in variable-time.
+    ///
+    /// <div class="warning">
+    /// <b>Security Warning</b>
+    ///
+    /// This should NOT be used on points which represent secrets!
+    /// </b>
+    fn batch_normalize_vartime(points: &Points) -> Self::Output {
+        // Call the constant-time implementation by default
+        Self::batch_normalize(points)
+    }
 }
 
 /// Decompress an elliptic curve point.


### PR DESCRIPTION
Adds the following:
- `BatchInvert::batch_invert_in_place_vartime`
- `BatchNormalize::batch_normalize_vartime`

Both are provided methods that currently call the constant-time path, but in the future we can potentially provide default implementations that are variable-time and optimized.

Since the new methods are provided, this isn't a breaking change.