### PR TITLE
cipher: document SeekNum encoding conventions and debug panic

### DIFF
--- a/cipher/src/stream.rs
+++ b/cipher/src/stream.rs
@@ -276,6 +276,18 @@ pub trait SeekNum: Sized {
     /// Try to get position for block number `block`, byte position inside
     /// block `byte`, and block size `bs`.
     ///
+    /// `block` and `byte` follow the keystream-buffer convention used by
+    /// `StreamCipherCoreWrapper`: `block` is the number of
+    /// the *next* keystream block to be generated, and `byte` (in range `1..=bs`) is the
+    /// number of bytes of the current keystream block that have been consumed, i.e. the
+    /// computed position is `block * bs - (bs - byte)`. Note that this is *not* the encoding
+    /// produced by [`into_block_byte`][SeekNum::into_block_byte], so the two methods are not
+    /// inverses of each other.
+    ///
+    /// # Panics
+    /// If debug assertions are enabled, panics when `byte` is `0` (a value never produced by
+    /// the keystream-buffer convention described above).
+    ///
     /// # Errors
     /// Returns [`OverflowError`] in the event of a counter overflow.
     fn from_block_byte<T: StreamCipherCounter>(
@@ -285,6 +297,12 @@ pub trait SeekNum: Sized {
     ) -> Result<Self, OverflowError>;
 
     /// Try to get block number and bytes position for given block size `bs`.
+    ///
+    /// The returned pair follows the position-division convention: `block` is the number of
+    /// the keystream block containing the position (`self / bs`) and `byte` (in range
+    /// `0..bs`) is the byte offset within that block (`self % bs`). Note that this is *not*
+    /// the encoding accepted by [`from_block_byte`][SeekNum::from_block_byte], so the two
+    /// methods are not inverses of each other.
     ///
     /// # Errors
     /// Returns [`OverflowError`] in the event of a counter overflow.

--- a/cipher/src/stream.rs
+++ b/cipher/src/stream.rs
@@ -289,7 +289,8 @@ pub trait SeekNum: Sized {
     /// the keystream-buffer convention described above).
     ///
     /// # Errors
-    /// Returns [`OverflowError`] in the event of a counter overflow.
+    /// Returns [`OverflowError`] when the computed position overflows `Self`, when
+    /// `byte > bs`, or when `block` cannot be converted into `Self`.
     fn from_block_byte<T: StreamCipherCounter>(
         block: T,
         byte: u8,
@@ -304,8 +305,12 @@ pub trait SeekNum: Sized {
     /// the encoding accepted by [`from_block_byte`][SeekNum::from_block_byte], so the two
     /// methods are not inverses of each other.
     ///
+    /// # Panics
+    /// Panics when `bs` is `0` (division by zero).
+    ///
     /// # Errors
-    /// Returns [`OverflowError`] in the event of a counter overflow.
+    /// Returns [`OverflowError`] when the block number does not fit into the counter type
+    /// `T`.
     fn into_block_byte<T: StreamCipherCounter>(self, bs: u8) -> Result<(T, u8), OverflowError>;
 }
 


### PR DESCRIPTION
`SeekNum::from_block_byte` and `SeekNum::into_block_byte` use different `(block, byte)` encodings and are not inverses of each other:

- `into_block_byte` returns the position-division pair: `block = self / bs`, `byte = self % bs` (so `byte` is in `0..bs`);
- `from_block_byte` expects the keystream-buffer pair used by `StreamCipherCoreWrapper::try_current_pos`: `block` is the next block to generate and `byte` in `1..=bs` is the consumed byte count, computing `block * bs - (bs - byte)`.

Feeding the output of one into the other therefore misbehaves: for a position at an exact block boundary (e.g. `16u32.into_block_byte(16)` = `(1, 0)`), `from_block_byte(1, 0, 16)` panics in debug builds (`debug_assert!(byte != 0)`) and silently returns the wrong position (`0` instead of `16`) in release builds. Only `# Errors` was documented.

This PR documents both conventions, their non-inverse relationship, and the debug panic — no functional change, since `StreamCipherCoreWrapper` uses the conventions consistently and correctly. If you would rather make the pair self-consistent (or replace the `debug_assert` with an `OverflowError`), happy to rework in that direction instead.

Found by running Kani's [autoharness](https://model-checking.github.io/kani/reference/experimental/autoharness.html) (model-checking/kani#3832) over cipher 0.5.2, which reported the `debug_assert` reachable on the public trait method; reproduced with plain cargo before filing.
