### PR TITLE
digest: implement ZeroizeOnDrop for buffer_ct_variable! wrapper types

### DIFF
--- a/digest/src/buffer_macros/variable.rs
+++ b/digest/src/buffer_macros/variable.rs
@@ -156,6 +156,32 @@ macro_rules! buffer_ct_variable {
                 $crate::Reset::reset(self);
             }
         }
+
+        // Verify that `core` and `buffer` fields implement `ZeroizeOnDrop`, so the
+        // marker impl below is a sound assertion rather than a false claim.
+        #[cfg(feature = "zeroize")]
+        const _: () = {
+            fn check_core<$out_size>(v: &$crate::block_api::CtOutWrapper<$core_ty, $out_size>)
+            where
+                $out_size: $crate::array::ArraySize + $crate::typenum::IsLessOrEqual<$max_size, Output = $crate::typenum::True>,
+            {
+                v as &dyn $crate::zeroize::ZeroizeOnDrop;
+            }
+
+            fn check_buffer<$out_size>(v: &$crate::block_api::Buffer<$core_ty>)
+            where
+                $out_size: $crate::array::ArraySize + $crate::typenum::IsLessOrEqual<$max_size, Output = $crate::typenum::True>,
+            {
+                v as &dyn $crate::zeroize::ZeroizeOnDrop;
+            }
+        };
+
+        #[cfg(feature = "zeroize")]
+        impl<$out_size> $crate::zeroize::ZeroizeOnDrop for $name<$out_size>
+        where
+            $out_size: $crate::array::ArraySize + $crate::typenum::IsLessOrEqual<$max_size, Output = $crate::typenum::True>,
+        {
+        }
     };
     (
         $(#[$attr:meta])*


### PR DESCRIPTION
Fixes RustCrypto/hashes#912 (`blake2::Blake2b512` does not implement `ZeroizeOnDrop`) at the root cause.

## The problem

`buffer_ct_variable!` (used by `blake2`, `groestl`, and `kupyna` to build their CT-selectable-output wrapper types, e.g. `Blake2b<OutSize>`) generates a struct:

```rust
struct $name<OutSize> {
    core: CtOutWrapper<$core_ty, OutSize>,
    buffer: Buffer<$core_ty>,
}
```

but never implements `ZeroizeOnDrop` for the wrapper itself, even when both field types do. As pointed out in the linked issue, decomposing into `core`/`buffer` gets you zeroization, but the ergonomic wrapper type (e.g. `Blake2b512`) doesn't advertise it.

## The fix

Mirrors the `ZeroizeOnDrop` handling already present in the sibling `buffer_fixed!` macro (`buffer_macros/fixed.rs`): a compile-time `const _` check asserting both fields implement `ZeroizeOnDrop` (so the marker impl is a verified assertion, not an unchecked claim), followed by the impl itself. No custom `Drop` is needed - `CtOutWrapper` and `BlockBuffer` already zeroize their own contents on drop when the `zeroize` feature is enabled, and Rust's default field-wise drop already invokes both, so the outer type genuinely satisfies `ZeroizeOnDrop`'s contract with no additional code.

## Verification

I don't have write access to run this repo's CI, so I verified locally with real builds against all three current consumers of `buffer_ct_variable!`, using `[patch.crates-io]` to point them at this branch's `digest`, with the `zeroize` feature enabled:

- **blake2**: confirmed `Blake2b512` now implements `ZeroizeOnDrop` via a runnable test program (`fn assert_zeroize_on_drop<T: zeroize::ZeroizeOnDrop>() {} assert_zeroize_on_drop::<blake2::Blake2b512>();` - compiles and runs).
- **groestl** and **kupyna**: confirmed their existing usage still compiles cleanly with `zeroize` enabled (their core types already implement `ZeroizeOnDrop`, so the new const-check assertion doesn't regress them).
- `cargo test --all-features` in `digest/` itself: all tests and doctests pass, no regressions.