### PR TITLE
crypto-common: fix `SerializableState` implementation for `[u128; N]`

### DIFF
--- a/crypto-common/CHANGELOG.md
+++ b/crypto-common/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.3 (UNRELEASED)
+### Fixed
+- `SerializableState` implementation for `[u128; N]` ([#2471])
+
+[#2471]: https://github.com/RustCrypto/traits/pull/2471
+
 ## 0.2.2 (2026-05-19)
 ### Added
 - `SetIvState` trait ([#2420])

--- a/crypto-common/src/hazmat.rs
+++ b/crypto-common/src/hazmat.rs
@@ -162,7 +162,7 @@ macro_rules! impl_serializable_state_u64_array {
 macro_rules! impl_serializable_state_u128_array {
     ($($n: ident),*) => {
         $(
-            impl_serializable_state_type_array!(u128, U8, $n);
+            impl_serializable_state_type_array!(u128, U16, $n);
         )*
     };
 }


### PR DESCRIPTION
Found with AI and Scrutineer. There appears to be a typo that incorrectly records the size of u126. The following test fails before this fix, and passes after it.

```
#[test]
fn test_serializable_state_u128_array() {
    let array: [u128; 4] = [1; 4];
    let serialized = array.serialize();
    let deserialized = <[u128; 4]>::deserialize(&serialized).unwrap();
    assert_eq!(array, deserialized);
}
```