### PR TITLE
doc: fix warning documentation HTML tags

### DIFF
--- a/cipher/src/stream.rs
+++ b/cipher/src/stream.rs
@@ -49,8 +49,8 @@ pub trait StreamCipher {
 
     /// Apply keystream to `inout` without checking for keystream repetition.
     ///
-    /// <div><class = "warning">
-    /// <b>WARNING<b>
+    /// <div class="warning">
+    /// <b>WARNING</b>
     ///
     /// This method should be used with extreme caution! Triggering keystream repetition can expose
     /// the stream cipher to chosen plaintext attacks.
@@ -59,8 +59,8 @@ pub trait StreamCipher {
 
     /// Apply keystream to `buf` without checking for keystream repetition.
     ///
-    /// <div><class = "warning">
-    /// <b>WARNING<b>
+    /// <div class="warning">
+    /// <b>WARNING</b>
     ///
     /// This method should be used with extreme caution! Triggering keystream repetition can expose
     /// the stream cipher to chosen plaintext attacks.
@@ -69,8 +69,8 @@ pub trait StreamCipher {
 
     /// Apply keystream to data behind `buf` without checking for keystream repetition.
     ///
-    /// <div><class = "warning">
-    /// <b>WARNING<b>
+    /// <div class="warning">
+    /// <b>WARNING</b>
     ///
     /// This method should be used with extreme caution! Triggering keystream repetition can expose
     /// the stream cipher to chosen plaintext attacks.
@@ -88,8 +88,8 @@ pub trait StreamCipher {
     /// # Errors
     /// Returns [`NotEqualError`] if the `input` and `output` buffers have different lengths.
     ///
-    /// <div><class = "warning">
-    /// <b>WARNING<b>
+    /// <div class="warning">
+    /// <b>WARNING</b>
     ///
     /// This method should be used with extreme caution! Triggering keystream repetition can expose
     /// the stream cipher to chosen plaintext attacks.

--- a/elliptic-curve/src/ops.rs
+++ b/elliptic-curve/src/ops.rs
@@ -36,7 +36,8 @@ pub trait BatchInvert: Field {
     /// <b>Security Warning</b>
     ///
     /// This should NOT be used on secret values!
-    /// </b>
+    ///
+    /// </div>
     fn batch_invert_in_place_vartime(elements: &mut [Self], scratch_space: &mut [Self]) -> Self {
         // Call the constant-time implementation by default
         Self::batch_invert_in_place(elements, scratch_space)
@@ -95,6 +96,7 @@ where
 ///
 /// Variable-time operations should only be used on non-secret values, and may potentially leak
 /// secret values!
+///
 /// </div>
 pub trait MulVartime<Rhs = Self>: Mul<Rhs> {
     /// Multiply `self` by `rhs` in variable-time.

--- a/elliptic-curve/src/point.rs
+++ b/elliptic-curve/src/point.rs
@@ -60,7 +60,8 @@ pub trait BatchNormalize<Points: ?Sized> {
     /// <b>Security Warning</b>
     ///
     /// This should NOT be used on points which represent secrets!
-    /// </b>
+    ///
+    /// </div>
     fn batch_normalize_vartime(points: &Points) -> Self::Output {
         // Call the constant-time implementation by default
         Self::batch_normalize(points)


### PR DESCRIPTION
Fix several rustdoc warnings about HTML tags in [warning sections](https://doc.rust-lang.org/rustdoc/how-to-write-documentation.html#adding-a-warning-block).

Before:

<img width="1920" height="960" alt="Screen Shot 2026-08-12 at 17 09 53" src="https://github.com/user-attachments/assets/7784c777-8bb8-4e83-bb54-25f07b01ac59" />

After:

<img width="1920" height="1072" alt="Screen Shot 2026-08-12 at 17 10 13" src="https://github.com/user-attachments/assets/8970a5b1-c658-4a77-81fa-50e4aa63a6c7" />

