### PR TITLE
digest: Hash the length of the prefix in `new_with_prefix()`

### DIFF
--- a/digest/src/digest.rs
+++ b/digest/src/digest.rs
@@ -68,6 +68,7 @@ impl<D: FixedOutput + Default + Update + HashMarker> Digest for D {
         Self: Default + Sized,
     {
         let mut h = Self::default();
+        h.update(&(data.as_ref().len() as u64).to_be_bytes());
         h.update(data.as_ref());
         h
     }


### PR DESCRIPTION
It seems that it is a good idea to hash the prefix length in addition to prefix itself in `new_with_prefix()` to avoid collisions. Was that an omission, or is there something I'm not considering?

The length can be cast to `u128` instead of `u64` to make it extremely future-proof, adding a small performance cost. 

Not sure what is the policy regarding the output consistency, this change may be considered breaking. 